### PR TITLE
Refactor events and add generic bus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ target_compile_options(${FLOX} PRIVATE
 
 add_library(${FLOX_SYNC} STATIC ${SRC_FILES})
 add_library(flox::${FLOX_SYNC} ALIAS ${FLOX_SYNC})
-target_compile_definitions(${FLOX_SYNC} PRIVATE USE_SYNC_MARKET_BUS)
+target_compile_definitions(${FLOX_SYNC} PRIVATE USE_SYNC_MARKET_BUS USE_SYNC_ORDER_BUS)
 target_compile_options(${FLOX_SYNC} PRIVATE
   $<$<CONFIG:Release>:-O3 -march=native -flto -funroll-loops>
 )

--- a/benchmarks/candle_aggregator_benchmark.cpp
+++ b/benchmarks/candle_aggregator_benchmark.cpp
@@ -37,11 +37,12 @@ static void BM_CandleAggregator_OnTrade(benchmark::State& state)
   {
     auto trade = tradePool.acquire();
 
-    trade->symbol = SYMBOL;
-    trade->price = Price::fromDouble(priceDist(rng));
-    trade->quantity = Quantity::fromDouble(qtyDist(rng));
-    trade->isBuy = true;
-    trade->timestamp = std::chrono::system_clock::time_point(std::chrono::seconds(baseTs++));
+    trade->trade.symbol = SYMBOL;
+    trade->trade.price = Price::fromDouble(priceDist(rng));
+    trade->trade.quantity = Quantity::fromDouble(qtyDist(rng));
+    trade->trade.isBuy = true;
+    trade->trade.timestamp =
+        std::chrono::system_clock::time_point(std::chrono::seconds(baseTs++));
 
     aggregator.onMarketData(*trade);
   }

--- a/benchmarks/full_order_book_benchmark.cpp
+++ b/benchmarks/full_order_book_benchmark.cpp
@@ -32,20 +32,20 @@ static void BM_ApplyBookUpdate(benchmark::State& state)
   for (auto _ : state)
   {
     auto update = pool.acquire();
-    update->type = BookUpdateType::DELTA;
-    update->timestamp = std::chrono::system_clock::now();
+    update->update.type = BookUpdateType::DELTA;
+    update->update.timestamp = std::chrono::system_clock::now();
 
-    update->bids.clear();
-    update->asks.clear();
-    update->bids.reserve(10000);
-    update->asks.reserve(10000);
+    update->update.bids.clear();
+    update->update.asks.clear();
+    update->update.bids.reserve(10000);
+    update->update.asks.reserve(10000);
 
     for (int i = 0; i < 10000; ++i)
     {
       Price price = Price::fromDouble(priceDist(rng));
       Quantity qty = Quantity::fromDouble(qtyDist(rng));
-      update->bids.push_back({price, qty});
-      update->asks.push_back({Price::fromDouble(price.toDouble() + 10.0), qty});
+      update->update.bids.push_back({price, qty});
+      update->update.asks.push_back({Price::fromDouble(price.toDouble() + 10.0), qty});
     }
 
     book.applyBookUpdate(*update);
@@ -59,15 +59,15 @@ static void BM_BestBid(benchmark::State& state)
   BookUpdatePool pool;
 
   auto update = pool.acquire();
-  update->type = BookUpdateType::SNAPSHOT;
-  update->bids.reserve(100000);
-  update->asks.clear();
+  update->update.type = BookUpdateType::SNAPSHOT;
+  update->update.bids.reserve(100000);
+  update->update.asks.clear();
 
   for (int i = 0; i < 100000; ++i)
   {
     Price price =
         Price::fromRaw(Price::fromDouble(20000.0).raw() - i * Price::fromDouble(0.1).raw());
-    update->bids.push_back({price, Quantity::fromDouble(1.0)});
+    update->update.bids.push_back({price, Quantity::fromDouble(1.0)});
   }
 
   book.applyBookUpdate(*update);
@@ -85,15 +85,15 @@ static void BM_BestAsk(benchmark::State& state)
   BookUpdatePool pool;
 
   auto update = pool.acquire();
-  update->type = BookUpdateType::SNAPSHOT;
-  update->asks.reserve(100000);
-  update->bids.clear();
+  update->update.type = BookUpdateType::SNAPSHOT;
+  update->update.asks.reserve(100000);
+  update->update.bids.clear();
 
   for (int i = 0; i < 100000; ++i)
   {
     Price price =
         Price::fromRaw(Price::fromDouble(20000.0).raw() + i * Price::fromDouble(0.1).raw());
-    update->asks.push_back({price, Quantity::fromDouble(1.0)});
+    update->update.asks.push_back({price, Quantity::fromDouble(1.0)});
   }
 
   book.applyBookUpdate(*update);

--- a/benchmarks/windowed_order_book_benchmark.cpp
+++ b/benchmarks/windowed_order_book_benchmark.cpp
@@ -35,19 +35,19 @@ static void BM_ApplyBookUpdate(benchmark::State& state)
   for (auto _ : state)
   {
     auto update = pool.acquire();
-    update->type = BookUpdateType::DELTA;
-    update->timestamp = std::chrono::system_clock::now();
-    update->bids.clear();
-    update->asks.clear();
-    update->bids.reserve(10000);
-    update->asks.reserve(10000);
+    update->update.type = BookUpdateType::DELTA;
+    update->update.timestamp = std::chrono::system_clock::now();
+    update->update.bids.clear();
+    update->update.asks.clear();
+    update->update.bids.reserve(10000);
+    update->update.asks.reserve(10000);
 
     for (int i = 0; i < 10000; ++i)
     {
       Price price = Price::fromDouble(priceDist(rng));
       Quantity qty = Quantity::fromDouble(qtyDist(rng));
-      update->bids.push_back({price, qty});
-      update->asks.push_back({Price::fromDouble(price.toDouble() + 10.0), qty});
+      update->update.bids.push_back({price, qty});
+      update->update.asks.push_back({Price::fromDouble(price.toDouble() + 10.0), qty});
     }
 
     book->applyBookUpdate(*update);
@@ -65,15 +65,15 @@ static void BM_BestBid(benchmark::State& state)
   BookUpdatePool pool;
 
   auto update = pool.acquire();
-  update->type = BookUpdateType::SNAPSHOT;
-  update->timestamp = std::chrono::system_clock::now();
-  update->asks.clear();
-  update->bids.reserve(100000);
+  update->update.type = BookUpdateType::SNAPSHOT;
+  update->update.timestamp = std::chrono::system_clock::now();
+  update->update.asks.clear();
+  update->update.bids.reserve(100000);
 
   for (int i = 0; i < 100000; ++i)
   {
     Price price = Price::fromRaw(Price::fromDouble(20000.0).raw() - i * tickSize.raw());
-    update->bids.push_back({price, Quantity::fromDouble(1.0)});
+    update->update.bids.push_back({price, Quantity::fromDouble(1.0)});
   }
 
   book->applyBookUpdate(*update);
@@ -95,15 +95,15 @@ static void BM_BestAsk(benchmark::State& state)
   BookUpdatePool pool;
 
   auto update = pool.acquire();
-  update->type = BookUpdateType::SNAPSHOT;
-  update->timestamp = std::chrono::system_clock::now();
-  update->bids.clear();
-  update->asks.reserve(100000);
+  update->update.type = BookUpdateType::SNAPSHOT;
+  update->update.timestamp = std::chrono::system_clock::now();
+  update->update.bids.clear();
+  update->update.asks.reserve(100000);
 
   for (int i = 0; i < 100000; ++i)
   {
     Price price = Price::fromRaw(Price::fromDouble(20000.0).raw() + i * tickSize.raw());
-    update->asks.push_back({price, Quantity::fromDouble(1.0)});
+    update->update.asks.push_back({price, Quantity::fromDouble(1.0)});
   }
 
   book->applyBookUpdate(*update);

--- a/include/flox/book/book_update.h
+++ b/include/flox/book/book_update.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <chrono>
+#include <memory_resource>
+#include <vector>
+#include "flox/common.h"
+
+namespace flox
+{
+
+enum class BookUpdateType
+{
+  SNAPSHOT,
+  DELTA
+};
+
+struct BookLevel
+{
+  Price price{};
+  Quantity quantity{};
+  BookLevel() = default;
+  BookLevel(Price p, Quantity q) : price(p), quantity(q) {}
+};
+
+struct BookUpdate
+{
+  SymbolId symbol{};
+  BookUpdateType type{};
+  std::pmr::vector<BookLevel> bids;
+  std::pmr::vector<BookLevel> asks;
+  std::chrono::system_clock::time_point timestamp{};
+
+  BookUpdate(std::pmr::memory_resource* res) : bids(res), asks(res) {}
+};
+
+}  // namespace flox

--- a/include/flox/book/full_order_book.h
+++ b/include/flox/book/full_order_book.h
@@ -33,9 +33,11 @@ class FullOrderBook : public IOrderBook
   {
   }
 
-  void applyBookUpdate(const BookUpdateEvent& update) override
+  void applyBookUpdate(const BookUpdateEvent& event) override
   {
     std::scoped_lock lock(_mutex);
+
+    const auto& update = event.update;
 
     if (update.type == BookUpdateType::SNAPSHOT)
     {

--- a/include/flox/book/trade.h
+++ b/include/flox/book/trade.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <chrono>
+#include "flox/common.h"
+
+namespace flox
+{
+
+struct Trade
+{
+  SymbolId symbol{};
+  Price price{};
+  Quantity quantity{};
+  bool isBuy{false};
+  std::chrono::system_clock::time_point timestamp{};
+};
+
+}  // namespace flox

--- a/include/flox/book/windowed_order_book.h
+++ b/include/flox/book/windowed_order_book.h
@@ -42,9 +42,11 @@ class WindowedOrderBook : public IOrderBook
   {
   }
 
-  void applyBookUpdate(const BookUpdateEvent& update) override
+  void applyBookUpdate(const BookUpdateEvent& event) override
   {
     std::scoped_lock lock(_mutex);
+
+    const auto& update = event.update;
 
     Price minPrice = Price(std::numeric_limits<int64_t>::max());
     Price maxPrice = Price(std::numeric_limits<int64_t>::lowest());

--- a/include/flox/engine/events/book_update_event.h
+++ b/include/flox/engine/events/book_update_event.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "flox/common.h"
+#include "flox/book/book_update.h"
 #include "flox/engine/abstract_market_data_subscriber.h"
 #include "flox/engine/events/market_data_event.h"
 #include "flox/engine/symbol_registry.h"
@@ -23,36 +23,24 @@
 namespace flox
 {
 
-enum class BookUpdateType
-{
-  SNAPSHOT,
-  DELTA
-};
-
-struct BookLevel
-{
-  Price price;
-  Quantity quantity;
-
-  BookLevel() = default;
-  BookLevel(Price p, Quantity q) : price(p), quantity(q) {}
-};
-
 struct BookUpdateEvent : public IMarketDataEvent
 {
-  SymbolId symbol;
-  BookUpdateType type;
-  std::pmr::vector<BookLevel> bids;
-  std::pmr::vector<BookLevel> asks;
-  std::chrono::system_clock::time_point timestamp;
+  using Listener = IMarketDataSubscriber;
 
-  BookUpdateEvent(std::pmr::memory_resource* res) : bids(res), asks(res)
+  BookUpdate update;
+
+  BookUpdateEvent(std::pmr::memory_resource* res) : update(res)
   {
     assert(res != nullptr && "pmr::memory_resource is null!");
   }
 
   MarketDataEventType eventType() const noexcept override;
   void dispatchTo(IMarketDataSubscriber& sub) const override;
+  void clear() override
+  {
+    update.bids.clear();
+    update.asks.clear();
+  }
 };
 
 }  // namespace flox

--- a/include/flox/engine/events/trade_event.h
+++ b/include/flox/engine/events/trade_event.h
@@ -12,7 +12,7 @@
 #include <chrono>
 #include <string>
 
-#include "flox/common.h"
+#include "flox/book/trade.h"
 #include "flox/engine/events/market_data_event.h"
 
 namespace flox
@@ -20,11 +20,9 @@ namespace flox
 
 struct TradeEvent : public IMarketDataEvent
 {
-  SymbolId symbol;
-  Price price;
-  Quantity quantity;
-  bool isBuy;
-  std::chrono::system_clock::time_point timestamp;
+  using Listener = IMarketDataSubscriber;
+
+  Trade trade{};
 
   TradeEvent(std::pmr::memory_resource*) {}
 

--- a/include/flox/engine/market_data_bus.h
+++ b/include/flox/engine/market_data_bus.h
@@ -44,7 +44,7 @@ class MarketDataBus
   void publish(EventHandle<T> event)
     requires std::is_base_of_v<IMarketDataEvent, T>
   {
-    publish(event.template upcast<IMarketDataEvent>());
+    publish(std::move(event).template upcast<IMarketDataEvent>());
   }
 
  private:

--- a/include/flox/execution/order_event.h
+++ b/include/flox/execution/order_event.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "flox/book/order.h"
+#include "flox/execution/abstract_execution_listener.h"
+
+namespace flox
+{
+
+enum class OrderEventType
+{
+  ACCEPTED,
+  PARTIALLY_FILLED,
+  FILLED,
+  CANCELED,
+  EXPIRED,
+  REJECTED,
+  REPLACED
+};
+
+struct OrderEvent
+{
+  using Listener = IOrderExecutionListener;
+  OrderEventType type{};
+  Order order{};
+  Order newOrder{};
+  Quantity fillQty{0};
+
+  void dispatchTo(IOrderExecutionListener& listener) const
+  {
+    switch (type)
+    {
+      case OrderEventType::ACCEPTED:
+        listener.onOrderAccepted(order);
+        break;
+      case OrderEventType::PARTIALLY_FILLED:
+        listener.onOrderPartiallyFilled(order, fillQty);
+        break;
+      case OrderEventType::FILLED:
+        listener.onOrderFilled(order);
+        break;
+      case OrderEventType::CANCELED:
+        listener.onOrderCanceled(order);
+        break;
+      case OrderEventType::EXPIRED:
+        listener.onOrderExpired(order);
+        break;
+      case OrderEventType::REJECTED:
+        listener.onOrderRejected(order);
+        break;
+      case OrderEventType::REPLACED:
+        listener.onOrderReplaced(order, newOrder);
+        break;
+    }
+  }
+};
+
+}  // namespace flox

--- a/include/flox/execution/order_execution_bus.h
+++ b/include/flox/execution/order_execution_bus.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "flox/execution/order_event.h"
+#include "flox/util/event_bus.h"
+
+namespace flox
+{
+
+#ifdef USE_SYNC_ORDER_BUS
+using OrderExecutionBus = EventBus<OrderEvent, true>;
+#else
+using OrderExecutionBus = EventBus<OrderEvent, false>;
+#endif
+
+}  // namespace flox

--- a/include/flox/util/event_bus.h
+++ b/include/flox/util/event_bus.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "flox/engine/tick_barrier.h"
+#include "flox/engine/tick_guard.h"
+#include "flox/util/spsc_queue.h"
+
+namespace flox
+{
+
+template <typename Event, bool Sync>
+class EventBus;
+
+// Synchronous specialization
+template <typename Event>
+class EventBus<Event, true>
+{
+ public:
+  using Listener = typename Event::Listener;
+  static constexpr size_t QueueSize = 4096;
+  using QueueItem = std::pair<Event, TickBarrier*>;
+  using Queue = SPSCQueue<QueueItem, QueueSize>;
+
+  EventBus() = default;
+  ~EventBus() { stop(); }
+
+  void subscribe(std::shared_ptr<Listener> listener)
+  {
+    Entry e;
+    e.listener = std::move(listener);
+    e.queue = std::make_unique<Queue>();
+    _subs.push_back(std::move(e));
+  }
+
+  void start()
+  {
+    if (_running.exchange(true))
+      return;
+    _active = _subs.size();
+    for (auto& entry : _subs)
+    {
+      auto& queue = *entry.queue;
+      auto& listener = entry.listener;
+      entry.thread = std::thread([this, &queue, &listener]
+                                 {
+        {
+          std::lock_guard<std::mutex> lk(_readyMutex);
+          if (--_active == 0)
+            _cv.notify_one();
+        }
+        while (_running.load(std::memory_order_acquire)) {
+          auto opt = queue.try_pop_ref();
+          if (opt) {
+            auto& [ev, barrier] = opt->get();
+            TickGuard guard(*barrier);
+            ev.dispatchTo(*listener);
+          } else {
+            std::this_thread::yield();
+          }
+        }
+        while (queue.try_pop_ref()) {} });
+    }
+    std::unique_lock<std::mutex> lk(_readyMutex);
+    _cv.wait(lk, [&]
+             { return _active == 0; });
+  }
+
+  void stop()
+  {
+    if (!_running.exchange(false))
+      return;
+    for (auto& entry : _subs)
+    {
+      if (entry.thread.joinable())
+        entry.thread.join();
+      while (entry.queue->try_pop_ref())
+      {
+      }
+    }
+    _subs.clear();
+  }
+
+  void publish(const Event& event)
+  {
+    TickBarrier barrier(_subs.size());
+    for (auto& entry : _subs)
+    {
+      entry.queue->emplace(QueueItem{event, &barrier});
+    }
+    barrier.wait();
+  }
+
+ private:
+  struct Entry
+  {
+    std::shared_ptr<Listener> listener;
+    std::unique_ptr<Queue> queue;
+    std::thread thread;
+  };
+
+  std::vector<Entry> _subs;
+  std::atomic<bool> _running{false};
+  std::atomic<size_t> _active{0};
+  std::condition_variable _cv;
+  std::mutex _readyMutex;
+};
+
+// Asynchronous specialization
+template <typename Event>
+class EventBus<Event, false>
+{
+ public:
+  using Listener = typename Event::Listener;
+  static constexpr size_t QueueSize = 4096;
+  using QueueItem = Event;
+  using Queue = SPSCQueue<QueueItem, QueueSize>;
+
+  EventBus() = default;
+  ~EventBus() = default;
+
+  void subscribe(std::shared_ptr<Listener> listener)
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _listeners.push_back(std::move(listener));
+  }
+
+  void start() {}
+  void stop() {}
+
+  void publish(const Event& event)
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    for (auto& l : _listeners)
+    {
+      if (l)
+        event.dispatchTo(*l);
+    }
+  }
+
+ private:
+  std::mutex _mutex;
+  std::vector<std::shared_ptr<Listener>> _listeners;
+};
+
+}  // namespace flox

--- a/src/aggregator/candle_aggregator.cpp
+++ b/src/aggregator/candle_aggregator.cpp
@@ -46,29 +46,29 @@ void CandleAggregator::onMarketData(const IMarketDataEvent& event)
 
 void CandleAggregator::onTrade(TradeEvent* trade)
 {
-  auto ts = alignToInterval(trade->timestamp);
-  auto& partial = _candles[trade->symbol];
+  auto ts = alignToInterval(trade->trade.timestamp);
+  auto& partial = _candles[trade->trade.symbol];
 
   if (!partial.initialized || partial.candle.startTime != ts)
   {
     if (partial.initialized)
     {
       partial.candle.endTime = partial.candle.startTime + _interval;
-      _callback(trade->symbol, partial.candle);
+      _callback(trade->trade.symbol, partial.candle);
     }
     partial.candle =
-        Candle(ts, trade->price,
-               Volume::fromDouble(trade->price.toDouble() * trade->quantity.toDouble()));
+        Candle(ts, trade->trade.price,
+               Volume::fromDouble(trade->trade.price.toDouble() * trade->trade.quantity.toDouble()));
     partial.candle.endTime = ts + _interval;
     partial.initialized = true;
     return;
   }
 
   auto& c = partial.candle;
-  c.high = std::max(c.high, trade->price);
-  c.low = std::min(c.low, trade->price);
-  c.close = trade->price;
-  c.volume += Volume::fromDouble(trade->price.toDouble() * trade->quantity.toDouble());
+  c.high = std::max(c.high, trade->trade.price);
+  c.low = std::min(c.low, trade->trade.price);
+  c.close = trade->trade.price;
+  c.volume += Volume::fromDouble(trade->trade.price.toDouble() * trade->trade.quantity.toDouble());
   c.endTime = partial.candle.startTime + _interval;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,5 +67,8 @@ add_flox_test(test_tick_barrier)
 add_flox_test(test_event_pool)
 add_flox_test(test_engine_smoke)
 add_flox_test(test_decimal)
+add_flox_test(test_order_execution_bus)
+
+add_flox_sync_test(test_sync_order_execution_bus)
 
 add_flox_sync_test(test_sync_market_data_bus)

--- a/tests/test_candle_aggregator.cpp
+++ b/tests/test_candle_aggregator.cpp
@@ -33,11 +33,11 @@ EventHandle<TradeEvent> makeTrade(TradePool& pool, SymbolId symbol, double price
                                   int sec)
 {
   auto handle = pool.acquire();
-  handle->symbol = symbol;
-  handle->price = Price::fromDouble(price);
-  handle->quantity = Quantity::fromDouble(qty);
-  handle->isBuy = true;
-  handle->timestamp = ts(sec);
+  handle->trade.symbol = symbol;
+  handle->trade.price = Price::fromDouble(price);
+  handle->trade.quantity = Quantity::fromDouble(qty);
+  handle->trade.isBuy = true;
+  handle->trade.timestamp = ts(sec);
   return handle;
 }
 

--- a/tests/test_connector_manager.cpp
+++ b/tests/test_connector_manager.cpp
@@ -49,11 +49,11 @@ class MockExchangeConnector : public ExchangeConnector
       EventPool<TradeEvent, 3> tradePool;
 
       auto bu = bookUpdatePool.acquire();
-      bu->symbol = 42;
+      bu->update.symbol = 42;
 
       auto tr = tradePool.acquire();
-      tr->symbol = 42;
-      tr->price = Price::fromDouble(3.14);
+      tr->trade.symbol = 42;
+      tr->trade.price = Price::fromDouble(3.14);
 
       _bookCb(bu.get());
       _tradeCb(tr.get());
@@ -82,13 +82,13 @@ TEST(ConnectorManagerTest, RegisterAndStartAll)
       [&](BookUpdateEvent* bu)
       {
         ASSERT_NE(bu, nullptr);
-        EXPECT_EQ(bu->symbol, 42);
+        EXPECT_EQ(bu->update.symbol, 42);
         bookUpdateCalled = true;
       },
       [&](TradeEvent* tr)
       {
-        EXPECT_EQ(tr->symbol, 42);
-        EXPECT_EQ(tr->price, Price::fromDouble(3.14));
+        EXPECT_EQ(tr->trade.symbol, 42);
+        EXPECT_EQ(tr->trade.price, Price::fromDouble(3.14));
         tradeCalled = true;
       });
 

--- a/tests/test_engine_smoke.cpp
+++ b/tests/test_engine_smoke.cpp
@@ -32,19 +32,19 @@ class TestStrategy : public IStrategy
 
   void onTrade(TradeEvent* trade) override
   {
-    if (trade->symbol == _symbol)
+    if (trade->trade.symbol == _symbol)
     {
       ++_seenTrades;
-      _lastTradePrice = trade->price;
+      _lastTradePrice = trade->trade.price;
     }
   }
 
   void onBookUpdate(BookUpdateEvent* update) override
   {
-    if (update->symbol == _symbol && !update->bids.empty())
+    if (update->update.symbol == _symbol && !update->update.bids.empty())
     {
       ++_seenBooks;
-      _lastBid = update->bids[0].price;
+      _lastBid = update->update.bids[0].price;
     }
   }
 
@@ -76,20 +76,20 @@ class MockConnector
   void publishTrade(Price price, Quantity qty)
   {
     auto event = _tradePool.acquire();
-    event->symbol = _symbol;
-    event->price = price;
-    event->quantity = qty;
-    event->isBuy = true;
-    event->timestamp = std::chrono::system_clock::now();
+    event->trade.symbol = _symbol;
+    event->trade.price = price;
+    event->trade.quantity = qty;
+    event->trade.isBuy = true;
+    event->trade.timestamp = std::chrono::system_clock::now();
     _bus.publish(std::move(event));
   }
 
   void publishBook(Price bidPrice, Quantity bidQty)
   {
     auto event = _bookPool.acquire();
-    event->symbol = _symbol;
-    event->type = BookUpdateType::SNAPSHOT;
-    event->bids.push_back({bidPrice, bidQty});
+    event->update.symbol = _symbol;
+    event->update.type = BookUpdateType::SNAPSHOT;
+    event->update.bids.push_back({bidPrice, bidQty});
     _bus.publish(std::move(event));
   }
 

--- a/tests/test_full_order_book.cpp
+++ b/tests/test_full_order_book.cpp
@@ -27,9 +27,9 @@ class FullOrderBookTest : public ::testing::Test
                                             const std::vector<BookLevel>& asks)
   {
     auto u = pool.acquire();
-    u->type = BookUpdateType::SNAPSHOT;
-    u->bids.assign(bids.begin(), bids.end());
-    u->asks.assign(asks.begin(), asks.end());
+    u->update.type = BookUpdateType::SNAPSHOT;
+    u->update.bids.assign(bids.begin(), bids.end());
+    u->update.asks.assign(asks.begin(), asks.end());
     return u;
   }
 
@@ -37,9 +37,9 @@ class FullOrderBookTest : public ::testing::Test
                                          const std::vector<BookLevel>& asks)
   {
     auto u = pool.acquire();
-    u->type = BookUpdateType::DELTA;
-    u->bids.assign(bids.begin(), bids.end());
-    u->asks.assign(asks.begin(), asks.end());
+    u->update.type = BookUpdateType::DELTA;
+    u->update.bids.assign(bids.begin(), bids.end());
+    u->update.asks.assign(asks.begin(), asks.end());
     return u;
   }
 };

--- a/tests/test_market_data_bus.cpp
+++ b/tests/test_market_data_bus.cpp
@@ -41,8 +41,8 @@ class TestSubscriber : public IMarketDataSubscriber
       const auto& update = static_cast<const BookUpdateEvent&>(event);
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
       ++_counter;
-      _lastPrice.store(update.bids.empty() ? Price::fromRaw(-1).raw()
-                                           : update.bids[0].price.raw());
+      _lastPrice.store(update.update.bids.empty() ? Price::fromRaw(-1).raw()
+                                                  : update.update.bids[0].price.raw());
     }
   }
 
