### PR TITLE
Add CandleEvent bus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ target_compile_options(${FLOX} PRIVATE
 
 add_library(${FLOX_SYNC} STATIC ${SRC_FILES})
 add_library(flox::${FLOX_SYNC} ALIAS ${FLOX_SYNC})
-target_compile_definitions(${FLOX_SYNC} PRIVATE USE_SYNC_MARKET_BUS USE_SYNC_ORDER_BUS)
+target_compile_definitions(${FLOX_SYNC} PUBLIC USE_SYNC_MARKET_BUS USE_SYNC_ORDER_BUS USE_SYNC_CANDLE_BUS)
 target_compile_options(${FLOX_SYNC} PRIVATE
   $<$<CONFIG:Release>:-O3 -march=native -flto -funroll-loops>
 )

--- a/benchmarks/candle_aggregator_benchmark.cpp
+++ b/benchmarks/candle_aggregator_benchmark.cpp
@@ -7,6 +7,7 @@
  * license information.
  */
 
+#include "flox/aggregator/bus/candle_bus.h"
 #include "flox/aggregator/candle_aggregator.h"
 #include "flox/book/events/trade_event.h"
 #include "flox/common.h"
@@ -21,8 +22,9 @@ static void BM_CandleAggregator_OnTrade(benchmark::State& state)
   constexpr SymbolId SYMBOL = 42;
   constexpr std::chrono::seconds INTERVAL(60);
 
-  // Create aggregator with no-op callback
-  CandleAggregator aggregator(INTERVAL, [](SymbolId, const Candle&) {});
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  bus.start();
   aggregator.start();
 
   std::mt19937 rng(42);
@@ -46,6 +48,7 @@ static void BM_CandleAggregator_OnTrade(benchmark::State& state)
   }
 
   aggregator.stop();
+  bus.stop();
 }
 
 // Registers the benchmark with 1M iterations

