### PR TITLE
EventBus: fix race conditions, add backpressure API, improve thread safety

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -10,6 +10,7 @@ endfunction()
 add_flox_benchmark(nlevel_order_book_benchmark)
 add_flox_benchmark(candle_aggregator_benchmark)
 add_flox_benchmark(binary_log_benchmark)
+add_flox_benchmark(event_bus_benchmark)
 
 if(FLOX_ENABLE_CPU_AFFINITY)
     add_flox_benchmark(cpu_affinity_benchmark)

--- a/benchmarks/event_bus_benchmark.cpp
+++ b/benchmarks/event_bus_benchmark.cpp
@@ -1,0 +1,327 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include <benchmark/benchmark.h>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "flox/util/eventing/event_bus.h"
+
+namespace flox
+{
+
+struct BenchEvent
+{
+  using Listener = struct IBenchListener
+  {
+    virtual ~IBenchListener() = default;
+    virtual void onEvent(const BenchEvent& e) = 0;
+  };
+
+  int64_t data[8]{};  // 64 bytes payload
+  uint64_t tickSequence{0};
+};
+
+template <>
+struct EventDispatcher<BenchEvent>
+{
+  static void dispatch(const BenchEvent& event, BenchEvent::Listener& listener)
+  {
+    listener.onEvent(event);
+  }
+};
+
+}  // namespace flox
+
+namespace
+{
+
+using namespace flox;
+
+class NoOpListener : public BenchEvent::Listener
+{
+ public:
+  void onEvent(const BenchEvent&) override
+  {
+    ++count;
+  }
+  std::atomic<int64_t> count{0};
+};
+
+}  // namespace
+
+// =============================================================================
+// Single-threaded publish latency
+// =============================================================================
+
+static void BM_EventBus_PublishLatency(benchmark::State& state)
+{
+  flox::EventBus<flox::BenchEvent, 4096, 4> bus;
+  NoOpListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+
+  flox::BenchEvent event{};
+
+  for (auto _ : state)
+  {
+    bus.publish(event);
+  }
+
+  bus.flush();
+  bus.stop();
+
+  state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_EventBus_PublishLatency)->Iterations(1'000'000);
+
+// =============================================================================
+// Publish throughput with single consumer
+// =============================================================================
+
+static void BM_EventBus_SingleConsumerThroughput(benchmark::State& state)
+{
+  flox::EventBus<flox::BenchEvent, 4096, 4> bus;
+  NoOpListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+
+  flox::BenchEvent event{};
+  int64_t totalPublished = 0;
+
+  for (auto _ : state)
+  {
+    for (int i = 0; i < 1000; ++i)
+    {
+      bus.publish(event);
+      ++totalPublished;
+    }
+  }
+
+  bus.flush();
+  bus.stop();
+
+  state.SetItemsProcessed(totalPublished);
+  state.SetBytesProcessed(totalPublished * sizeof(flox::BenchEvent));
+}
+BENCHMARK(BM_EventBus_SingleConsumerThroughput);
+
+// =============================================================================
+// Publish throughput with multiple consumers
+// =============================================================================
+
+static void BM_EventBus_MultiConsumerThroughput(benchmark::State& state)
+{
+  const int numConsumers = state.range(0);
+
+  flox::EventBus<flox::BenchEvent, 4096, 8> bus;
+  std::vector<std::unique_ptr<NoOpListener>> listeners;
+
+  for (int i = 0; i < numConsumers; ++i)
+  {
+    listeners.push_back(std::make_unique<NoOpListener>());
+    bus.subscribe(listeners.back().get());
+  }
+
+  bus.start();
+
+  flox::BenchEvent event{};
+  int64_t totalPublished = 0;
+
+  for (auto _ : state)
+  {
+    for (int i = 0; i < 1000; ++i)
+    {
+      bus.publish(event);
+      ++totalPublished;
+    }
+  }
+
+  bus.flush();
+  bus.stop();
+
+  state.SetItemsProcessed(totalPublished);
+}
+BENCHMARK(BM_EventBus_MultiConsumerThroughput)->Arg(1)->Arg(2)->Arg(4)->Arg(8);
+
+// =============================================================================
+// Concurrent publishers
+// =============================================================================
+
+static void BM_EventBus_ConcurrentPublishers(benchmark::State& state)
+{
+  const int numPublishers = state.range(0);
+
+  flox::EventBus<flox::BenchEvent, 8192, 4> bus;
+  NoOpListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+
+  std::atomic<bool> running{true};
+  std::atomic<int64_t> totalPublished{0};
+
+  std::vector<std::thread> publishers;
+  for (int i = 0; i < numPublishers; ++i)
+  {
+    publishers.emplace_back([&bus, &running, &totalPublished]
+                            {
+      flox::BenchEvent event{};
+      while (running.load(std::memory_order_relaxed))
+      {
+        bus.publish(event);
+        totalPublished.fetch_add(1, std::memory_order_relaxed);
+      } });
+  }
+
+  for (auto _ : state)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds{10});
+  }
+
+  running.store(false, std::memory_order_relaxed);
+
+  for (auto& t : publishers)
+  {
+    t.join();
+  }
+
+  bus.flush();
+  bus.stop();
+
+  state.SetItemsProcessed(totalPublished.load());
+}
+BENCHMARK(BM_EventBus_ConcurrentPublishers)->Arg(1)->Arg(2)->Arg(4);
+
+// =============================================================================
+// tryPublish latency (no backpressure)
+// =============================================================================
+
+static void BM_EventBus_TryPublishLatency(benchmark::State& state)
+{
+  flox::EventBus<flox::BenchEvent, 4096, 4> bus;
+  NoOpListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+
+  flox::BenchEvent event{};
+
+  for (auto _ : state)
+  {
+    auto [result, seq] = bus.tryPublish(event, std::chrono::microseconds{1000});
+    benchmark::DoNotOptimize(result);
+    benchmark::DoNotOptimize(seq);
+  }
+
+  bus.flush();
+  bus.stop();
+
+  state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_EventBus_TryPublishLatency)->Iterations(1'000'000);
+
+// =============================================================================
+// Buffer wrap-around performance
+// =============================================================================
+
+static void BM_EventBus_WrapAround(benchmark::State& state)
+{
+  const size_t bufferSize = state.range(0);
+
+  // Use different buffer sizes
+  flox::EventBus<flox::BenchEvent, 256, 4> bus256;
+  flox::EventBus<flox::BenchEvent, 1024, 4> bus1024;
+  flox::EventBus<flox::BenchEvent, 4096, 4> bus4096;
+
+  NoOpListener listener;
+
+  if (bufferSize == 256)
+  {
+    bus256.subscribe(&listener);
+    bus256.start();
+
+    flox::BenchEvent event{};
+    for (auto _ : state)
+    {
+      for (int i = 0; i < 1000; ++i)
+      {
+        bus256.publish(event);
+      }
+    }
+    bus256.flush();
+    bus256.stop();
+  }
+  else if (bufferSize == 1024)
+  {
+    bus1024.subscribe(&listener);
+    bus1024.start();
+
+    flox::BenchEvent event{};
+    for (auto _ : state)
+    {
+      for (int i = 0; i < 1000; ++i)
+      {
+        bus1024.publish(event);
+      }
+    }
+    bus1024.flush();
+    bus1024.stop();
+  }
+  else
+  {
+    bus4096.subscribe(&listener);
+    bus4096.start();
+
+    flox::BenchEvent event{};
+    for (auto _ : state)
+    {
+      for (int i = 0; i < 1000; ++i)
+      {
+        bus4096.publish(event);
+      }
+    }
+    bus4096.flush();
+    bus4096.stop();
+  }
+
+  state.SetItemsProcessed(state.iterations() * 1000);
+}
+BENCHMARK(BM_EventBus_WrapAround)->Arg(256)->Arg(1024)->Arg(4096);
+
+// =============================================================================
+// End-to-end latency (publish -> consume)
+// =============================================================================
+
+static void BM_EventBus_EndToEndLatency(benchmark::State& state)
+{
+  flox::EventBus<flox::BenchEvent, 4096, 4> bus;
+  NoOpListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+
+  flox::BenchEvent event{};
+
+  for (auto _ : state)
+  {
+    auto seq = bus.publish(event);
+    bus.waitConsumed(seq);
+  }
+
+  bus.stop();
+
+  state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_EventBus_EndToEndLatency)->Iterations(100'000);
+
+BENCHMARK_MAIN();

--- a/docs/components/util/eventing/event_bus.md
+++ b/docs/components/util/eventing/event_bus.md
@@ -13,18 +13,42 @@ class EventBus : public ISubsystem;
 
 * Deliver high-frequency events (market data, orders, etc.) to multiple subscribers with minimal latency and zero allocations on the hot path.
 * Support CPU affinity and real-time thread priority for latency-critical components.
+* Provide backpressure handling via timeout-based publishing.
 
 ## Key Methods
 
 | Method                  | Description                                                     |
 | ----------------------- | --------------------------------------------------------------- |
-| `subscribe(listener)`   | Registers a consumer with optional `required` flag for gating.  |
-| `publish(event)`        | Publishes event to ring buffer, returns sequence number.        |
+| `subscribe(listener)`   | Registers a consumer. Returns `bool` (false if bus running or at capacity). |
+| `publish(event)`        | Publishes event to ring buffer, returns sequence number (-1 if stopped). |
+| `tryPublish(event, timeout)` | Publishes with timeout. Returns `{PublishResult, seq}`. |
 | `start()` / `stop()`    | Starts or stops all consumer threads.                           |
 | `waitConsumed(seq)`     | Blocks until all consumers have processed up to `seq`.          |
 | `flush()`               | Waits until all published events are consumed.                  |
 | `consumerCount()`       | Returns number of registered consumers.                         |
 | `enableDrainOnStop()`   | Ensures remaining events are dispatched before shutdown.        |
+
+## PublishResult
+
+```cpp
+enum class PublishResult
+{
+  SUCCESS,   // Event published successfully
+  TIMEOUT,   // Buffer full, timeout expired
+  STOPPED    // Bus not running
+};
+```
+
+## Backpressure Handling
+
+When the ring buffer is full (consumers too slow), `publish()` blocks until space is available. Use `tryPublish()` with a timeout to handle backpressure:
+
+```cpp
+auto [result, seq] = bus.tryPublish(event, std::chrono::microseconds{1000});
+if (result == Bus::PublishResult::TIMEOUT) {
+  // Handle backpressure: drop event, log warning, etc.
+}
+```
 
 ## CPU Affinity (when `FLOX_CPU_AFFINITY_ENABLED`)
 
@@ -55,6 +79,8 @@ struct AffinityConfig
 | `setupOptimalConfiguration()` | Auto-configure for component type.                    |
 | `verifyIsolatedCoreConfig()`  | Verify isolated core setup.                           |
 
+Consumer threads are distributed across available cores using round-robin assignment.
+
 ## Design Highlights
 
 * **Disruptor Pattern**: Single producer, multiple consumers with sequence-based coordination.
@@ -65,13 +91,16 @@ struct AffinityConfig
 * **Zero Allocations**: Events stored directly in pre-allocated ring buffer slots.
 * **Tick Sequencing**: `tickSequence` field is automatically set if present on event.
 * **In-Place Construction**: Events constructed via placement new, destructed on reclaim.
+* **Thread-Safe Subscribe**: `subscribe()` returns false if called after `start()`.
+* **Overflow Protection**: Sequence counter overflow is detected and handled.
 
 ## Internal Types
 
 | Name           | Description                                                |
 | -------------- | ---------------------------------------------------------- |
-| `ConsumerSlot` | Per-consumer state: listener, sequence, thread, required.  |
+| `ConsumerSlot` | Per-consumer state: listener, sequence, thread, required, coreIndex. |
 | `Listener`     | Inferred from `Event::Listener` via `ListenerType` trait.  |
+| `PublishResult`| Enum for publish outcome (SUCCESS, TIMEOUT, STOPPED).      |
 
 ## Template Parameters
 
@@ -87,14 +116,27 @@ struct AffinityConfig
 using BookBus = EventBus<pool::Handle<BookUpdateEvent>>;
 
 BookBus bus;
-bus.subscribe(&bookHandler);
+
+// subscribe() returns bool - check for success
+if (!bus.subscribe(&bookHandler)) {
+  // Handle error: null listener, bus running, or at capacity
+}
 
 #if FLOX_CPU_AFFINITY_ENABLED
 bus.setupOptimalConfiguration(BookBus::ComponentType::MARKET_DATA);
 #endif
 
 bus.start();
-bus.publish(std::move(bookUpdateHandle));
+
+// Standard publish (blocks on backpressure)
+auto seq = bus.publish(std::move(bookUpdateHandle));
+
+// Publish with timeout (non-blocking backpressure handling)
+auto [result, seq2] = bus.tryPublish(event, std::chrono::microseconds{500});
+if (result == BookBus::PublishResult::TIMEOUT) {
+  LOG_WARN("Backpressure detected, event dropped");
+}
+
 bus.flush();
 bus.stop();
 ```
@@ -103,5 +145,27 @@ bus.stop();
 
 * Capacity must be a power of 2 for efficient masking.
 * Non-required consumers (second arg to `subscribe`) don't block publisher.
+* `subscribe()` must be called before `start()` - returns false otherwise.
 * `enableDrainOnStop()` should be called before `start()` if drain behavior is needed.
 * CPU affinity features require `FLOX_CPU_AFFINITY_ENABLED` compile flag.
+* `publish()` returns -1 if the bus is not running.
+
+## Benchmarking
+
+Run `event_bus_benchmark` to measure performance on your hardware:
+
+```bash
+cmake -DFLOX_ENABLE_BENCHMARKS=ON ..
+make event_bus_benchmark
+./benchmarks/event_bus_benchmark
+```
+
+Example results on Intel i5-1135G7 @ 2.40GHz (4 cores / 8 threads):
+
+| Benchmark | Time | Throughput |
+|-----------|------|------------|
+| PublishLatency | 50 ns | 20 M/s |
+| SingleConsumerThroughput | 61 µs/1000 | 16 M/s |
+| MultiConsumer (4) | 195 µs/1000 | 5 M/s |
+| TryPublishLatency | 110 ns | 9 M/s |
+| EndToEndLatency | 200 ns | 5 M/s |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,9 @@ add_flox_test(test_sync_order_execution_bus)
 add_flox_test(test_sync_book_update_bus)
 add_flox_test(test_sync_candle_aggregator)
 
+# EventBus core tests
+add_flox_test(test_event_bus)
+
 # Replay tests
 add_flox_test(test_binary_log)
 add_flox_test(test_market_data_recorder)

--- a/tests/test_event_bus.cpp
+++ b/tests/test_event_bus.cpp
@@ -1,0 +1,438 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "flox/util/eventing/event_bus.h"
+
+namespace flox
+{
+
+struct TestEvent
+{
+  using Listener = struct ITestListener
+  {
+    virtual ~ITestListener() = default;
+    virtual void onEvent(const TestEvent& e) = 0;
+  };
+
+  int value{0};
+  uint64_t tickSequence{0};
+};
+
+template <>
+struct EventDispatcher<TestEvent>
+{
+  static void dispatch(const TestEvent& event, TestEvent::Listener& listener)
+  {
+    listener.onEvent(event);
+  }
+};
+
+}  // namespace flox
+
+namespace
+{
+
+using namespace flox;
+
+class CountingListener : public TestEvent::Listener
+{
+ public:
+  void onEvent(const TestEvent& e) override
+  {
+    ++count;
+    lastValue = e.value;
+    lastSeq = e.tickSequence;
+  }
+
+  std::atomic<int> count{0};
+  std::atomic<int> lastValue{0};
+  std::atomic<uint64_t> lastSeq{0};
+};
+
+class SlowListener : public TestEvent::Listener
+{
+ public:
+  explicit SlowListener(std::chrono::microseconds delay) : _delay(delay) {}
+
+  void onEvent(const TestEvent& e) override
+  {
+    std::this_thread::sleep_for(_delay);
+    ++count;
+    lastValue = e.value;
+  }
+
+  std::atomic<int> count{0};
+  std::atomic<int> lastValue{0};
+
+ private:
+  std::chrono::microseconds _delay;
+};
+
+using TestBus = EventBus<TestEvent, 64, 8>;
+using SmallBus = EventBus<TestEvent, 4, 2>;
+
+// =============================================================================
+// Subscribe tests
+// =============================================================================
+
+TEST(EventBusTest, SubscribeReturnsTrue)
+{
+  TestBus bus;
+  CountingListener listener;
+
+  EXPECT_TRUE(bus.subscribe(&listener));
+  EXPECT_EQ(bus.consumerCount(), 1);
+}
+
+TEST(EventBusTest, SubscribeNullReturnsFalse)
+{
+  TestBus bus;
+  EXPECT_FALSE(bus.subscribe(nullptr));
+  EXPECT_EQ(bus.consumerCount(), 0);
+}
+
+TEST(EventBusTest, SubscribeAfterStartReturnsFalse)
+{
+  TestBus bus;
+  CountingListener listener1;
+  CountingListener listener2;
+
+  EXPECT_TRUE(bus.subscribe(&listener1));
+  bus.start();
+
+  EXPECT_FALSE(bus.subscribe(&listener2));
+  EXPECT_EQ(bus.consumerCount(), 1);
+
+  bus.stop();
+}
+
+TEST(EventBusTest, SubscribeExceedsMaxReturnsFalse)
+{
+  SmallBus bus;  // MaxConsumers = 2
+  CountingListener l1, l2, l3;
+
+  EXPECT_TRUE(bus.subscribe(&l1));
+  EXPECT_TRUE(bus.subscribe(&l2));
+  EXPECT_FALSE(bus.subscribe(&l3));
+  EXPECT_EQ(bus.consumerCount(), 2);
+}
+
+// =============================================================================
+// Basic publish/consume tests
+// =============================================================================
+
+TEST(EventBusTest, SingleConsumerReceivesEvents)
+{
+  TestBus bus;
+  CountingListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+
+  for (int i = 0; i < 10; ++i)
+  {
+    TestEvent e{.value = i};
+    bus.publish(e);
+  }
+
+  bus.flush();
+  bus.stop();
+
+  EXPECT_EQ(listener.count.load(), 10);
+  EXPECT_EQ(listener.lastValue.load(), 9);
+}
+
+TEST(EventBusTest, MultipleConsumersReceiveAllEvents)
+{
+  TestBus bus;
+  CountingListener l1, l2, l3;
+
+  bus.subscribe(&l1);
+  bus.subscribe(&l2);
+  bus.subscribe(&l3);
+  bus.start();
+
+  constexpr int kEventCount = 50;
+  for (int i = 0; i < kEventCount; ++i)
+  {
+    bus.publish(TestEvent{.value = i});
+  }
+
+  bus.flush();
+  bus.stop();
+
+  EXPECT_EQ(l1.count.load(), kEventCount);
+  EXPECT_EQ(l2.count.load(), kEventCount);
+  EXPECT_EQ(l3.count.load(), kEventCount);
+}
+
+TEST(EventBusTest, TickSequenceIsSet)
+{
+  TestBus bus;
+  CountingListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+
+  bus.publish(TestEvent{.value = 42});
+  bus.flush();
+  bus.stop();
+
+  EXPECT_EQ(listener.lastSeq.load(), 0);  // First event has seq 0
+}
+
+TEST(EventBusTest, SequenceIncrementsCorrectly)
+{
+  TestBus bus;
+  CountingListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+
+  for (int i = 0; i < 5; ++i)
+  {
+    auto seq = bus.publish(TestEvent{.value = i});
+    EXPECT_EQ(seq, i);
+  }
+
+  bus.flush();
+  bus.stop();
+
+  EXPECT_EQ(listener.lastSeq.load(), 4);
+}
+
+// =============================================================================
+// tryPublish with timeout tests
+// =============================================================================
+
+TEST(EventBusTest, TryPublishSucceedsWithoutBackpressure)
+{
+  TestBus bus;
+  CountingListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+
+  auto [result, seq] = bus.tryPublish(TestEvent{.value = 123}, std::chrono::microseconds{1000});
+
+  EXPECT_EQ(result, TestBus::PublishResult::SUCCESS);
+  EXPECT_EQ(seq, 0);
+
+  bus.flush();
+  bus.stop();
+
+  EXPECT_EQ(listener.count.load(), 1);
+  EXPECT_EQ(listener.lastValue.load(), 123);
+}
+
+TEST(EventBusTest, TryPublishTimeoutOnBackpressure)
+{
+  SmallBus smallBus;  // Very small buffer (4 slots, 2 consumers max)
+  SlowListener slowListener(std::chrono::milliseconds{100});
+
+  smallBus.subscribe(&slowListener);
+  smallBus.start();
+
+  // Fill the buffer
+  for (int i = 0; i < 4; ++i)
+  {
+    smallBus.publish(TestEvent{.value = i});
+  }
+
+  // This should timeout because buffer is full and consumer is slow
+  auto [result, seq] = smallBus.tryPublish(TestEvent{.value = 999}, std::chrono::microseconds{100});
+
+  // May succeed or timeout depending on timing
+  EXPECT_TRUE(result == SmallBus::PublishResult::SUCCESS || result == SmallBus::PublishResult::TIMEOUT);
+
+  smallBus.stop();
+}
+
+TEST(EventBusTest, PublishReturnsNegativeWhenStopped)
+{
+  TestBus bus;
+  CountingListener listener;
+
+  bus.subscribe(&listener);
+  // Don't start the bus
+
+  auto seq = bus.publish(TestEvent{.value = 1});
+  EXPECT_EQ(seq, -1);
+}
+
+TEST(EventBusTest, TryPublishReturnsStoppedWhenNotRunning)
+{
+  TestBus bus;
+  CountingListener listener;
+
+  bus.subscribe(&listener);
+  // Don't start
+
+  auto [result, seq] = bus.tryPublish(TestEvent{.value = 1}, std::chrono::microseconds{1000});
+
+  EXPECT_EQ(result, TestBus::PublishResult::STOPPED);
+  EXPECT_EQ(seq, -1);
+}
+
+// =============================================================================
+// Start/Stop tests
+// =============================================================================
+
+TEST(EventBusTest, DoubleStartIsIdempotent)
+{
+  TestBus bus;
+  CountingListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+  bus.start();  // Second start should be no-op
+
+  bus.publish(TestEvent{.value = 1});
+  bus.flush();
+  bus.stop();
+
+  EXPECT_EQ(listener.count.load(), 1);
+}
+
+TEST(EventBusTest, DoubleStopIsIdempotent)
+{
+  TestBus bus;
+  CountingListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+
+  bus.publish(TestEvent{.value = 1});
+  bus.flush();
+
+  bus.stop();
+  bus.stop();  // Second stop should be no-op
+
+  EXPECT_EQ(listener.count.load(), 1);
+}
+
+TEST(EventBusTest, DrainOnStopProcessesRemainingEvents)
+{
+  TestBus bus;
+  CountingListener listener;
+
+  bus.subscribe(&listener);
+  bus.enableDrainOnStop();
+  bus.start();
+
+  for (int i = 0; i < 10; ++i)
+  {
+    bus.publish(TestEvent{.value = i});
+  }
+
+  // Stop without explicit flush
+  bus.stop();
+
+  EXPECT_EQ(listener.count.load(), 10);
+}
+
+// =============================================================================
+// Wrap-around tests
+// =============================================================================
+
+TEST(EventBusTest, BufferWrapAroundWorks)
+{
+  EventBus<TestEvent, 8, 2> smallBus;  // Capacity 8
+  CountingListener listener;
+
+  smallBus.subscribe(&listener);
+  smallBus.start();
+
+  // Publish more than buffer capacity
+  constexpr int kCount = 100;
+  for (int i = 0; i < kCount; ++i)
+  {
+    smallBus.publish(TestEvent{.value = i});
+  }
+
+  smallBus.flush();
+  smallBus.stop();
+
+  EXPECT_EQ(listener.count.load(), kCount);
+  EXPECT_EQ(listener.lastValue.load(), kCount - 1);
+}
+
+// =============================================================================
+// Concurrent publish tests
+// =============================================================================
+
+TEST(EventBusTest, ConcurrentPublishersWork)
+{
+  TestBus bus;
+  CountingListener listener;
+
+  bus.subscribe(&listener);
+  bus.start();
+
+  constexpr int kThreads = 4;
+  constexpr int kEventsPerThread = 100;
+
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t)
+  {
+    threads.emplace_back([&bus, t]
+                         {
+      for (int i = 0; i < kEventsPerThread; ++i)
+      {
+        bus.publish(TestEvent{.value = t * 1000 + i});
+      } });
+  }
+
+  for (auto& t : threads)
+  {
+    t.join();
+  }
+
+  bus.flush();
+  bus.stop();
+
+  EXPECT_EQ(listener.count.load(), kThreads * kEventsPerThread);
+}
+
+// =============================================================================
+// Required vs optional consumer tests
+// =============================================================================
+
+TEST(EventBusTest, OptionalConsumerDoesNotBlockGating)
+{
+  TestBus bus;
+  CountingListener requiredListener;
+  SlowListener optionalSlowListener(std::chrono::milliseconds{50});
+
+  bus.subscribe(&requiredListener, true);       // required
+  bus.subscribe(&optionalSlowListener, false);  // optional
+
+  bus.start();
+
+  for (int i = 0; i < 10; ++i)
+  {
+    bus.publish(TestEvent{.value = i});
+  }
+
+  bus.waitConsumed(9);  // Wait for required consumer only
+
+  bus.stop();
+
+  EXPECT_EQ(requiredListener.count.load(), 10);
+  // Optional listener may not have finished all events
+  EXPECT_LE(optionalSlowListener.count.load(), 10);
+}
+
+}  // namespace


### PR DESCRIPTION
**Fixes**
Remove tryReclaim() from do_publish() to prevent race with consumer reclaim Add _running check in subscribe() - returns false if bus already started Add MaxConsumers overflow check with rollback
Fix CPU affinity: distribute consumers across cores via round-robin (was: all on core 0) Add sequence counter overflow protection

**Features**
tryPublish(event, timeout) - non-blocking publish with backpressure handling PublishResult enum: SUCCESS, TIMEOUT, STOPPED
publish() now returns -1 when bus is stopped

**Improvements**
Replace std::aligned_storage_t with aligned byte array
subscribe() now returns bool instead of void

**Tests & Benchmarks**
Add test_event_bus.cpp (18 tests)
Add event_bus_benchmark.cpp (7 benchmarks)

**Docs**
Update docs/components/util/eventing/event_bus.md
Update docs/reference/api/util/eventing/event_bus.md