@@ -70,8 +70,8 @@ TEST(MarketDataBusTest, SingleSubscriberReceivesUpdates)
   {
     auto update = pool.acquire();
     ASSERT_NE(update.get(), nullptr);
-    update->type = BookUpdateType::SNAPSHOT;
-    update->bids.emplace_back(Price::fromDouble(100.0 + 1), Quantity::fromDouble(1.0));
+    update->update.type = BookUpdateType::SNAPSHOT;
+    update->update.bids.emplace_back(Price::fromDouble(100.0 + 1), Quantity::fromDouble(1.0));
     bus.publish(std::move(update));
   }
 
@@ -100,8 +100,8 @@ TEST(MarketDataBusTest, MultipleSubscribersReceiveAll)
   {
     auto update = pool.acquire();
     ASSERT_NE(update.get(), nullptr);
-    update->type = BookUpdateType::SNAPSHOT;
-    update->bids.emplace_back(Price::fromDouble(200.0 + i), Quantity::fromDouble(1.0));
+    update->update.type = BookUpdateType::SNAPSHOT;
+    update->update.bids.emplace_back(Price::fromDouble(200.0 + i), Quantity::fromDouble(1.0));
     bus.publish(std::move(update));
   }
 
@@ -126,8 +126,8 @@ TEST(MarketDataBusTest, GracefulStopDoesNotLeak)
   {
     auto update = pool.acquire();
     ASSERT_NE(update.get(), nullptr);
-    update->type = BookUpdateType::SNAPSHOT;
-    update->bids.emplace_back(Price::fromDouble(300.0 + i), Quantity::fromDouble(1.0));
+    update->update.type = BookUpdateType::SNAPSHOT;
+    update->update.bids.emplace_back(Price::fromDouble(300.0 + i), Quantity::fromDouble(1.0));
     bus.publish(std::move(update));
   }
 