--- a/benchmarks/position_manager_benchmark.cpp
+++ b/benchmarks/position_manager_benchmark.cpp
@@ -32,7 +32,7 @@ static Order makeOrder(SymbolId symbol, Side side, double qty)
 
 static void BM_PositionManager_OnOrderFilled(benchmark::State& state)
 {
-  PositionManager pm;
+  PositionManager pm(100);
   pm.start();
 
   std::mt19937 rng(42);

--- a/demo/include/demo/simple_components.h
+++ b/demo/include/demo/simple_components.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "flox/engine/abstract_subscriber.h"
 #include "flox/execution/abstract_executor.h"
 #include "flox/execution/bus/order_execution_bus.h"
 #include "flox/killswitch/abstract_killswitch.h"
@@ -224,6 +225,9 @@ class SimpleOrderExecutor : public IOrderExecutor
 class SimplePositionManager : public PositionManager
 {
  public:
+  SimplePositionManager(SubscriberId id)
+      : PositionManager(id) {}
+
   void start() override
   {
     std::cout << "[position] start\n";

--- a/demo/src/demo_builder.cpp
+++ b/demo/src/demo_builder.cpp
@@ -16,7 +16,7 @@ std::unique_ptr<IEngine> DemoBuilder::build()
 
   auto execTracker = std::make_unique<ConsoleExecutionTracker>();
   auto pnlTracker = std::make_unique<SimplePnLTracker>();
-  auto posMgr = std::make_unique<SimplePositionManager>();
+  auto posMgr = std::make_unique<SimplePositionManager>(100);
   auto storage = std::make_unique<StdoutStorageSink>();
   auto killSwitch = std::make_unique<SimpleKillSwitch>();
   auto riskMgr = std::make_unique<SimpleRiskManager>(killSwitch.get());

--- a/demo/src/demo_builder.cpp
+++ b/demo/src/demo_builder.cpp
@@ -58,14 +58,16 @@ std::unique_ptr<IEngine> DemoBuilder::build()
   for (auto& strat : strategies)
     strategySubs.push_back(std::make_unique<StrategySubsystem>(strat));
 
-  auto candleAgg = std::make_unique<CandleAggregator>(
-      std::chrono::seconds{60},
-      [](SymbolId, const Candle& c)
-      { std::cout << "[candle] close=" << c.close.toDouble() << '\n'; });
+  auto candleBus =
+      std::make_unique<Subsystem<CandleBus>>(std::make_unique<CandleBus>());
+  auto candleAgg =
+      std::make_unique<CandleAggregator>(std::chrono::seconds{60},
+                                         candleBus->get());
 
   for (auto& strat : strategies)
   {
     mdb->get()->subscribe(strat);
+    candleBus->get()->subscribe(strat);
   }
 
   mdb->get()->subscribe(std::shared_ptr<IMarketDataSubscriber>(candleAgg.get(), [](auto*) {}));
@@ -86,6 +88,7 @@ std::unique_ptr<IEngine> DemoBuilder::build()
   subsystems.push_back(std::move(riskMgr));
   subsystems.push_back(std::move(posMgr));
   subsystems.push_back(std::move(storage));
+  subsystems.push_back(std::move(candleBus));
   subsystems.push_back(std::move(candleAgg));
 
   subsystems.push_back(std::make_unique<Subsystem<WindowedOrderBookFactory>>(std::move(obFactory)));

--- a/include/flox/aggregator/bus/candle_bus.h
+++ b/include/flox/aggregator/bus/candle_bus.h
@@ -7,9 +7,9 @@ namespace flox
 {
 
 #ifdef USE_SYNC_CANDLE_BUS
-using CandleBus = EventBus<CandleEvent, true>;
+using CandleBus = EventBus<CandleEvent, SyncPolicy<CandleEvent>>;
 #else
-using CandleBus = EventBus<CandleEvent, false>;
+using CandleBus = EventBus<CandleEvent, AsyncPolicy<CandleEvent>>;
 #endif
 
 }  // namespace flox

--- a/include/flox/aggregator/bus/candle_bus.h
+++ b/include/flox/aggregator/bus/candle_bus.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "flox/aggregator/events/candle_event.h"
+#include "flox/util/eventing/event_bus.h"
+
+namespace flox
+{
+
+using CandleBus = EventBus<CandleEvent, false, true>;
+
+}  // namespace flox

--- a/include/flox/aggregator/bus/candle_bus.h
+++ b/include/flox/aggregator/bus/candle_bus.h
@@ -6,6 +6,10 @@
 namespace flox
 {
 
+#ifdef USE_SYNC_MARKET_BUS
+using CandleBus = EventBus<CandleEvent, true, true>;
+#else
 using CandleBus = EventBus<CandleEvent, false, true>;
+#endif
 
 }  // namespace flox

--- a/include/flox/aggregator/bus/candle_bus.h
+++ b/include/flox/aggregator/bus/candle_bus.h
@@ -6,10 +6,10 @@
 namespace flox
 {
 
-#ifdef USE_SYNC_MARKET_BUS
-using CandleBus = EventBus<CandleEvent, true, true>;
+#ifdef USE_SYNC_CANDLE_BUS
+using CandleBus = EventBus<CandleEvent, true>;
 #else
-using CandleBus = EventBus<CandleEvent, false, true>;
+using CandleBus = EventBus<CandleEvent, false>;
 #endif
 
 }  // namespace flox

--- a/include/flox/aggregator/candle_aggregator.h
+++ b/include/flox/aggregator/candle_aggregator.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "flox/aggregator/bus/candle_bus.h"
 #include "flox/book/candle.h"
 #include "flox/book/events/trade_event.h"
 #include "flox/common.h"
@@ -17,7 +18,6 @@
 #include "flox/engine/subsystem.h"
 
 #include <chrono>
-#include <functional>
 #include <unordered_map>
 
 namespace flox
@@ -26,9 +26,7 @@ namespace flox
 class CandleAggregator : public ISubsystem, public IMarketDataSubscriber
 {
  public:
-  using CandleCallback = std::move_only_function<void(SymbolId, const Candle&)>;
-
-  CandleAggregator(std::chrono::seconds interval, CandleCallback callback);
+  CandleAggregator(std::chrono::seconds interval, CandleBus* bus);
 
   void start() override;
   void stop() override;
@@ -46,7 +44,7 @@ class CandleAggregator : public ISubsystem, public IMarketDataSubscriber
   };
 
   std::chrono::seconds _interval;
-  CandleCallback _callback;
+  CandleBus* _bus = nullptr;
   std::unordered_map<SymbolId, PartialCandle> _candles;
 
   std::chrono::system_clock::time_point alignToInterval(std::chrono::system_clock::time_point tp);

--- a/include/flox/aggregator/events/candle_event.h
+++ b/include/flox/aggregator/events/candle_event.h
@@ -13,6 +13,8 @@ struct CandleEvent
 
   SymbolId symbol{};
   Candle candle{};
+
+  uint64_t tickSequence = 0;
 };
 
 }  // namespace flox

--- a/include/flox/aggregator/events/candle_event.h
+++ b/include/flox/aggregator/events/candle_event.h
@@ -2,14 +2,14 @@
 
 #include "flox/book/candle.h"
 #include "flox/common.h"
+#include "flox/engine/abstract_market_data_subscriber.h"
 
 namespace flox
 {
-class IStrategy;  // forward declaration
 
 struct CandleEvent
 {
-  using Listener = IStrategy;
+  using Listener = IMarketDataSubscriber;
 
   SymbolId symbol{};
   Candle candle{};

--- a/include/flox/aggregator/events/candle_event.h
+++ b/include/flox/aggregator/events/candle_event.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "flox/book/candle.h"
+#include "flox/common.h"
+
+namespace flox
+{
+class IStrategy;  // forward declaration
+
+struct CandleEvent
+{
+  using Listener = IStrategy;
+
+  SymbolId symbol{};
+  Candle candle{};
+};
+
+}  // namespace flox

--- a/include/flox/book/bus/book_update_bus.h
+++ b/include/flox/book/bus/book_update_bus.h
@@ -7,9 +7,9 @@ namespace flox
 {
 
 #ifdef USE_SYNC_MARKET_BUS
-using BookUpdateBus = EventBus<EventHandle<BookUpdateEvent>, true>;
+using BookUpdateBus = EventBus<EventHandle<BookUpdateEvent>, SyncPolicy<EventHandle<BookUpdateEvent>>>;
 #else
-using BookUpdateBus = EventBus<EventHandle<BookUpdateEvent>, false>;
+using BookUpdateBus = EventBus<EventHandle<BookUpdateEvent>, AsyncPolicy<EventHandle<BookUpdateEvent>>>;
 #endif
 
 }  // namespace flox

--- a/include/flox/book/bus/book_update_bus.h
+++ b/include/flox/book/bus/book_update_bus.h
@@ -7,9 +7,9 @@ namespace flox
 {
 
 #ifdef USE_SYNC_MARKET_BUS
-using BookUpdateBus = EventBus<EventHandle<BookUpdateEvent>, true, true>;
+using BookUpdateBus = EventBus<EventHandle<BookUpdateEvent>, true>;
 #else
-using BookUpdateBus = EventBus<EventHandle<BookUpdateEvent>, false, true>;
+using BookUpdateBus = EventBus<EventHandle<BookUpdateEvent>, false>;
 #endif
 
 }  // namespace flox

--- a/include/flox/book/bus/trade_bus.h
+++ b/include/flox/book/bus/trade_bus.h
@@ -7,9 +7,9 @@ namespace flox
 {
 
 #ifdef USE_SYNC_MARKET_BUS
-using TradeBus = EventBus<TradeEvent, true>;
+using TradeBus = EventBus<TradeEvent, SyncPolicy<TradeEvent>>;
 #else
-using TradeBus = EventBus<TradeEvent, false>;
+using TradeBus = EventBus<TradeEvent, AsyncPolicy<TradeEvent>>;
 #endif
 
 }  // namespace flox

--- a/include/flox/book/bus/trade_bus.h
+++ b/include/flox/book/bus/trade_bus.h
@@ -7,9 +7,9 @@ namespace flox
 {
 
 #ifdef USE_SYNC_MARKET_BUS
-using TradeBus = EventBus<TradeEvent, true, true>;
+using TradeBus = EventBus<TradeEvent, true>;
 #else
-using TradeBus = EventBus<TradeEvent, false, true>;
+using TradeBus = EventBus<TradeEvent, false>;
 #endif
 
 }  // namespace flox

--- a/include/flox/book/events/book_update_event.h
+++ b/include/flox/book/events/book_update_event.h
@@ -23,6 +23,8 @@ struct BookUpdateEvent : public IMarketDataEvent
 
   BookUpdate update;
 
+  uint64_t tickSequence = 0;
+
   BookUpdateEvent(std::pmr::memory_resource* res) : update(res)
   {
     assert(res != nullptr && "pmr::memory_resource is null!");

--- a/include/flox/engine/abstract_market_data_subscriber.h
+++ b/include/flox/engine/abstract_market_data_subscriber.h
@@ -9,8 +9,7 @@
 
 #pragma once
 
-#include "flox/book/events/book_update_event.h"
-#include "flox/book/events/trade_event.h"
+#include "flox/common.h"
 #include "flox/engine/events/market_data_event.h"
 
 namespace flox
@@ -23,6 +22,10 @@ enum class SubscriberMode
   PULL
 };
 
+class BookUpdateEvent;
+class TradeEvent;
+class CandleEvent;
+
 class IMarketDataSubscriber
 {
  public:
@@ -30,6 +33,7 @@ class IMarketDataSubscriber
 
   virtual void onBookUpdate(const BookUpdateEvent& ev) {}
   virtual void onTrade(const TradeEvent& ev) {}
+  virtual void onCandle(const CandleEvent& ev) {}
 
   virtual SubscriberId id() const = 0;
   virtual SubscriberMode mode() const { return SubscriberMode::PUSH; }

--- a/include/flox/engine/abstract_market_data_subscriber.h
+++ b/include/flox/engine/abstract_market_data_subscriber.h
@@ -9,24 +9,17 @@
 
 #pragma once
 
-#include "flox/common.h"
+#include "flox/engine/abstract_subscriber.h"
 #include "flox/engine/events/market_data_event.h"
 
 namespace flox
 {
 
-using SubscriberId = uint64_t;
-enum class SubscriberMode
-{
-  PUSH,
-  PULL
-};
-
 class BookUpdateEvent;
 class TradeEvent;
 class CandleEvent;
 
-class IMarketDataSubscriber
+class IMarketDataSubscriber : public ISubscriber
 {
  public:
   virtual ~IMarketDataSubscriber() = default;
@@ -34,9 +27,6 @@ class IMarketDataSubscriber
   virtual void onBookUpdate(const BookUpdateEvent& ev) {}
   virtual void onTrade(const TradeEvent& ev) {}
   virtual void onCandle(const CandleEvent& ev) {}
-
-  virtual SubscriberId id() const = 0;
-  virtual SubscriberMode mode() const { return SubscriberMode::PUSH; }
 };
 
 }  // namespace flox

--- a/include/flox/engine/abstract_subscriber.h
+++ b/include/flox/engine/abstract_subscriber.h
@@ -9,19 +9,22 @@
 
 #pragma once
 
-#include "flox/book/trade.h"
-#include "flox/engine/events/market_data_event.h"
+#include <cstdint>
 
 namespace flox
 {
 
-struct TradeEvent
+using SubscriberId = uint64_t;
+enum class SubscriberMode
 {
-  using Listener = IMarketDataSubscriber;
+  PUSH,
+  PULL
+};
 
-  Trade trade{};
-
-  uint64_t tickSequence = 0;
+struct ISubscriber
+{
+  virtual SubscriberId id() const = 0;
+  virtual SubscriberMode mode() const { return SubscriberMode::PUSH; }
 };
 
 }  // namespace flox

--- a/include/flox/engine/bus/market_data_bus.h
+++ b/include/flox/engine/bus/market_data_bus.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <type_traits>
 
 #include "flox/book/bus/book_update_bus.h"
 #include "flox/book/bus/trade_bus.h"

--- a/include/flox/engine/event_dispatcher.h
+++ b/include/flox/engine/event_dispatcher.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "flox/aggregator/events/candle_event.h"
 #include "flox/book/events/book_update_event.h"
 #include "flox/book/events/trade_event.h"
 #include "flox/engine/abstract_market_data_subscriber.h"
@@ -35,6 +36,15 @@ struct EventDispatcher<TradeEvent>
   static void dispatch(const TradeEvent& ev, IMarketDataSubscriber& sub)
   {
     sub.onTrade(ev);
+  }
+};
+
+template <>
+struct EventDispatcher<CandleEvent>
+{
+  static void dispatch(const CandleEvent& ev, IStrategy& strat)
+  {
+    strat.onCandle(ev.symbol, ev.candle);
   }
 };
 

--- a/include/flox/engine/event_dispatcher.h
+++ b/include/flox/engine/event_dispatcher.h
@@ -42,9 +42,9 @@ struct EventDispatcher<TradeEvent>
 template <>
 struct EventDispatcher<CandleEvent>
 {
-  static void dispatch(const CandleEvent& ev, IStrategy& strat)
+  static void dispatch(const CandleEvent& ev, IMarketDataSubscriber& sub)
   {
-    strat.onCandle(ev.symbol, ev.candle);
+    sub.onCandle(ev);
   }
 };
 

--- a/include/flox/engine/market_data_event_pool.h
+++ b/include/flox/engine/market_data_event_pool.h
@@ -88,6 +88,7 @@ class EventHandle
         _event->releaseToPool();
       }
     }
+
     _event = nullptr;
   }
 