--- a/tests/test_order_execution_bus.cpp
+++ b/tests/test_order_execution_bus.cpp
@@ -1,0 +1,70 @@
+/*
+ * Flox Engine
+ * Developed by Evgenii Makarov (https://github.com/eeiaao)
+ *
+ * Copyright (c) 2025 Evgenii Makarov
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <memory>
+
+#include "flox/book/order.h"
+#include "flox/execution/order_event.h"
+#include "flox/execution/order_execution_bus.h"
+
+using namespace flox;
+
+namespace
+{
+
+class CountingListener : public IOrderExecutionListener
+{
+ public:
+  explicit CountingListener(std::atomic<int>& c) : _counter(c) {}
+
+  void onOrderAccepted(const Order&) override {}
+  void onOrderPartiallyFilled(const Order&, Quantity) override {}
+  void onOrderFilled(const Order& order) override
+  {
+    ++_counter;
+    last = order;
+  }
+  void onOrderCanceled(const Order&) override {}
+  void onOrderExpired(const Order&) override {}
+  void onOrderRejected(const Order&) override {}
+  void onOrderReplaced(const Order&, const Order&) override {}
+
+  Order last{};
+
+ private:
+  std::atomic<int>& _counter;
+};
+
+}  // namespace
+
+TEST(OrderExecutionBusTest, SubscribersReceiveFill)
+{
+  OrderExecutionBus bus;
+  std::atomic<int> c1{0}, c2{0};
+  auto l1 = std::make_shared<CountingListener>(c1);
+  auto l2 = std::make_shared<CountingListener>(c2);
+  bus.subscribe(l1);
+  bus.subscribe(l2);
+
+  bus.start();
+
+  OrderEvent event{};
+  event.type = OrderEventType::FILLED;
+  event.order.symbol = 1;
+  event.order.side = Side::BUY;
+  event.order.quantity = Quantity::fromDouble(1.0);
+
+  bus.publish(event);
+  bus.stop();
+
+  EXPECT_EQ(c1.load(), 1);
+  EXPECT_EQ(c2.load(), 1);
+}

--- a/tests/test_push_pull_subscribers.cpp
+++ b/tests/test_push_pull_subscribers.cpp
@@ -58,8 +58,8 @@ class PullingSubscriber : public IMarketDataSubscriber
       const auto& event = opt->get();
       const auto& book = static_cast<const BookUpdateEvent&>(*event);
       ++_counter;
-      if (!book.bids.empty())
-        _lastPrice.store(book.bids[0].price.toDouble());
+      if (!book.update.bids.empty())
+        _lastPrice.store(book.update.bids[0].price.toDouble());
     }
   }
 
@@ -84,8 +84,8 @@ TEST(MarketDataBusTest, PullSubscriberProcessesEvent)
 
   EventPool<BookUpdateEvent, 3> pool;
   auto event = pool.acquire();
-  event->type = BookUpdateType::SNAPSHOT;
-  event->bids = {{Price::fromDouble(200.0), Quantity::fromDouble(1.0)}};
+  event->update.type = BookUpdateType::SNAPSHOT;
+  event->update.bids = {{Price::fromDouble(200.0), Quantity::fromDouble(1.0)}};
   bus.publish(std::move(event));
 
   sub->readLoop();
@@ -109,7 +109,7 @@ class PushTestSubscriber : public IMarketDataSubscriber
   void onMarketData(const IMarketDataEvent& event) override
   {
     const auto& book = static_cast<const BookUpdateEvent&>(event);
-    if (!book.bids.empty() && book.bids[0].price.toDouble() > 0.0)
+    if (!book.update.bids.empty() && book.update.bids[0].price.toDouble() > 0.0)
       ++_counter;
   }
 
@@ -130,8 +130,8 @@ TEST(MarketDataBusTest, PushSubscriberReceivesAllEvents)
   for (int i = 0; i < 3; ++i)
   {
     auto handle = pool.acquire();
-    handle->type = BookUpdateType::SNAPSHOT;
-    handle->bids = {{Price::fromDouble(100.0 + i), Quantity::fromDouble(1.0)}};
+    handle->update.type = BookUpdateType::SNAPSHOT;
+    handle->update.bids = {{Price::fromDouble(100.0 + i), Quantity::fromDouble(1.0)}};
     bus.publish(std::move(handle));
   }
 
@@ -158,8 +158,8 @@ TEST(MarketDataBusTest, MixedPushAndPullWorkTogether)
   bus.subscribe(pull);
 
   auto handle = pool.acquire();
-  handle->type = BookUpdateType::SNAPSHOT;
-  handle->bids = {{Price::fromDouble(105.5), Quantity::fromDouble(3.3)}};
+  handle->update.type = BookUpdateType::SNAPSHOT;
+  handle->update.bids = {{Price::fromDouble(105.5), Quantity::fromDouble(3.3)}};
   bus.publish(std::move(handle));
 
   pull->readLoop();

--- a/tests/test_sync_market_data_bus.cpp
+++ b/tests/test_sync_market_data_bus.cpp
@@ -42,8 +42,8 @@ class SyncTestSubscriber : public IMarketDataSubscriber
     const auto& book = static_cast<const BookUpdateEvent&>(event);
     std::this_thread::sleep_for(10ms);  // simulate work
     ++_counter;
-    if (!book.bids.empty())
-      _lastPrice.store(book.bids[0].price.toDouble());
+    if (!book.update.bids.empty())
+      _lastPrice.store(book.update.bids[0].price.toDouble());
   }
 
   SubscriberId id() const override { return _id; };
@@ -77,8 +77,8 @@ TEST(SyncMarketDataBusTest, AllSubscribersProcessEachTick)
   {
     auto handle = pool.acquire();
     ASSERT_TRUE(handle);
-    handle->type = BookUpdateType::SNAPSHOT;
-    handle->bids = {{Price::fromDouble(100.0 + i), Quantity::fromDouble(1.0)}};
+    handle->update.type = BookUpdateType::SNAPSHOT;
+    handle->update.bids = {{Price::fromDouble(100.0 + i), Quantity::fromDouble(1.0)}};
     bus.publish(std::move(handle));
   }
 
@@ -117,9 +117,9 @@ TEST(SyncMarketDataBusTest, AllSubscribersProcessEachTickSynchronously)
     {
       const auto& book = static_cast<const BookUpdateEvent&>(event);
       std::this_thread::sleep_for(10ms);  // simulate work
-      if (!book.bids.empty())
+      if (!book.update.bids.empty())
       {
-        const int seq = static_cast<int>(book.bids[0].price.toDouble());
+        const int seq = static_cast<int>(book.update.bids[0].price.toDouble());
         std::lock_guard<std::mutex> lock(_logMutex);
         _tickLog[seq].insert(_id);
       }
@@ -146,8 +146,8 @@ TEST(SyncMarketDataBusTest, AllSubscribersProcessEachTickSynchronously)
     {
       auto handle = pool.acquire();
       ASSERT_TRUE(handle);
-      handle->type = BookUpdateType::SNAPSHOT;
-      handle->bids = {{Price::fromDouble(static_cast<double>(tick)), Quantity::fromDouble(1.0)}};
+      handle->update.type = BookUpdateType::SNAPSHOT;
+      handle->update.bids = {{Price::fromDouble(static_cast<double>(tick)), Quantity::fromDouble(1.0)}};
       bus.publish(std::move(handle));
     }
 

--- a/tests/test_sync_order_execution_bus.cpp
+++ b/tests/test_sync_order_execution_bus.cpp
@@ -1,0 +1,69 @@
+/*
+ * Flox Engine
+ * Developed by Evgenii Makarov (https://github.com/eeiaao)
+ *
+ * Copyright (c) 2025 Evgenii Makarov
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <memory>
+
+#include "flox/book/order.h"
+#include "flox/execution/order_event.h"
+#include "flox/execution/order_execution_bus.h"
+
+using namespace flox;
+
+namespace
+{
+
+class SyncListener : public IOrderExecutionListener
+{
+ public:
+  explicit SyncListener(std::atomic<int>& c) : _counter(c) {}
+
+  void onOrderAccepted(const Order&) override {}
+  void onOrderPartiallyFilled(const Order&, Quantity) override {}
+  void onOrderFilled(const Order& order) override
+  {
+    ++_counter;
+    last = order;
+  }
+  void onOrderCanceled(const Order&) override {}
+  void onOrderExpired(const Order&) override {}
+  void onOrderRejected(const Order&) override {}
+  void onOrderReplaced(const Order&, const Order&) override {}
+
+  Order last{};
+
+ private:
+  std::atomic<int>& _counter;
+};
+
+}  // namespace
+
+TEST(SyncOrderExecutionBusTest, WaitsForAllSubscribers)
+{
+  OrderExecutionBus bus;
+  std::atomic<int> counter{0};
+  auto l1 = std::make_shared<SyncListener>(counter);
+  auto l2 = std::make_shared<SyncListener>(counter);
+  bus.subscribe(l1);
+  bus.subscribe(l2);
+
+  bus.start();
+
+  OrderEvent event{};
+  event.type = OrderEventType::FILLED;
+  event.order.symbol = 42;
+  event.order.side = Side::BUY;
+  event.order.quantity = Quantity::fromDouble(1.0);
+
+  bus.publish(event);
+  EXPECT_EQ(counter.load(), 2);
+
+  bus.stop();
+}

--- a/tests/test_verify_order_book.cpp
+++ b/tests/test_verify_order_book.cpp
@@ -32,7 +32,7 @@ class WindowedOrderBookTestFixture : public ::testing::Test
   {
     auto handle = _pool.acquire();
     EXPECT_TRUE(handle);
-    handle->type = BookUpdateType::SNAPSHOT;
+    handle->update.type = BookUpdateType::SNAPSHOT;
     _handles.emplace_back(std::move(handle));
     return _handles.back().get();
   }
@@ -41,7 +41,7 @@ class WindowedOrderBookTestFixture : public ::testing::Test
   {
     auto handle = _pool.acquire();
     EXPECT_TRUE(handle);
-    handle->type = BookUpdateType::DELTA;
+    handle->update.type = BookUpdateType::DELTA;
     _handles.emplace_back(std::move(handle));
     return _handles.back().get();
   }
@@ -55,10 +55,10 @@ class WindowedOrderBookTestFixture : public ::testing::Test
 TEST_F(WindowedOrderBookTestFixture, SnapshotFitsInWindow)
 {
   auto snapshot = acquireSnapshot();
-  snapshot->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(5.0)},
-                    {Price::fromDouble(99.0), Quantity::fromDouble(3.0)}};
-  snapshot->asks = {{Price::fromDouble(101.0), Quantity::fromDouble(2.0)},
-                    {Price::fromDouble(102.0), Quantity::fromDouble(4.0)}};
+  snapshot->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(5.0)},
+                           {Price::fromDouble(99.0), Quantity::fromDouble(3.0)}};
+  snapshot->update.asks = {{Price::fromDouble(101.0), Quantity::fromDouble(2.0)},
+                           {Price::fromDouble(102.0), Quantity::fromDouble(4.0)}};
   _book->applyBookUpdate(*snapshot);
 
   EXPECT_EQ(_book->bidAtPrice(Price::fromDouble(100.0)), Quantity::fromDouble(5.0));
@@ -71,9 +71,9 @@ TEST_F(WindowedOrderBookTestFixture, SnapshotPartiallyOutsideWindow)
 {
   auto snapshot = acquireSnapshot();
   for (double p = 200.0; p <= 210.0; ++p)
-    snapshot->bids.push_back({Price::fromDouble(p), Quantity::fromDouble(1.0)});
+    snapshot->update.bids.push_back({Price::fromDouble(p), Quantity::fromDouble(1.0)});
   for (double p = 211.0; p <= 220.0; ++p)
-    snapshot->asks.push_back({Price::fromDouble(p), Quantity::fromDouble(1.0)});
+    snapshot->update.asks.push_back({Price::fromDouble(p), Quantity::fromDouble(1.0)});
   _book->applyBookUpdate(*snapshot);
 
   for (double p = 200.0; p <= 210.0; ++p)
@@ -85,13 +85,13 @@ TEST_F(WindowedOrderBookTestFixture, SnapshotPartiallyOutsideWindow)
 TEST_F(WindowedOrderBookTestFixture, DeltaWithinWindow)
 {
   auto snapshot = acquireSnapshot();
-  snapshot->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1.0)}};
-  snapshot->asks = {{Price::fromDouble(101.0), Quantity::fromDouble(1.0)}};
+  snapshot->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1.0)}};
+  snapshot->update.asks = {{Price::fromDouble(101.0), Quantity::fromDouble(1.0)}};
   _book->applyBookUpdate(*snapshot);
 
   auto delta = acquireDelta();
-  delta->bids = {{Price::fromDouble(99.0), Quantity::fromDouble(2.0)}};
-  delta->asks = {{Price::fromDouble(102.0), Quantity::fromDouble(2.5)}};
+  delta->update.bids = {{Price::fromDouble(99.0), Quantity::fromDouble(2.0)}};
+  delta->update.asks = {{Price::fromDouble(102.0), Quantity::fromDouble(2.5)}};
   _book->applyBookUpdate(*delta);
 
   EXPECT_EQ(_book->bidAtPrice(Price::fromDouble(99.0)), Quantity::fromDouble(2.0));
@@ -103,8 +103,8 @@ TEST_F(WindowedOrderBookTestFixture, DeltaWithinWindow)
 TEST_F(WindowedOrderBookTestFixture, DeltaAtWindowEdge)
 {
   auto snapshot = acquireSnapshot();
-  snapshot->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1.0)}};
-  snapshot->asks = {{Price::fromDouble(101.0), Quantity::fromDouble(1.0)}};
+  snapshot->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1.0)}};
+  snapshot->update.asks = {{Price::fromDouble(101.0), Quantity::fromDouble(1.0)}};
   _book->applyBookUpdate(*snapshot);
 
   double baseRaw = std::round((100.5 - 5.0) / TickSize.toDouble()) * TickSize.toDouble();
@@ -112,8 +112,8 @@ TEST_F(WindowedOrderBookTestFixture, DeltaAtWindowEdge)
   Price edgeAsk = Price::fromDouble(baseRaw + 9.0 * TickSize.toDouble());
 
   auto delta = acquireDelta();
-  delta->bids = {{base, Quantity::fromDouble(3.0)}};
-  delta->asks = {{edgeAsk, Quantity::fromDouble(3.0)}};
+  delta->update.bids = {{base, Quantity::fromDouble(3.0)}};
+  delta->update.asks = {{edgeAsk, Quantity::fromDouble(3.0)}};
   _book->applyBookUpdate(*delta);
 
   EXPECT_EQ(_book->bidAtPrice(Price::fromDouble(100.0)), Quantity::fromDouble(1.0));
@@ -125,13 +125,13 @@ TEST_F(WindowedOrderBookTestFixture, DeltaAtWindowEdge)
 TEST_F(WindowedOrderBookTestFixture, DeltaOutsideWindowIsIgnored)
 {
   auto snapshot = acquireSnapshot();
-  snapshot->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1.0)}};
-  snapshot->asks = {{Price::fromDouble(101.0), Quantity::fromDouble(1.0)}};
+  snapshot->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1.0)}};
+  snapshot->update.asks = {{Price::fromDouble(101.0), Quantity::fromDouble(1.0)}};
   _book->applyBookUpdate(*snapshot);
 
   auto delta = acquireDelta();
-  delta->bids = {{Price::fromDouble(80.0), Quantity::fromDouble(10.0)}};
-  delta->asks = {{Price::fromDouble(120.0), Quantity::fromDouble(10.0)}};
+  delta->update.bids = {{Price::fromDouble(80.0), Quantity::fromDouble(10.0)}};
+  delta->update.asks = {{Price::fromDouble(120.0), Quantity::fromDouble(10.0)}};
   _book->applyBookUpdate(*delta);
 
   EXPECT_EQ(_book->bidAtPrice(Price::fromDouble(100.0)), Quantity::fromDouble(1.0));
@@ -143,15 +143,15 @@ TEST_F(WindowedOrderBookTestFixture, DeltaOutsideWindowIsIgnored)
 TEST_F(WindowedOrderBookTestFixture, ShiftWindowCleansOldLevels)
 {
   auto snapshot1 = acquireSnapshot();
-  snapshot1->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(5.0)},
-                     {Price::fromDouble(101.0), Quantity::fromDouble(6.0)}};
-  snapshot1->asks = {{Price::fromDouble(102.0), Quantity::fromDouble(7.0)},
-                     {Price::fromDouble(103.0), Quantity::fromDouble(8.0)}};
+  snapshot1->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(5.0)},
+                            {Price::fromDouble(101.0), Quantity::fromDouble(6.0)}};
+  snapshot1->update.asks = {{Price::fromDouble(102.0), Quantity::fromDouble(7.0)},
+                            {Price::fromDouble(103.0), Quantity::fromDouble(8.0)}};
   _book->applyBookUpdate(*snapshot1);
 
   auto snapshot2 = acquireSnapshot();
-  snapshot2->bids = {{Price::fromDouble(199.0), Quantity::fromDouble(1.0)}};
-  snapshot2->asks = {{Price::fromDouble(201.0), Quantity::fromDouble(1.0)}};
+  snapshot2->update.bids = {{Price::fromDouble(199.0), Quantity::fromDouble(1.0)}};
+  snapshot2->update.asks = {{Price::fromDouble(201.0), Quantity::fromDouble(1.0)}};
   _book->applyBookUpdate(*snapshot2);
 
   for (double p = 190.0; p <= 210.0; ++p)
@@ -168,27 +168,27 @@ TEST_F(WindowedOrderBookTestFixture, ShiftWindowCleansOldLevels)
 TEST_F(WindowedOrderBookTestFixture, MultipleExtremeDeltasAreHandledCorrectly)
 {
   auto snapshot = acquireSnapshot();
-  snapshot->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(5.0)}};
-  snapshot->asks = {{Price::fromDouble(101.0), Quantity::fromDouble(5.0)}};
+  snapshot->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(5.0)}};
+  snapshot->update.asks = {{Price::fromDouble(101.0), Quantity::fromDouble(5.0)}};
   _book->applyBookUpdate(*snapshot);
 
   auto d1 = acquireDelta();
-  d1->bids = {{Price::fromDouble(99.0), Quantity::fromDouble(2.0)},
-              {Price::fromDouble(98.0), Quantity::fromDouble(1.0)}};
-  d1->asks = {{Price::fromDouble(102.0), Quantity::fromDouble(3.0)},
-              {Price::fromDouble(103.0), Quantity::fromDouble(4.0)}};
+  d1->update.bids = {{Price::fromDouble(99.0), Quantity::fromDouble(2.0)},
+                     {Price::fromDouble(98.0), Quantity::fromDouble(1.0)}};
+  d1->update.asks = {{Price::fromDouble(102.0), Quantity::fromDouble(3.0)},
+                     {Price::fromDouble(103.0), Quantity::fromDouble(4.0)}};
   _book->applyBookUpdate(*d1);
 
   auto d2 = acquireDelta();
-  d2->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(6.0)},
-              {Price::fromDouble(98.0), Quantity::fromDouble(0.0)}};
-  d2->asks = {{Price::fromDouble(101.0), Quantity::fromDouble(7.0)},
-              {Price::fromDouble(102.0), Quantity::fromDouble(0.0)}};
+  d2->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(6.0)},
+                     {Price::fromDouble(98.0), Quantity::fromDouble(0.0)}};
+  d2->update.asks = {{Price::fromDouble(101.0), Quantity::fromDouble(7.0)},
+                     {Price::fromDouble(102.0), Quantity::fromDouble(0.0)}};
   _book->applyBookUpdate(*d2);
 
   auto d3 = acquireDelta();
-  d3->bids = {{Price::fromDouble(80.0), Quantity::fromDouble(10.0)}};
-  d3->asks = {{Price::fromDouble(120.0), Quantity::fromDouble(10.0)}};
+  d3->update.bids = {{Price::fromDouble(80.0), Quantity::fromDouble(10.0)}};
+  d3->update.asks = {{Price::fromDouble(120.0), Quantity::fromDouble(10.0)}};
   _book->applyBookUpdate(*d3);
 
   EXPECT_EQ(_book->bidAtPrice(Price::fromDouble(100.0)), Quantity::fromDouble(6.0));

--- a/tests/test_windowed_order_book.cpp
+++ b/tests/test_windowed_order_book.cpp
@@ -25,11 +25,11 @@ TEST(WindowedOrderBookTest, ApplySnapshot)
 
   EventPool<BookUpdateEvent, 3> pool;
   auto snapshot = pool.acquire();
-  snapshot->type = BookUpdateType::SNAPSHOT;
-  snapshot->bids = {{Price::fromDouble(20000), Quantity::fromDouble(5)},
-                    {Price::fromDouble(19990), Quantity::fromDouble(3)}};
-  snapshot->asks = {{Price::fromDouble(20010), Quantity::fromDouble(2)},
-                    {Price::fromDouble(20020), Quantity::fromDouble(4)}};
+  snapshot->update.type = BookUpdateType::SNAPSHOT;
+  snapshot->update.bids = {{Price::fromDouble(20000), Quantity::fromDouble(5)},
+                           {Price::fromDouble(19990), Quantity::fromDouble(3)}};
+  snapshot->update.asks = {{Price::fromDouble(20010), Quantity::fromDouble(2)},
+                           {Price::fromDouble(20020), Quantity::fromDouble(4)}};
   book->applyBookUpdate(*snapshot);
 
   ASSERT_EQ(book->bestBid(), Price::fromDouble(20000));
@@ -44,16 +44,16 @@ TEST(WindowedOrderBookTest, ApplyDelta)
 
   EventPool<BookUpdateEvent, 3> pool;
   auto snapshot = pool.acquire();
-  snapshot->type = BookUpdateType::SNAPSHOT;
-  snapshot->bids = {{Price::fromDouble(1500), Quantity::fromDouble(1)}};
-  snapshot->asks = {{Price::fromDouble(1505), Quantity::fromDouble(1)}};
+  snapshot->update.type = BookUpdateType::SNAPSHOT;
+  snapshot->update.bids = {{Price::fromDouble(1500), Quantity::fromDouble(1)}};
+  snapshot->update.asks = {{Price::fromDouble(1505), Quantity::fromDouble(1)}};
   book->applyBookUpdate(*snapshot);
 
   auto delta = pool.acquire();
-  delta->type = BookUpdateType::DELTA;
-  delta->bids = {{Price::fromDouble(1500), Quantity::fromDouble(0)},
-                 {Price::fromDouble(1495), Quantity::fromDouble(2)}};
-  delta->asks = {{Price::fromDouble(1505), Quantity::fromDouble(3)}};
+  delta->update.type = BookUpdateType::DELTA;
+  delta->update.bids = {{Price::fromDouble(1500), Quantity::fromDouble(0)},
+                        {Price::fromDouble(1495), Quantity::fromDouble(2)}};
+  delta->update.asks = {{Price::fromDouble(1505), Quantity::fromDouble(3)}};
   book->applyBookUpdate(*delta);
 
   ASSERT_EQ(book->bestBid(), Price::fromDouble(1495));
@@ -68,15 +68,15 @@ TEST(WindowedOrderBookTest, SnapshotRemovesStaleLevels)
 
   EventPool<BookUpdateEvent, 3> pool;
   auto snap1 = pool.acquire();
-  snap1->type = BookUpdateType::SNAPSHOT;
-  snap1->bids = {{Price::fromDouble(20000), Quantity::fromDouble(5)},
-                 {Price::fromDouble(19990), Quantity::fromDouble(3)}};
+  snap1->update.type = BookUpdateType::SNAPSHOT;
+  snap1->update.bids = {{Price::fromDouble(20000), Quantity::fromDouble(5)},
+                        {Price::fromDouble(19990), Quantity::fromDouble(3)}};
   book->applyBookUpdate(*snap1);
   ASSERT_EQ(book->bestBid(), Price::fromDouble(20000));
 
   auto snap2 = pool.acquire();
-  snap2->type = BookUpdateType::SNAPSHOT;
-  snap2->bids = {{Price::fromDouble(19990), Quantity::fromDouble(7)}};
+  snap2->update.type = BookUpdateType::SNAPSHOT;
+  snap2->update.bids = {{Price::fromDouble(19990), Quantity::fromDouble(7)}};
   book->applyBookUpdate(*snap2);
   ASSERT_EQ(book->bestBid(), Price::fromDouble(19990));
 }
@@ -101,15 +101,15 @@ TEST(WindowedOrderBookTest, BestBidAskEmptyAfterErase)
 
   EventPool<BookUpdateEvent, 3> pool;
   auto snap = pool.acquire();
-  snap->type = BookUpdateType::SNAPSHOT;
-  snap->bids = {{Price::fromDouble(100), Quantity::fromDouble(1)}};
-  snap->asks = {{Price::fromDouble(101), Quantity::fromDouble(1)}};
+  snap->update.type = BookUpdateType::SNAPSHOT;
+  snap->update.bids = {{Price::fromDouble(100), Quantity::fromDouble(1)}};
+  snap->update.asks = {{Price::fromDouble(101), Quantity::fromDouble(1)}};
   book->applyBookUpdate(*snap);
 
   auto delta = pool.acquire();
-  delta->type = BookUpdateType::DELTA;
-  delta->bids = {{Price::fromDouble(100), Quantity::fromDouble(0)}};
-  delta->asks = {{Price::fromDouble(101), Quantity::fromDouble(0)}};
+  delta->update.type = BookUpdateType::DELTA;
+  delta->update.bids = {{Price::fromDouble(100), Quantity::fromDouble(0)}};
+  delta->update.asks = {{Price::fromDouble(101), Quantity::fromDouble(0)}};
   book->applyBookUpdate(*delta);
 
   ASSERT_FALSE(book->bestBid().has_value());
@@ -124,13 +124,13 @@ TEST(WindowedOrderBookTest, DeltaAddsNewLevel)
 
   EventPool<BookUpdateEvent, 3> pool;
   auto snap = pool.acquire();
-  snap->type = BookUpdateType::SNAPSHOT;
-  snap->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1)}};
+  snap->update.type = BookUpdateType::SNAPSHOT;
+  snap->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1)}};
   book->applyBookUpdate(*snap);
 
   auto delta = pool.acquire();
-  delta->type = BookUpdateType::DELTA;
-  delta->bids = {{Price::fromDouble(99.9), Quantity::fromDouble(2)}};
+  delta->update.type = BookUpdateType::DELTA;
+  delta->update.bids = {{Price::fromDouble(99.9), Quantity::fromDouble(2)}};
   book->applyBookUpdate(*delta);
 
   ASSERT_EQ(book->bestBid(), Price::fromDouble(100.0));
@@ -145,14 +145,14 @@ TEST(WindowedOrderBookTest, DeltaRemovesLevel)
 
   EventPool<BookUpdateEvent, 3> pool;
   auto snap = pool.acquire();
-  snap->type = BookUpdateType::SNAPSHOT;
-  snap->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1)},
-                {Price::fromDouble(99.9), Quantity::fromDouble(2)}};
+  snap->update.type = BookUpdateType::SNAPSHOT;
+  snap->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1)},
+                       {Price::fromDouble(99.9), Quantity::fromDouble(2)}};
   book->applyBookUpdate(*snap);
 
   auto delta = pool.acquire();
-  delta->type = BookUpdateType::DELTA;
-  delta->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(0)}};
+  delta->update.type = BookUpdateType::DELTA;
+  delta->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(0)}};
   book->applyBookUpdate(*delta);
 
   ASSERT_EQ(book->bestBid(), Price::fromDouble(99.9));
@@ -166,13 +166,13 @@ TEST(WindowedOrderBookTest, DeltaModifiesLevel)
 
   EventPool<BookUpdateEvent, 3> pool;
   auto snap = pool.acquire();
-  snap->type = BookUpdateType::SNAPSHOT;
-  snap->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1)}};
+  snap->update.type = BookUpdateType::SNAPSHOT;
+  snap->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1)}};
   book->applyBookUpdate(*snap);
 
   auto delta = pool.acquire();
-  delta->type = BookUpdateType::DELTA;
-  delta->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(5)}};
+  delta->update.type = BookUpdateType::DELTA;
+  delta->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(5)}};
   book->applyBookUpdate(*delta);
 
   ASSERT_EQ(book->bidAtPrice(Price::fromDouble(100.0)), Quantity::fromDouble(5));
@@ -186,14 +186,14 @@ TEST(WindowedOrderBookTest, DeltaIsPartialUpdate)
 
   EventPool<BookUpdateEvent, 3> pool;
   auto snap = pool.acquire();
-  snap->type = BookUpdateType::SNAPSHOT;
-  snap->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1)},
-                {Price::fromDouble(99.9), Quantity::fromDouble(2)}};
+  snap->update.type = BookUpdateType::SNAPSHOT;
+  snap->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(1)},
+                       {Price::fromDouble(99.9), Quantity::fromDouble(2)}};
   book->applyBookUpdate(*snap);
 
   auto delta = pool.acquire();
-  delta->type = BookUpdateType::DELTA;
-  delta->bids = {{Price::fromDouble(100.0), Quantity::fromDouble(3)}};
+  delta->update.type = BookUpdateType::DELTA;
+  delta->update.bids = {{Price::fromDouble(100.0), Quantity::fromDouble(3)}};
   book->applyBookUpdate(*delta);
 
   ASSERT_EQ(book->bidAtPrice(Price::fromDouble(100.0)), Quantity::fromDouble(3));


### PR DESCRIPTION
## Summary
- introduce `Trade` and `BookUpdate` data structures
- implement template `EventBus` with sync and async modes
- refactor `TradeEvent`, `BookUpdateEvent`, and `OrderExecutionBus` to use the generic bus
- fix duplicate definitions in `BookUpdateEvent`
- update order book implementations and tests for new `BookUpdateEvent` layout
- fix event struct usage in tests and benchmark
- fix lifetime bug in `MarketDataBus` publish

## Testing
- ❌ `cmake -DENABLE_BENCHMARK=OFF -B build -S .` *(failed to clone nlohmann_json)*
- ❌ `cmake --build build -j$(nproc)` *(no Makefile generated)*


------
https://chatgpt.com/codex/tasks/task_e_684277fe4768832e8110642590191990