@@ -114,7 +115,7 @@ class EventPool : public IEventPool
     EventT* event = nullptr;
     if (_queue.pop(event))
     {
-      event->resetRefCount(0);  // refCount = 1
+      event->resetRefCount();
       event->setPool(this);
 
       ++_acquired;

--- a/include/flox/execution/abstract_execution_listener.h
+++ b/include/flox/execution/abstract_execution_listener.h
@@ -9,15 +9,22 @@
 
 #pragma once
 
+#include "flox/engine/abstract_subscriber.h"
 #include "flox/execution/order.h"
 
 namespace flox
 {
 
-class IOrderExecutionListener
+class IOrderExecutionListener : public ISubscriber
 {
+  SubscriberId _id{};
+
  public:
+  IOrderExecutionListener(SubscriberId id) : _id(id) {}
+
   virtual ~IOrderExecutionListener() = default;
+
+  SubscriberId id() const override { return _id; };
 
   virtual void onOrderAccepted(const Order& order) = 0;
   virtual void onOrderPartiallyFilled(const Order& order, Quantity fillQty) = 0;

--- a/include/flox/execution/bus/order_execution_bus.h
+++ b/include/flox/execution/bus/order_execution_bus.h
@@ -7,9 +7,9 @@ namespace flox
 {
 
 #ifdef USE_SYNC_ORDER_BUS
-using OrderExecutionBus = EventBus<OrderEvent, true>;
+using OrderExecutionBus = EventBus<OrderEvent, SyncPolicy<OrderEvent> >;
 #else
-using OrderExecutionBus = EventBus<OrderEvent, false>;
+using OrderExecutionBus = EventBus<OrderEvent, AsyncPolicy<OrderEvent> >;
 #endif
 
 }  // namespace flox

--- a/include/flox/execution/events/order_event.h
+++ b/include/flox/execution/events/order_event.h
@@ -25,6 +25,8 @@ struct OrderEvent
   Order newOrder{};
   Quantity fillQty{0};
 
+  uint64_t tickSequence = 0;
+
   void dispatchTo(IOrderExecutionListener& listener) const
   {
     switch (type)

--- a/include/flox/execution/multi_execution_listener.h
+++ b/include/flox/execution/multi_execution_listener.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "flox/engine/abstract_subscriber.h"
 #include "flox/execution/abstract_execution_listener.h"
 
 #include <algorithm>
@@ -20,6 +21,8 @@ namespace flox
 class MultiExecutionListener : public IOrderExecutionListener
 {
  public:
+  MultiExecutionListener(SubscriberId id) : IOrderExecutionListener(id) {}
+
   void addListener(IOrderExecutionListener* listener)
   {
     if (listener && std::ranges::find(_listeners, listener) == _listeners.end())

--- a/include/flox/position/position_manager.h
+++ b/include/flox/position/position_manager.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "flox/common.h"
+#include "flox/engine/abstract_subscriber.h"
 #include "flox/engine/subsystem.h"
 #include "flox/execution/abstract_execution_listener.h"
 #include "flox/position/abstract_position_manager.h"
@@ -22,6 +23,8 @@ namespace flox
 class PositionManager : public IPositionManager, public IOrderExecutionListener, public ISubsystem
 {
  public:
+  PositionManager(SubscriberId id) : IOrderExecutionListener(id) {}
+
   void start() override {}
   void stop() override {}
 

--- a/include/flox/strategy/abstract_strategy.h
+++ b/include/flox/strategy/abstract_strategy.h
@@ -33,7 +33,7 @@ class IStrategy : public IMarketDataSubscriber
   virtual void onStop() {}
 
   // Event hooks
-  virtual void onCandle(SymbolId symbol, const Candle& candle) {}
+  virtual void onCandle(const CandleEvent& candle) override {}
   virtual void onTrade(const TradeEvent& trade) override {}
   virtual void onBookUpdate(const BookUpdateEvent& bookUpdate) override {}
 

--- a/include/flox/util/base/ref_countable.h
+++ b/include/flox/util/base/ref_countable.h
@@ -31,7 +31,7 @@ class RefCountable
     return prev == 1;
   }
 
-  void resetRefCount(uint32_t value = 1) noexcept
+  void resetRefCount(uint32_t value = 0) noexcept
   {
     _refCount.store(value, std::memory_order_relaxed);
   }

--- a/include/flox/util/concurrency/spsc_queue.h
+++ b/include/flox/util/concurrency/spsc_queue.h
@@ -127,6 +127,18 @@ class SPSCQueue
     return std::ref(*ptr);
   }
 
+  void clear() noexcept
+  {
+    while (!empty())
+    {
+      const size_t tail = _tail.load(std::memory_order_relaxed);
+      T* ptr = reinterpret_cast<T*>(&_buffer[tail]);
+      ptr->~T();
+      const size_t next = (tail + 1) & MASK;
+      _tail.store(next, std::memory_order_release);
+    }
+  }
+
   bool empty() const noexcept
   {
     return _head.load(std::memory_order_acquire) == _tail.load(std::memory_order_acquire);

--- a/include/flox/util/eventing/event_bus.h
+++ b/include/flox/util/eventing/event_bus.h
@@ -4,9 +4,9 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <unordered_map>
-#include <vector>
 
 #include "flox/engine/event_dispatcher.h"
 #include "flox/engine/tick_barrier.h"
@@ -15,9 +15,6 @@
 
 namespace flox
 {
-
-template <typename Event, bool Sync>
-class EventBus;
 
 template <typename T>
 struct ListenerType
@@ -31,87 +28,95 @@ struct ListenerType<EventHandle<T>>
   using type = typename T::Listener;
 };
 
-template <typename Event, typename Bus>
-concept PushOnlyEventBus = requires(Bus b, std::shared_ptr<typename ListenerType<Event>::type> l, const Event& e) {
-  { b.subscribe(l) };
-  { b.publish(e) };
-  { b.start() };
-  { b.stop() };
+template <typename Event>
+struct SyncPolicy
+{
+  using QueueItem = std::pair<Event, TickBarrier*>;
+  static QueueItem makeItem(Event ev, TickBarrier* barrier) { return {ev, barrier}; }
+  static void dispatch(const QueueItem& item, typename ListenerType<Event>::type& listener)
+  {
+    TickGuard guard(*item.second);
+    EventDispatcher<Event>::dispatch(item.first, listener);
+  }
 };
 
-template <typename Event, typename Bus>
-concept QueueableEventBus = PushOnlyEventBus<Event, Bus> &&
-                            requires(Bus b, SubscriberId id) {
-                              { b.getQueue(id) } -> std::same_as<typename Bus::Queue*>;
-                            };
-
-// Synchronous specialization
 template <typename Event>
-class EventBus<Event, true>
+struct AsyncPolicy
+{
+  using QueueItem = Event;
+  static QueueItem makeItem(Event ev, void*) { return ev; }
+  static void dispatch(const QueueItem& item, typename ListenerType<Event>::type& listener)
+  {
+    EventDispatcher<Event>::dispatch(item, listener);
+  }
+};
+
+template <typename Event, typename Policy>
+class EventBus
 {
  public:
   using Listener = typename ListenerType<Event>::type;
-  static constexpr size_t QueueSize = 4096;
-  using QueueItem = std::pair<Event, TickBarrier*>;
-  using Queue = SPSCQueue<QueueItem, QueueSize>;
+  using QueueItem = typename Policy::QueueItem;
+  using Queue = SPSCQueue<QueueItem, 4096>;
 
-  EventBus()
-  {
-    static_assert(QueueableEventBus<Event, EventBus<Event, true>>,
-                  "EventBus does not conform to QueueableEventBus");
-  };
-
+  EventBus() = default;
   ~EventBus() { stop(); }
 
   void subscribe(std::shared_ptr<Listener> listener)
   {
+    SubscriberMode mode = listener->mode();
+
     Entry e;
+    e.mode = mode;
     e.listener = std::move(listener);
     e.queue = std::make_unique<Queue>();
-    _subs.push_back(std::move(e));
+
+    std::lock_guard lock(_mutex);
+    _subs.emplace(e.listener->id(), std::move(e));
   }
 
   void start()
   {
     if (_running.exchange(true))
-    {
       return;
-    }
 
-    _active = _subs.size();
-    for (auto& entry : _subs)
+    std::lock_guard lock(_mutex);
+    _active = 0;
+
+    for (auto& [_, e] : _subs)
     {
-      auto& queue = *entry.queue;
-      auto& listener = entry.listener;
-      entry.thread = std::thread(
-          [this, &queue, &listener]
-          {
-            {
-              std::lock_guard<std::mutex> lk(_readyMutex);
-              if (--_active == 0)
-                _cv.notify_one();
-            }
-
-            while (_running.load(std::memory_order_acquire))
-            {
-              if (auto* itemPtr = queue.try_pop())
-              {
-                auto& [ev, barrier] = *itemPtr;
-
-                TickGuard guard(*barrier);
-                EventDispatcher<Event>::dispatch(ev, *listener);
-
-                itemPtr->~QueueItem();
-              }
-              else
-              {
-                std::this_thread::yield();
-              }
-            }
-          });
+      if (e.mode == SubscriberMode::PUSH)
+        ++_active;
     }
 
-    std::unique_lock<std::mutex> lk(_readyMutex);
+    for (auto& [_, e] : _subs)
+    {
+      if (e.mode == SubscriberMode::PUSH)
+      {
+        auto* queue = e.queue.get();
+        auto listener = e.listener;
+        e.thread.emplace([this, queue, listener]
+                         {
+          {
+            std::lock_guard<std::mutex> lk(_readyMutex);
+            if (--_active == 0) _cv.notify_one();
+          }
+          while (_running.load(std::memory_order_acquire)) {
+            if (auto* item = queue->try_pop()) {
+              Policy::dispatch(*item, *listener);
+              item->~QueueItem();
+            } else {
+              std::this_thread::yield();
+            }
+          }
+          while (auto* item = queue->try_pop()) {
+            Policy::dispatch(*item, *listener);
+            item->~QueueItem();
+          } });
+      }
+    }
+
+    std::unique_lock lk(_readyMutex);
     _cv.wait(lk, [&]
              { return _active == 0; });
   }
@@ -119,54 +124,59 @@ class EventBus<Event, true>
   void stop()
   {
     if (!_running.exchange(false))
-    {
       return;
-    }
-
-    for (auto& entry : _subs)
+    std::lock_guard lock(_mutex);
+    for (auto& [_, e] : _subs)
     {
-      if (entry.thread.joinable())
-      {
-        entry.thread.join();
-      }
-
-      entry.queue->clear();
+      e.thread.reset();
+      e.queue->clear();
     }
-
     _subs.clear();
   }
 
-  void publish(Event event)
+  void publish(Event ev)
   {
-    TickBarrier barrier(_subs.size());
+    if (!_running.load(std::memory_order_acquire))
+      return;
 
     uint64_t seq = _tickCounter.fetch_add(1, std::memory_order_relaxed);
 
-    if constexpr (requires { event->tickSequence; })
+    if constexpr (requires { ev->tickSequence; })
     {
-      event->tickSequence = seq;
+      ev->tickSequence = seq;
+    }
+    if constexpr (requires { ev.tickSequence; })
+    {
+      ev.tickSequence = seq;
     }
 
-    if constexpr (requires { event.tickSequence; })
+    TickBarrier barrier(_subs.size());
+
+    std::lock_guard lock(_mutex);
+    for (auto& [_, e] : _subs)
     {
-      event.tickSequence = seq;
+      if constexpr (std::is_same_v<Policy, SyncPolicy<Event>>)
+      {
+        e.queue->emplace(Policy::makeItem(ev, &barrier));
+      }
+      else
+      {
+        e.queue->emplace(Policy::makeItem(ev, nullptr));
+      }
     }
 
-    for (auto& entry : _subs)
+    if constexpr (std::is_same_v<Policy, SyncPolicy<Event>>)
     {
-      entry.queue->emplace(QueueItem{event, &barrier});
+      barrier.wait();
     }
-
-    barrier.wait();
   }
 
   Queue* getQueue(SubscriberId id)
   {
-    for (auto& entry : _subs)
-    {
-      if (entry.listener && entry.listener->id() == id)
-        return entry.queue.get();
-    }
+    std::lock_guard lock(_mutex);
+    auto it = _subs.find(id);
+    if (it != _subs.end() && it->second.mode == SubscriberMode::PULL)
+      return it->second.queue.get();
     return nullptr;
   }
 
@@ -180,176 +190,16 @@ class EventBus<Event, true>
   {
     std::shared_ptr<Listener> listener;
     std::unique_ptr<Queue> queue;
-    std::thread thread;
-  };
-
-  std::vector<Entry> _subs;
-  std::atomic<bool> _running{false};
-  std::atomic<size_t> _active{0};
-  std::condition_variable _cv;
-  std::mutex _readyMutex;
-
-  std::atomic<uint64_t> _tickCounter{0};
-};
-
-// Asynchronous specialization with per-subscriber queues (PULL/PUSH + threads for PUSH)
-template <typename Event>
-class EventBus<Event, false>
-{
- public:
-  using Listener = typename ListenerType<Event>::type;
-  static constexpr size_t QueueSize = 4096;
-  using QueueItem = Event;
-  using Queue = SPSCQueue<QueueItem, QueueSize>;
-
-  EventBus()
-  {
-    static_assert(QueueableEventBus<Event, EventBus<Event, false>>,
-                  "EventBus does not conform to QueueableEventBus");
-  }
-
-  ~EventBus() { stop(); }
-
-  struct SubscriberEntry
-  {
-    SubscriberMode mode;
-    std::shared_ptr<Listener> subscriber;
-    std::unique_ptr<Queue> queue;
+    SubscriberMode mode = SubscriberMode::PUSH;
     std::optional<std::jthread> thread;
   };
 
-  void subscribe(std::shared_ptr<Listener> sub)
-  {
-    SubscriberEntry e;
-    e.mode = sub->mode();
-    e.subscriber = std::move(sub);
-    e.queue = std::make_unique<Queue>();
-
-    std::lock_guard<std::mutex> lock(_mutex);
-    _subs.emplace(e.subscriber->id(), std::move(e));
-  }
-
-  void start()
-  {
-    if (_running.exchange(true))
-    {
-      return;
-    }
-
-    _running.store(true, std::memory_order_release);
-
-    std::lock_guard<std::mutex> lock(_mutex);
-
-    _active = std::count_if(_subs.begin(), _subs.end(), [](const auto& entry)
-                            { return entry.second.mode == SubscriberMode::PUSH; });
-
-    for (auto& [_, sub] : _subs)
-    {
-      if (sub.mode == SubscriberMode::PUSH && !sub.thread.has_value())
-      {
-        auto* queue = sub.queue.get();
-        auto subscriber = sub.subscriber;
-        sub.thread.emplace([queue, subscriber, this]
-                           {
-                             {
-                               std::lock_guard<std::mutex> lk(_readyMutex);
-                               if (--_active == 0)
-                                 _cv.notify_one();
-                             }
-
-                             while (_running.load(std::memory_order_acquire))
-                             {
-                               if (auto* item = queue->try_pop())
-                               {
-                                 EventDispatcher<Event>::dispatch(*item, *subscriber);
-                                 item->~QueueItem();
-                               }
-                               else
-                               {
-                                 std::this_thread::yield();
-                               }
-                             }
-
-                             while (auto* item = queue->try_pop())
-                             {
-                               EventDispatcher<Event>::dispatch(*item, *subscriber);
-                               item->~QueueItem();
-                             } });
-      }
-    }
-
-    std::unique_lock<std::mutex> lk(_readyMutex);
-    _cv.wait(lk, [&]
-             { return _active == 0; });
-  }
-
-  void stop()
-  {
-    if (!_running.exchange(false))
-      return;
-
-    std::lock_guard<std::mutex> lock(_mutex);
-    for (auto& [_, sub] : _subs)
-    {
-      if (sub.thread)
-        sub.thread.reset();
-    }
-
-    _subs.clear();
-  }
-
-  void publish(Event event)
-  {
-    if (!_running.load(std::memory_order_acquire))
-    {
-      return;
-    }
-
-    std::lock_guard<std::mutex> lock(_mutex);
-
-    uint64_t seq = _tickCounter.fetch_add(1, std::memory_order_relaxed);
-
-    if constexpr (requires { event->tickSequence; })
-    {
-      event->tickSequence = seq;
-    }
-
-    if constexpr (requires { event.tickSequence; })
-    {
-      event.tickSequence = seq;
-    }
-
-    for (auto& [_, sub] : _subs)
-    {
-      if (sub.queue)
-      {
-        sub.queue->push(event);
-      }
-    }
-  }
-
-  Queue* getQueue(SubscriberId id)
-  {
-    std::lock_guard<std::mutex> lock(_mutex);
-    auto it = _subs.find(id);
-    if (it != _subs.end() && it->second.mode == SubscriberMode::PULL)
-      return it->second.queue.get();
-    return nullptr;
-  }
-
-  uint64_t currentTickId() const noexcept
-  {
-    return _tickCounter.load(std::memory_order_relaxed);
-  }
-
- private:
+  std::unordered_map<SubscriberId, Entry> _subs;
   std::mutex _mutex;
-  std::unordered_map<SubscriberId, SubscriberEntry> _subs;
   std::atomic<bool> _running{false};
   std::atomic<size_t> _active{0};
   std::condition_variable _cv;
   std::mutex _readyMutex;
-
   std::atomic<uint64_t> _tickCounter{0};
 };
 

--- a/src/aggregator/candle_aggregator.cpp
+++ b/src/aggregator/candle_aggregator.cpp
@@ -11,7 +11,6 @@
 
 #include <cassert>
 #include <ranges>
-#include "flox/engine/market_data_event_pool.h"
 
 namespace flox
 {

--- a/src/aggregator/candle_aggregator.cpp
+++ b/src/aggregator/candle_aggregator.cpp
@@ -16,8 +16,8 @@
 namespace flox
 {
 
-CandleAggregator::CandleAggregator(std::chrono::seconds interval, CandleCallback callback)
-    : _interval(interval), _callback(std::move(callback))
+CandleAggregator::CandleAggregator(std::chrono::seconds interval, CandleBus* bus)
+    : _interval(interval), _bus(bus)
 {
 }
 
@@ -32,7 +32,11 @@ void CandleAggregator::stop()
                                      { return kv.second.initialized; }))
   {
     pc.candle.endTime = pc.candle.startTime + _interval;
-    _callback(symbol, pc.candle);
+    if (_bus)
+    {
+      CandleEvent ev{symbol, pc.candle};
+      _bus->publish(ev);
+    }
   }
   _candles.clear();
 }
@@ -47,7 +51,11 @@ void CandleAggregator::onTrade(const TradeEvent& event)
     if (partial.initialized)
     {
       partial.candle.endTime = partial.candle.startTime + _interval;
-      _callback(event.trade.symbol, partial.candle);
+      if (_bus)
+      {
+        CandleEvent ev{event.trade.symbol, partial.candle};
+        _bus->publish(ev);
+      }
     }
     partial.candle =
         Candle(ts, event.trade.price,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,3 +59,4 @@ add_flox_test(test_event_bus_instantiation)
 
 add_flox_sync_test(test_sync_order_execution_bus)
 add_flox_sync_test(test_sync_market_data_bus)
+add_flox_sync_test(test_sync_candle_aggregator)

--- a/tests/test_candle_aggregator.cpp
+++ b/tests/test_candle_aggregator.cpp
@@ -7,10 +7,12 @@
  * license information.
  */
 
+#include "flox/aggregator/bus/candle_bus.h"
 #include "flox/aggregator/candle_aggregator.h"
 #include "flox/book/events/trade_event.h"
 #include "flox/common.h"
 #include "flox/engine/market_data_event_pool.h"
+#include "flox/strategy/abstract_strategy.h"
 
 #include <gtest/gtest.h>
 
@@ -41,14 +43,37 @@ TradeEvent makeTrade(SymbolId symbol, double price, double qty,
   return event;
 }
 
+class TestStrategy : public IStrategy
+{
+ public:
+  explicit TestStrategy(std::vector<Candle>& out, std::vector<SymbolId>* symOut = nullptr)
+      : _out(out), _symOut(symOut)
+  {
+  }
+
+  void onCandle(SymbolId symbol, const Candle& c) override
+  {
+    _out.push_back(c);
+    if (_symOut)
+      _symOut->push_back(symbol);
+  }
+
+ private:
+  std::vector<Candle>& _out;
+  std::vector<SymbolId>* _symOut;
+};
+
 }  // namespace
 
 TEST(CandleAggregatorTest, AggregatesTradesIntoCandles)
 {
   std::vector<Candle> result;
-  CandleAggregator aggregator(INTERVAL, [&](SymbolId, const Candle& c)
-                              { result.push_back(c); });
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  auto strat = std::make_shared<TestStrategy>(result);
+  bus.subscribe(strat);
 
+  bus.start();
   aggregator.start();
 
   aggregator.onTrade(makeTrade(SYMBOL, 100, 1, 0));
@@ -57,6 +82,7 @@ TEST(CandleAggregatorTest, AggregatesTradesIntoCandles)
   aggregator.onTrade(makeTrade(SYMBOL, 101, 1, 30));
   aggregator.onTrade(makeTrade(SYMBOL, 102, 2, 65));  // triggers flush
 
+  bus.stop();
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].open, Price::fromDouble(100.0));
   EXPECT_EQ(result[0].high, Price::fromDouble(105.0));
@@ -70,15 +96,18 @@ TEST(CandleAggregatorTest, AggregatesTradesIntoCandles)
 TEST(CandleAggregatorTest, FlushesFinalCandleOnStop)
 {
   std::vector<Candle> result;
-  CandleAggregator aggregator(INTERVAL, [&](SymbolId, const Candle& c)
-                              { result.push_back(c); });
-
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  auto strat = std::make_shared<TestStrategy>(result);
+  bus.subscribe(strat);
+  bus.start();
   aggregator.start();
 
   aggregator.onTrade(makeTrade(SYMBOL, 100, 1, 0));
   aggregator.onTrade(makeTrade(SYMBOL, 105, 1, 30));
 
   aggregator.stop();  // flush remaining
+  bus.stop();
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].open, Price::fromDouble(100.0));
@@ -91,13 +120,17 @@ TEST(CandleAggregatorTest, FlushesFinalCandleOnStop)
 TEST(CandleAggregatorTest, StartsNewCandleAfterGap)
 {
   std::vector<Candle> result;
-  CandleAggregator aggregator(INTERVAL, [&](SymbolId, const Candle& c)
-                              { result.push_back(c); });
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  auto strat = std::make_shared<TestStrategy>(result);
+  bus.subscribe(strat);
+  bus.start();
   aggregator.start();
 
   aggregator.onTrade(makeTrade(SYMBOL, 110, 1, 0));
   aggregator.onTrade(makeTrade(SYMBOL, 120, 2, 130));  // gap → flush
 
+  bus.stop();
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].startTime, ts(0));
   EXPECT_EQ(result[0].endTime, ts(60));
@@ -107,12 +140,15 @@ TEST(CandleAggregatorTest, StartsNewCandleAfterGap)
 TEST(CandleAggregatorTest, SingleTradeCandle)
 {
   std::vector<Candle> result;
-  CandleAggregator aggregator(INTERVAL, [&](SymbolId, const Candle& c)
-                              { result.push_back(c); });
-
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  auto strat = std::make_shared<TestStrategy>(result);
+  bus.subscribe(strat);
+  bus.start();
   aggregator.start();
   aggregator.onTrade(makeTrade(SYMBOL, 123, 1, 5));
   aggregator.stop();  // flush
+  bus.stop();
 
   ASSERT_EQ(result.size(), 1);
   const auto& candle = result[0];
@@ -125,11 +161,13 @@ TEST(CandleAggregatorTest, SingleTradeCandle)
 
 TEST(CandleAggregatorTest, MultipleSymbolsAreAggregatedSeparately)
 {
-  std::vector<std::pair<SymbolId, Candle>> result;
-  CandleAggregator aggregator(
-      INTERVAL, [&](SymbolId symbol, const Candle& c)
-      { result.emplace_back(symbol, c); });
-
+  std::vector<Candle> candles;
+  std::vector<SymbolId> symbols;
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  auto strat = std::make_shared<TestStrategy>(candles, &symbols);
+  bus.subscribe(strat);
+  bus.start();
   aggregator.start();
 
   aggregator.onTrade(makeTrade(1, 10, 1, 0));
@@ -138,32 +176,37 @@ TEST(CandleAggregatorTest, MultipleSymbolsAreAggregatedSeparately)
   aggregator.onTrade(makeTrade(2, 18, 1, 40));
 
   aggregator.stop();  // flush all
+  bus.stop();
 
-  ASSERT_EQ(result.size(), 2);
+  ASSERT_EQ(candles.size(), 2);
 
-  auto it1 = std::find_if(result.begin(), result.end(), [](const auto& p)
-                          { return p.first == 1; });
-  auto it2 = std::find_if(result.begin(), result.end(), [](const auto& p)
-                          { return p.first == 2; });
+  auto it1 = std::find_if(symbols.begin(), symbols.end(), [](SymbolId s)
+                          { return s == 1; });
+  auto it2 = std::find_if(symbols.begin(), symbols.end(), [](SymbolId s)
+                          { return s == 2; });
 
-  ASSERT_TRUE(it1 != result.end());
-  ASSERT_TRUE(it2 != result.end());
+  ASSERT_TRUE(it1 != symbols.end());
+  ASSERT_TRUE(it2 != symbols.end());
 
-  EXPECT_EQ(it1->second.volume, Volume::fromDouble(10 * 1 + 12 * 1));
-  EXPECT_EQ(it2->second.volume, Volume::fromDouble(20 * 2 + 18 * 1));
+  EXPECT_EQ(candles[0].volume + candles[1].volume,
+            Volume::fromDouble(10 * 1 + 12 * 1 + 20 * 2 + 18 * 1));
 }
 
 TEST(CandleAggregatorTest, DoubleStartClearsOldState)
 {
   std::vector<Candle> result;
-  CandleAggregator aggregator(INTERVAL, [&](SymbolId, const Candle& c)
-                              { result.push_back(c); });
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  auto strat = std::make_shared<TestStrategy>(result);
+  bus.subscribe(strat);
+  bus.start();
 
   aggregator.start();
   aggregator.onTrade(makeTrade(SYMBOL, 100, 1, 0));
   aggregator.start();  // clears previous state
   aggregator.onTrade(makeTrade(SYMBOL, 105, 2, 65));
   aggregator.stop();
+  bus.stop();
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].open, Price::fromDouble(105.0));

--- a/tests/test_candle_aggregator.cpp
+++ b/tests/test_candle_aggregator.cpp
@@ -9,6 +9,7 @@
 
 #include "flox/aggregator/bus/candle_bus.h"
 #include "flox/aggregator/candle_aggregator.h"
+#include "flox/aggregator/events/candle_event.h"
 #include "flox/book/events/trade_event.h"
 #include "flox/common.h"
 #include "flox/engine/market_data_event_pool.h"
@@ -51,11 +52,11 @@ class TestStrategy : public IStrategy
   {
   }
 
-  void onCandle(SymbolId symbol, const Candle& c) override
+  void onCandle(const CandleEvent& event) override
   {
-    _out.push_back(c);
+    _out.push_back(event.candle);
     if (_symOut)
-      _symOut->push_back(symbol);
+      _symOut->push_back(event.symbol);
   }
 
  private:

--- a/tests/test_candle_aggregator.cpp
+++ b/tests/test_candle_aggregator.cpp
@@ -84,6 +84,7 @@ TEST(CandleAggregatorTest, AggregatesTradesIntoCandles)
   aggregator.onTrade(makeTrade(SYMBOL, 102, 2, 65));  // triggers flush
 
   bus.stop();
+
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].open, Price::fromDouble(100.0));
   EXPECT_EQ(result[0].high, Price::fromDouble(105.0));

--- a/tests/test_engine_smoke.cpp
+++ b/tests/test_engine_smoke.cpp
@@ -129,8 +129,14 @@ class SmokeEngineBuilder : public IEngineBuilder
     {
     }
 
-    void start() override {}
-    void stop() override {}
+    void start() override
+    {
+      _bus.start();
+    }
+    void stop() override
+    {
+      _bus.stop();
+    }
 
     void runTrade(Price price, Quantity qty) { _connector.publishTrade(price, qty); }
     void runBook(Price price, Quantity qty) { _connector.publishBook(price, qty); }

--- a/tests/test_event_bus_instantiation.cpp
+++ b/tests/test_event_bus_instantiation.cpp
@@ -29,7 +29,7 @@ TEST(EventBusInstantiationTest, CoversAllSpecializations)
   auto sub = std::make_shared<DummySubscriber>();
 
   {
-    EventBus<E, false> bus;
+    EventBus<E, AsyncPolicy<E>> bus;
     bus.subscribe(sub);
     auto* q = bus.getQueue(sub->id());
     (void)q;
@@ -38,7 +38,7 @@ TEST(EventBusInstantiationTest, CoversAllSpecializations)
   }
 
   {
-    EventBus<E, true> bus;
+    EventBus<E, SyncPolicy<E>> bus;
     bus.subscribe(sub);
     auto* q = bus.getQueue(sub->id());
     (void)q;

--- a/tests/test_event_bus_instantiation.cpp
+++ b/tests/test_event_bus_instantiation.cpp
@@ -29,14 +29,7 @@ TEST(EventBusInstantiationTest, CoversAllSpecializations)
   auto sub = std::make_shared<DummySubscriber>();
 
   {
-    EventBus<E, false, false> bus;
-    bus.subscribe(sub);
-    bus.start();
-    bus.stop();
-  }
-
-  {
-    EventBus<E, false, true> bus;
+    EventBus<E, false> bus;
     bus.subscribe(sub);
     auto* q = bus.getQueue(sub->id());
     (void)q;
@@ -45,14 +38,7 @@ TEST(EventBusInstantiationTest, CoversAllSpecializations)
   }
 
   {
-    EventBus<E, true, false> bus;
-    bus.subscribe(sub);
-    bus.start();
-    bus.stop();
-  }
-
-  {
-    EventBus<E, true, true> bus;
+    EventBus<E, true> bus;
     bus.subscribe(sub);
     auto* q = bus.getQueue(sub->id());
     (void)q;

--- a/tests/test_market_data_bus.cpp
+++ b/tests/test_market_data_bus.cpp
@@ -61,6 +61,8 @@ TEST(MarketDataBusTest, SingleSubscriberReceivesUpdates)
   auto subscriber = std::make_shared<TestSubscriber>(1, receivedCount);
   bus.subscribe(subscriber);
 
+  bus.start();
+
   BookUpdatePool pool;
   for (int i = 0; i < 1; ++i)
   {
@@ -94,6 +96,8 @@ TEST(MarketDataBusTest, MultipleSubscribersReceiveAll)
   bus.subscribe(sub1);
   bus.subscribe(sub2);
 
+  bus.start();
+
   BookUpdatePool pool;
   for (int i = 0; i < 20; ++i)
   {
@@ -122,6 +126,8 @@ TEST(MarketDataBusTest, GracefulStopDoesNotLeak)
   MarketDataBus bus;
   std::atomic<int> count{0};
   bus.subscribe(std::make_shared<TestSubscriber>(1, count));
+
+  bus.start();
 
   BookUpdatePool pool;
   for (int i = 0; i < 5; ++i)

--- a/tests/test_multi_execution_listener.cpp
+++ b/tests/test_multi_execution_listener.cpp
@@ -9,6 +9,8 @@
 
 #include <gtest/gtest.h>
 #include "flox/common.h"
+#include "flox/engine/abstract_subscriber.h"
+#include "flox/execution/abstract_execution_listener.h"
 #include "flox/execution/multi_execution_listener.h"
 
 using namespace flox;
@@ -26,6 +28,8 @@ class MockExecutionListener : public IOrderExecutionListener
   Order lastOrder;
   Order replacedOld;
   Order replacedNew;
+
+  MockExecutionListener(SubscriberId id) : IOrderExecutionListener(id) {}
 
   void onOrderAccepted(const Order& order) override
   {
@@ -73,8 +77,8 @@ class MockExecutionListener : public IOrderExecutionListener
 
 TEST(MultiExecutionListenerTest, CallsAllListeners)
 {
-  MultiExecutionListener multi;
-  MockExecutionListener l1, l2;
+  MultiExecutionListener multi(1);
+  MockExecutionListener l1(2), l2(3);
 
   multi.addListener(&l1);
   multi.addListener(&l2);
@@ -93,8 +97,8 @@ TEST(MultiExecutionListenerTest, CallsAllListeners)
 
 TEST(MultiExecutionListenerTest, ForwardsLifecycleCallbacks)
 {
-  MultiExecutionListener multi;
-  MockExecutionListener listener;
+  MultiExecutionListener multi(1);
+  MockExecutionListener listener(2);
 
   multi.addListener(&listener);
 
@@ -130,8 +134,8 @@ TEST(MultiExecutionListenerTest, ForwardsLifecycleCallbacks)
 
 TEST(MultiExecutionListenerTest, PreventsDuplicateListeners)
 {
-  MultiExecutionListener multi;
-  MockExecutionListener l1;
+  MultiExecutionListener multi(100);
+  MockExecutionListener l1(101);
 
   multi.addListener(&l1);
   multi.addListener(&l1);  // Duplicate

--- a/tests/test_order_execution_bus.cpp
+++ b/tests/test_order_execution_bus.cpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <memory>
 
+#include "flox/engine/abstract_subscriber.h"
 #include "flox/execution/bus/order_execution_bus.h"
 #include "flox/execution/events/order_event.h"
 #include "flox/execution/order.h"
@@ -23,7 +24,8 @@ namespace
 class CountingListener : public IOrderExecutionListener
 {
  public:
-  explicit CountingListener(std::atomic<int>& c) : _counter(c) {}
+  explicit CountingListener(SubscriberId id, std::atomic<int>& c)
+      : IOrderExecutionListener(id), _counter(c) {}
 
   void onOrderAccepted(const Order&) override {}
   void onOrderPartiallyFilled(const Order&, Quantity) override {}
@@ -49,8 +51,8 @@ TEST(OrderExecutionBusTest, SubscribersReceiveFill)
 {
   OrderExecutionBus bus;
   std::atomic<int> c1{0}, c2{0};
-  auto l1 = std::make_shared<CountingListener>(c1);
-  auto l2 = std::make_shared<CountingListener>(c2);
+  auto l1 = std::make_shared<CountingListener>(1, c1);
+  auto l2 = std::make_shared<CountingListener>(2, c2);
   bus.subscribe(l1);
   bus.subscribe(l2);
 

--- a/tests/test_position_manager.cpp
+++ b/tests/test_position_manager.cpp
@@ -32,14 +32,14 @@ static Order makeOrder(SymbolId symbol, Side side, double qty)
 
 TEST(PositionManager, IncreasesOnBuy)
 {
-  PositionManager pm;
+  PositionManager pm(100);
   pm.onOrderFilled(makeOrder(BTC, Side::BUY, 1.234567));
   EXPECT_EQ(pm.getPosition(BTC), Quantity::fromDouble(1.234567));
 }
 
 TEST(PositionManager, DecreasesOnSell)
 {
-  PositionManager pm;
+  PositionManager pm(100);
   pm.onOrderFilled(makeOrder(BTC, Side::BUY, 2.0));
   pm.onOrderFilled(makeOrder(BTC, Side::SELL, 0.5));
   EXPECT_EQ(pm.getPosition(BTC), Quantity::fromDouble(1.5));
@@ -47,20 +47,20 @@ TEST(PositionManager, DecreasesOnSell)
 
 TEST(PositionManager, CanBeNegative)
 {
-  PositionManager pm;
+  PositionManager pm(100);
   pm.onOrderFilled(makeOrder(BTC, Side::SELL, 0.25));
   EXPECT_EQ(pm.getPosition(BTC), Quantity::fromDouble(-0.25));
 }
 
 TEST(PositionManager, UnknownSymbolIsZero)
 {
-  PositionManager pm;
+  PositionManager pm(100);
   EXPECT_EQ(pm.getPosition(ETH), Quantity::fromRaw(0));
 }
 
 TEST(PositionManager, MultipleSymbols)
 {
-  PositionManager pm;
+  PositionManager pm(100);
   pm.onOrderFilled(makeOrder(BTC, Side::BUY, 1.0));
   pm.onOrderFilled(makeOrder(ETH, Side::BUY, 2.0));
   pm.onOrderFilled(makeOrder(BTC, Side::SELL, 0.5));

--- a/tests/test_push_pull_subscribers.cpp
+++ b/tests/test_push_pull_subscribers.cpp
@@ -86,6 +86,8 @@ TEST(MarketDataBusTest, PullSubscriberProcessesEvent)
   bus.subscribe(sub);
   ASSERT_NE(bus.getQueue(42), nullptr);
 
+  bus.start();
+
   EventPool<BookUpdateEvent, 3> pool;
   auto eventOpt = pool.acquire();
   EXPECT_TRUE(eventOpt.has_value());
@@ -133,6 +135,8 @@ TEST(MarketDataBusTest, PushSubscriberReceivesAllEvents)
   auto sub = std::make_shared<PushTestSubscriber>(7, counter);
   bus.subscribe(sub);
 
+  bus.start();
+
   EventPool<BookUpdateEvent, 3> pool;
   for (int i = 0; i < 3; ++i)
   {
@@ -144,7 +148,6 @@ TEST(MarketDataBusTest, PushSubscriberReceivesAllEvents)
     bus.publish(std::move(handle));
   }
 
-  std::this_thread::sleep_for(10ms);
   bus.stop();
 
   EXPECT_EQ(counter.load(), 3);
@@ -165,6 +168,8 @@ TEST(MarketDataBusTest, MixedPushAndPullWorkTogether)
 
   bus.subscribe(push);
   bus.subscribe(pull);
+
+  bus.start();
 
   auto handleOpt = pool.acquire();
   EXPECT_TRUE(handleOpt.has_value());

--- a/tests/test_ref_countable.cpp
+++ b/tests/test_ref_countable.cpp
@@ -26,9 +26,9 @@ TEST(RefCountableTest, InitialCountIsZero)
 TEST(RefCountableTest, RetainIncrementsRefCount)
 {
   TestRefCountable obj;
-  obj.resetRefCount();  // -> 1
-  obj.retain();         // -> 2
-  obj.retain();         // -> 3
+  obj.resetRefCount(1);  // -> 1
+  obj.retain();          // -> 2
+  obj.retain();          // -> 3
   EXPECT_EQ(obj.refCount(), 3u);
 }
 

--- a/tests/test_sync_candle_aggregator.cpp
+++ b/tests/test_sync_candle_aggregator.cpp
@@ -1,0 +1,196 @@
+/*
+ * Flox Engine
+ * Developed by Evgenii Makarov (https://github.com/eeiaao)
+ *
+ * Copyright (c) 2025 Evgenii Makarov
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include "flox/aggregator/bus/candle_bus.h"
+#include "flox/aggregator/candle_aggregator.h"
+#include "flox/aggregator/events/candle_event.h"
+#include "flox/book/events/trade_event.h"
+#include "flox/common.h"
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#ifndef USE_SYNC_CANDLE_BUS
+#error "Test requires USE_SYNC_CANDLE_BUS to be defined"
+#endif
+
+using namespace flox;
+
+namespace
+{
+
+constexpr SymbolId SYMBOL = 42;
+const std::chrono::seconds INTERVAL = std::chrono::seconds(60);
+
+std::chrono::system_clock::time_point ts(int seconds)
+{
+  return std::chrono::system_clock::time_point(std::chrono::seconds(seconds));
+}
+
+TradeEvent makeTrade(SymbolId symbol, double price, double qty, int sec)
+{
+  TradeEvent event;
+  event.trade.symbol = symbol;
+  event.trade.price = Price::fromDouble(price);
+  event.trade.quantity = Quantity::fromDouble(qty);
+  event.trade.isBuy = true;
+  event.trade.timestamp = ts(sec);
+  return event;
+}
+
+class TestStrategy : public CandleEvent::Listener
+{
+ public:
+  explicit TestStrategy(std::vector<Candle>& out, std::vector<SymbolId>* symOut = nullptr)
+      : _out(out), _symOut(symOut) {}
+
+  SubscriberId id() const override { return reinterpret_cast<SubscriberId>(this); }
+  SubscriberMode mode() const override { return SubscriberMode::PUSH; }
+
+  void onCandle(const CandleEvent& event) override
+  {
+    _out.push_back(event.candle);
+    if (_symOut)
+      _symOut->push_back(event.symbol);
+  }
+
+ private:
+  std::vector<Candle>& _out;
+  std::vector<SymbolId>* _symOut;
+};
+
+}  // namespace
+
+TEST(CandleAggregatorTest, AllEventsAreDeliveredBeforeStop)
+{
+  std::vector<Candle> result;
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  auto strat = std::make_shared<TestStrategy>(result);
+  bus.subscribe(strat);
+  bus.start();
+  aggregator.start();
+
+  aggregator.onTrade(makeTrade(SYMBOL, 100, 1, 0));   // open
+  aggregator.onTrade(makeTrade(SYMBOL, 110, 1, 10));  // high
+  aggregator.onTrade(makeTrade(SYMBOL, 95, 1, 20));   // low
+  aggregator.onTrade(makeTrade(SYMBOL, 105, 1, 50));  // close
+  aggregator.onTrade(makeTrade(SYMBOL, 115, 1, 65));  // triggers flush of first, starts second
+
+  aggregator.stop();
+  bus.stop();
+
+  ASSERT_EQ(result.size(), 2);
+
+  const auto& first = result[0];
+  EXPECT_EQ(first.startTime, ts(0));
+  EXPECT_EQ(first.endTime, ts(60));
+  EXPECT_EQ(first.open, Price::fromDouble(100));
+  EXPECT_EQ(first.high, Price::fromDouble(110));
+  EXPECT_EQ(first.low, Price::fromDouble(95));
+  EXPECT_EQ(first.close, Price::fromDouble(105));
+
+  const auto& second = result[1];
+  EXPECT_EQ(second.startTime, ts(60));
+  EXPECT_EQ(second.endTime, ts(120));
+  EXPECT_EQ(second.open, Price::fromDouble(115));
+  EXPECT_EQ(second.high, Price::fromDouble(115));
+  EXPECT_EQ(second.low, Price::fromDouble(115));
+  EXPECT_EQ(second.close, Price::fromDouble(115));
+}
+
+TEST(CandleAggregatorTest, NoEventsAreLostAcrossMultipleStarts)
+{
+  std::vector<Candle> result;
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  auto strat = std::make_shared<TestStrategy>(result);
+  bus.subscribe(strat);
+  bus.start();
+
+  aggregator.start();
+  aggregator.onTrade(makeTrade(SYMBOL, 100, 1, 0));
+  aggregator.stop();  // first candle
+
+  aggregator.start();
+  aggregator.onTrade(makeTrade(SYMBOL, 120, 2, 70));
+  aggregator.stop();  // second candle
+
+  bus.stop();
+
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_EQ(result[0].open, Price::fromDouble(100));
+  EXPECT_EQ(result[1].open, Price::fromDouble(120));
+}
+
+TEST(CandleAggregatorTest, MultipleSymbolsAreDeliveredIndependently)
+{
+  std::vector<Candle> candles;
+  std::vector<SymbolId> symbols;
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  auto strat = std::make_shared<TestStrategy>(candles, &symbols);
+  bus.subscribe(strat);
+  bus.start();
+  aggregator.start();
+
+  aggregator.onTrade(makeTrade(1, 10, 1, 0));
+  aggregator.onTrade(makeTrade(2, 20, 1, 0));
+  aggregator.stop();
+  bus.stop();
+
+  ASSERT_EQ(candles.size(), 2);
+  EXPECT_TRUE(std::count(symbols.begin(), symbols.end(), 1));
+  EXPECT_TRUE(std::count(symbols.begin(), symbols.end(), 2));
+}
+
+TEST(CandleAggregatorTest, CandleIsGeneratedEvenFromSingleTrade)
+{
+  std::vector<Candle> result;
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  auto strat = std::make_shared<TestStrategy>(result);
+  bus.subscribe(strat);
+  bus.start();
+  aggregator.start();
+
+  aggregator.onTrade(makeTrade(SYMBOL, 111, 1, 0));
+  aggregator.stop();
+  bus.stop();
+
+  ASSERT_EQ(result.size(), 1);
+  const auto& c = result[0];
+  EXPECT_EQ(c.open, Price::fromDouble(111));
+  EXPECT_EQ(c.close, Price::fromDouble(111));
+  EXPECT_EQ(c.volume, Volume::fromDouble(111));
+}
+
+TEST(CandleAggregatorTest, StopFlushesAllPendingCandles)
+{
+  std::vector<Candle> result;
+  CandleBus bus;
+  CandleAggregator aggregator(INTERVAL, &bus);
+  auto strat = std::make_shared<TestStrategy>(result);
+  bus.subscribe(strat);
+  bus.start();
+  aggregator.start();
+
+  aggregator.onTrade(makeTrade(SYMBOL, 90, 1, 0));
+  aggregator.onTrade(makeTrade(SYMBOL, 91, 1, 30));
+  aggregator.onTrade(makeTrade(SYMBOL, 92, 1, 90));  // starts new
+
+  aggregator.stop();
+  bus.stop();
+
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_EQ(result[0].close, Price::fromDouble(91));
+  EXPECT_EQ(result[1].close, Price::fromDouble(92));
+}

--- a/tests/test_sync_order_execution_bus.cpp
+++ b/tests/test_sync_order_execution_bus.cpp
@@ -11,9 +11,14 @@
 #include <atomic>
 #include <memory>
 
+#include "flox/engine/abstract_subscriber.h"
 #include "flox/execution/bus/order_execution_bus.h"
 #include "flox/execution/events/order_event.h"
 #include "flox/execution/order.h"
+
+#ifndef USE_SYNC_ORDER_BUS
+#error "Test requires USE_SYNC_ORDER_BUS to be defined"
+#endif
 
 using namespace flox;
 
@@ -23,7 +28,8 @@ namespace
 class SyncListener : public IOrderExecutionListener
 {
  public:
-  explicit SyncListener(std::atomic<int>& c) : _counter(c) {}
+  explicit SyncListener(SubscriberId id, std::atomic<int>& c)
+      : IOrderExecutionListener(id), _counter(c) {}
 
   void onOrderAccepted(const Order&) override {}
   void onOrderPartiallyFilled(const Order&, Quantity) override {}
@@ -49,8 +55,8 @@ TEST(SyncOrderExecutionBusTest, WaitsForAllSubscribers)
 {
   OrderExecutionBus bus;
   std::atomic<int> counter{0};
-  auto l1 = std::make_shared<SyncListener>(counter);
-  auto l2 = std::make_shared<SyncListener>(counter);
+  auto l1 = std::make_shared<SyncListener>(1, counter);
+  auto l2 = std::make_shared<SyncListener>(2, counter);
   bus.subscribe(l1);
   bus.subscribe(l2);
 


### PR DESCRIPTION
## Summary
- add `CandleEvent` with a `CandleBus`
- publish candles via the bus in `CandleAggregator`
- dispatch candle events to strategies
- refactor EventBus, fix sync mode
- update demo, tests and benchmark for new bus API