### PR TITLE
Position aggregator with net, per-side, and grouped tracking

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -23,6 +23,7 @@ add_flox_benchmark(binary_log_benchmark)
 add_flox_benchmark(event_bus_benchmark)
 add_flox_benchmark(multi_symbol_benchmark)
 add_flox_benchmark(cex_benchmark)
+add_flox_benchmark(position_aggregator_benchmark)
 
 if(FLOX_ENABLE_CPU_AFFINITY)
     add_flox_benchmark(cpu_affinity_benchmark)

--- a/benchmarks/position_aggregator_benchmark.cpp
+++ b/benchmarks/position_aggregator_benchmark.cpp
@@ -1,0 +1,319 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include "flox/execution/multi_execution_listener.h"
+#include "flox/position/multi_mode_position_tracker.h"
+#include "flox/position/position_group.h"
+#include "flox/position/position_reconciler.h"
+
+using namespace flox;
+
+namespace
+{
+
+Order makeOrder(OrderId id, SymbolId sym, Side side, double price, double qty,
+                bool reduceOnly = false, uint16_t tag = 0)
+{
+  Order o{};
+  o.id = id;
+  o.symbol = sym;
+  o.side = side;
+  o.price = Price::fromDouble(price);
+  o.quantity = Quantity::fromDouble(qty);
+  o.flags.reduceOnly = reduceOnly ? 1 : 0;
+  o.orderTag = tag;
+  return o;
+}
+
+struct OrderSequence
+{
+  std::vector<Order> orders;
+
+  OrderSequence(size_t n, size_t numSymbols = 4)
+  {
+    orders.reserve(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+      SymbolId sym = static_cast<SymbolId>(100 + (i % numSymbols));
+      Side side = (i % 3 == 0) ? Side::SELL : Side::BUY;
+      double price = 100.0 + (i % 50);
+      double qty = 0.1 + (i % 10) * 0.1;
+      orders.push_back(makeOrder(i + 1, sym, side, price, qty));
+    }
+  }
+};
+
+static void BM_NetMode_Fill(benchmark::State& state)
+{
+  OrderSequence seq(10000);
+  for (auto _ : state)
+  {
+    MultiModePositionTracker tracker{1, PositionAggregationMode::NET, CostBasisMethod::FIFO};
+    for (const auto& order : seq.orders)
+    {
+      tracker.onOrderFilled(order);
+    }
+    benchmark::DoNotOptimize(tracker.getPosition(100));
+  }
+  state.SetItemsProcessed(state.iterations() * 10000);
+}
+BENCHMARK(BM_NetMode_Fill);
+
+static void BM_NetMode_FillSingleSymbol(benchmark::State& state)
+{
+  OrderSequence seq(10000, 1);
+  for (auto _ : state)
+  {
+    MultiModePositionTracker tracker{1, PositionAggregationMode::NET, CostBasisMethod::FIFO};
+    for (const auto& order : seq.orders)
+    {
+      tracker.onOrderFilled(order);
+    }
+    benchmark::DoNotOptimize(tracker.getPosition(100));
+  }
+  state.SetItemsProcessed(state.iterations() * 10000);
+}
+BENCHMARK(BM_NetMode_FillSingleSymbol);
+
+static void BM_NetMode_LIFO(benchmark::State& state)
+{
+  OrderSequence seq(10000);
+  for (auto _ : state)
+  {
+    MultiModePositionTracker tracker{1, PositionAggregationMode::NET, CostBasisMethod::LIFO};
+    for (const auto& order : seq.orders)
+    {
+      tracker.onOrderFilled(order);
+    }
+    benchmark::DoNotOptimize(tracker.getPosition(100));
+  }
+  state.SetItemsProcessed(state.iterations() * 10000);
+}
+BENCHMARK(BM_NetMode_LIFO);
+
+static void BM_NetMode_AVERAGE(benchmark::State& state)
+{
+  OrderSequence seq(10000);
+  for (auto _ : state)
+  {
+    MultiModePositionTracker tracker{1, PositionAggregationMode::NET, CostBasisMethod::AVERAGE};
+    for (const auto& order : seq.orders)
+    {
+      tracker.onOrderFilled(order);
+    }
+    benchmark::DoNotOptimize(tracker.getPosition(100));
+  }
+  state.SetItemsProcessed(state.iterations() * 10000);
+}
+BENCHMARK(BM_NetMode_AVERAGE);
+
+// Single fill latency
+static void BM_NetMode_SingleFill(benchmark::State& state)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET, CostBasisMethod::FIFO};
+  Order order = makeOrder(1, 100, Side::BUY, 100.0, 1.0);
+  uint64_t id = 1;
+  for (auto _ : state)
+  {
+    order.id = ++id;
+    order.side = (id % 2) ? Side::BUY : Side::SELL;
+    tracker.onOrderFilled(order);
+    benchmark::DoNotOptimize(tracker.getPosition(100));
+  }
+}
+BENCHMARK(BM_NetMode_SingleFill);
+
+static void BM_PerSideMode_Fill(benchmark::State& state)
+{
+  OrderSequence seq(10000);
+  for (auto _ : state)
+  {
+    MultiModePositionTracker tracker{1, PositionAggregationMode::PER_SIDE, CostBasisMethod::FIFO};
+    for (const auto& order : seq.orders)
+    {
+      tracker.onOrderFilled(order);
+    }
+    benchmark::DoNotOptimize(tracker.getLongPosition(100));
+  }
+  state.SetItemsProcessed(state.iterations() * 10000);
+}
+BENCHMARK(BM_PerSideMode_Fill);
+
+static void BM_PerSideMode_FillAndClose(benchmark::State& state)
+{
+  for (auto _ : state)
+  {
+    MultiModePositionTracker tracker{1, PositionAggregationMode::PER_SIDE, CostBasisMethod::FIFO};
+    for (int i = 0; i < 5000; ++i)
+    {
+      tracker.onOrderFilled(makeOrder(i * 2 + 1, 100, Side::BUY, 100.0 + i, 1.0));
+      tracker.onOrderFilled(makeOrder(i * 2 + 2, 100, Side::SELL, 110.0 + i, 1.0, true));
+    }
+    benchmark::DoNotOptimize(tracker.getRealizedPnl(100));
+  }
+  state.SetItemsProcessed(state.iterations() * 10000);
+}
+BENCHMARK(BM_PerSideMode_FillAndClose);
+
+static void BM_GroupedMode_Fill(benchmark::State& state)
+{
+  OrderSequence seq(10000);
+  for (auto _ : state)
+  {
+    MultiModePositionTracker tracker{1, PositionAggregationMode::GROUPED, CostBasisMethod::FIFO};
+    for (const auto& order : seq.orders)
+    {
+      tracker.onOrderFilled(order);
+    }
+    benchmark::DoNotOptimize(tracker.getPosition(100));
+  }
+  state.SetItemsProcessed(state.iterations() * 10000);
+}
+BENCHMARK(BM_GroupedMode_Fill);
+
+static void BM_GroupedMode_FillWithTags(benchmark::State& state)
+{
+  std::vector<Order> orders;
+  orders.reserve(10000);
+  for (int i = 0; i < 10000; ++i)
+  {
+    uint16_t tag = static_cast<uint16_t>(1 + (i % 100));
+    orders.push_back(makeOrder(i + 1, 100, Side::BUY, 100.0 + i, 0.5, false, tag));
+  }
+
+  for (auto _ : state)
+  {
+    MultiModePositionTracker tracker{1, PositionAggregationMode::GROUPED, CostBasisMethod::FIFO};
+    for (const auto& order : orders)
+    {
+      tracker.onOrderFilled(order);
+    }
+    benchmark::DoNotOptimize(tracker.getPosition(100));
+  }
+  state.SetItemsProcessed(state.iterations() * 10000);
+}
+BENCHMARK(BM_GroupedMode_FillWithTags);
+
+static void BM_GroupedMode_NetPositionQuery(benchmark::State& state)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::GROUPED, CostBasisMethod::FIFO};
+  for (int i = 0; i < 10000; ++i)
+  {
+    tracker.onOrderFilled(makeOrder(i + 1, static_cast<SymbolId>(100 + i % 4),
+                                    (i % 2) ? Side::BUY : Side::SELL, 100.0, 1.0));
+  }
+
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(tracker.getPosition(100));
+    benchmark::DoNotOptimize(tracker.getPosition(101));
+    benchmark::DoNotOptimize(tracker.getPosition(102));
+    benchmark::DoNotOptimize(tracker.getPosition(103));
+  }
+}
+BENCHMARK(BM_GroupedMode_NetPositionQuery);
+
+static void BM_GroupTracker_OpenClose(benchmark::State& state)
+{
+  for (auto _ : state)
+  {
+    PositionGroupTracker gt;
+    for (int i = 0; i < 5000; ++i)
+    {
+      PositionId pid = gt.openPosition(i + 1, 100, Side::BUY,
+                                       Price::fromDouble(100.0 + i), Quantity::fromDouble(1.0));
+      gt.closePosition(pid, Price::fromDouble(110.0 + i));
+    }
+    benchmark::DoNotOptimize(gt.totalRealizedPnl());
+  }
+  state.SetItemsProcessed(state.iterations() * 10000);
+}
+BENCHMARK(BM_GroupTracker_OpenClose);
+
+static void BM_Reconciler_100Symbols(benchmark::State& state)
+{
+  PositionReconciler reconciler;
+  reconciler.setMismatchHandler([](const PositionMismatch&)
+                                { return ReconcileAction::ACCEPT_EXCHANGE; });
+
+  std::vector<ExchangePosition> exchange;
+  for (int i = 0; i < 100; ++i)
+  {
+    exchange.push_back({static_cast<SymbolId>(i), Quantity::fromDouble(5.0 + i),
+                        Price::fromDouble(100.0 + i)});
+  }
+
+  for (auto _ : state)
+  {
+    auto mismatches = reconciler.reconcile(exchange,
+                                           [](SymbolId sym) -> std::pair<Quantity, Price>
+                                           {
+                                             // Every other symbol has mismatch
+                                             double qty = (sym % 2 == 0) ? 5.0 + sym : 3.0 + sym;
+                                             return {Quantity::fromDouble(qty), Price::fromDouble(100.0 + sym)};
+                                           });
+    benchmark::DoNotOptimize(mismatches.size());
+  }
+}
+BENCHMARK(BM_Reconciler_100Symbols);
+
+static void BM_SharedDistributor_3Trackers(benchmark::State& state)
+{
+  OrderSequence seq(10000);
+  for (auto _ : state)
+  {
+    MultiExecutionListener dist{0};
+    auto net = std::make_shared<MultiModePositionTracker>(1, PositionAggregationMode::NET);
+    auto perSide = std::make_shared<MultiModePositionTracker>(2, PositionAggregationMode::PER_SIDE);
+    auto grouped = std::make_shared<MultiModePositionTracker>(3, PositionAggregationMode::GROUPED);
+    dist.addListener(net.get());
+    dist.addListener(perSide.get());
+    dist.addListener(grouped.get());
+
+    for (const auto& order : seq.orders)
+    {
+      dist.onOrderFilled(order);
+    }
+    benchmark::DoNotOptimize(net->getPosition(100));
+    benchmark::DoNotOptimize(perSide->getLongPosition(100));
+    benchmark::DoNotOptimize(grouped->getPosition(100));
+  }
+  state.SetItemsProcessed(state.iterations() * 10000);
+}
+BENCHMARK(BM_SharedDistributor_3Trackers);
+
+static void BM_SharedDistributor_vs_Individual(benchmark::State& state)
+{
+  // Baseline: 3 individual trackers, each receiving fills separately
+  OrderSequence seq(10000);
+  for (auto _ : state)
+  {
+    MultiModePositionTracker t1{1, PositionAggregationMode::NET};
+    MultiModePositionTracker t2{2, PositionAggregationMode::PER_SIDE};
+    MultiModePositionTracker t3{3, PositionAggregationMode::GROUPED};
+
+    for (const auto& order : seq.orders)
+    {
+      t1.onOrderFilled(order);
+      t2.onOrderFilled(order);
+      t3.onOrderFilled(order);
+    }
+    benchmark::DoNotOptimize(t1.getPosition(100));
+    benchmark::DoNotOptimize(t2.getLongPosition(100));
+    benchmark::DoNotOptimize(t3.getPosition(100));
+  }
+  state.SetItemsProcessed(state.iterations() * 10000);
+}
+BENCHMARK(BM_SharedDistributor_vs_Individual);
+
+}  // namespace
+
+BENCHMARK_MAIN();

--- a/docs/reference/api/position/abstract_position_manager.md
+++ b/docs/reference/api/position/abstract_position_manager.md
@@ -29,16 +29,16 @@ public:
 * Must be registered with `OrderExecutionBus` to receive fill and cancel notifications.
 * Can optionally implement position limits or exposure constraints internally.
 
-## Implementation
+## Implementations
 
-Use `PositionTracker` for a full-featured implementation with:
-
-- FIFO, LIFO, and AVERAGE cost basis methods
-- Realized PnL calculation
-- Average entry price tracking
-
-See [PositionTracker](position_tracker.md) for details.
+| Class | Use Case |
+|-------|----------|
+| [PositionTracker](position_tracker.md) | Net position with FIFO/LIFO/AVERAGE cost basis |
+| [MultiModePositionTracker](multi_mode_position_tracker.md) | Net, per-side (hedging), or grouped (per-order) aggregation |
+| [AggregatedPositionTracker](../cex/aggregated_position_tracker.md) | Lock-free multi-exchange aggregation |
 
 ## See Also
 
-- [PositionTracker](position_tracker.md) - Full implementation with cost basis methods
+- [PositionTracker](position_tracker.md) - Net-only, lot-based
+- [MultiModePositionTracker](multi_mode_position_tracker.md) - Multi-mode with reconciliation
+- [PositionReconciler](position_reconciler.md) - Exchange position reconciliation

--- a/docs/reference/api/position/multi_mode_position_tracker.md
+++ b/docs/reference/api/position/multi_mode_position_tracker.md
@@ -1,0 +1,111 @@
+# MultiModePositionTracker
+
+Position tracking with configurable aggregation: net, per-side (hedging), or grouped (per-order).
+
+## Header
+
+```cpp
+#include "flox/position/multi_mode_position_tracker.h"
+```
+
+## Aggregation Modes
+
+| Mode | Behavior |
+|------|----------|
+| `NET` | Single position per symbol. BUY adds, SELL deducts. Automatic flip through zero. |
+| `PER_SIDE` | Separate long and short positions. Intent via `reduceOnly`/`closePosition` flags or explicit API. |
+| `GROUPED` | Each order creates an individual position. Contingent orders (TP/SL/OCO) grouped by `orderTag`. |
+
+## Explicit Intent API
+
+```cpp
+MultiModePositionTracker tracker{1, PositionAggregationMode::PER_SIDE};
+
+tracker.openLong(symbol, price, qty);
+tracker.closeLong(symbol, price, qty);
+tracker.openShort(symbol, price, qty);
+tracker.closeShort(symbol, price, qty);
+
+// With tag for grouped mode:
+tracker.openLong(symbol, price, qty, /*tag=*/42);
+tracker.closeLong(symbol, price, qty, /*tag=*/42);
+```
+
+Works in all modes. In NET mode, `openLong`/`openShort` both aggregate into the net position.
+
+## Snapshot
+
+Atomic read of all position fields in a single lock acquisition:
+
+```cpp
+auto snap = tracker.snapshot(symbol);
+snap.longQty;       // long side quantity
+snap.shortQty;      // short side quantity
+snap.longAvgEntry;  // long side average entry price
+snap.shortAvgEntry; // short side average entry price
+snap.realizedPnl;   // accumulated realized PnL
+snap.netQty();      // longQty - shortQty
+snap.unrealizedPnl(currentPrice);  // mark-to-market
+```
+
+## Position Change Callback
+
+```cpp
+tracker.onPositionChange([](SymbolId sym, const auto& snap) {
+    log("Position changed: {} net={}", sym, snap.netQty().toDouble());
+});
+```
+
+Fires after every fill. Called under the lock.
+
+## Exchange Integration
+
+Receives fills via `IOrderExecutionListener`:
+
+```cpp
+// Subscribe to OrderExecutionBus
+bus.subscribe(&tracker);
+
+// For multiple trackers, use MultiExecutionListener
+MultiExecutionListener multi{0};
+multi.addListener(&netTracker);
+multi.addListener(&perSideTracker);
+bus.subscribe(&multi);
+```
+
+`onOrderFilled` is called once with the full order quantity for complete fills. `onOrderPartiallyFilled` is called for each partial fill. Do not call both for the same fill.
+
+## Reconciliation
+
+```cpp
+PositionReconciler reconciler;
+auto mismatches = tracker.reconcile(reconciler, exchangePositions);
+```
+
+Holds the lock for the entire operation (atomic across all symbols).
+
+## Reset
+
+```cpp
+tracker.reset();  // Clear all positions and PnL
+```
+
+## Thread Safety
+
+- All public methods are mutex-protected
+- `lockedGroups()` returns a proxy that holds the lock:
+
+```cpp
+auto positions = tracker.lockedGroups()->getOpenPositions(symbol);
+```
+
+- `groups()` provides raw access without locking (caller must ensure safety)
+
+## Cost Basis
+
+Inherits FIFO/LIFO/AVERAGE from `PositionTracker`. All PnL computed in fixed-point arithmetic (no float conversion).
+
+## See Also
+
+- [PositionTracker](position_tracker.md) - Original net-only tracker
+- [AggregatedPositionTracker](../cex/aggregated_position_tracker.md) - Lock-free multi-exchange aggregation

--- a/docs/reference/api/position/position_reconciler.md
+++ b/docs/reference/api/position/position_reconciler.md
@@ -1,0 +1,70 @@
+# PositionReconciler
+
+Detects and resolves discrepancies between local position state and exchange-reported positions.
+
+## Header
+
+```cpp
+#include "flox/position/position_reconciler.h"
+```
+
+## Usage
+
+### With MultiModePositionTracker
+
+```cpp
+MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+
+std::vector<ExchangePosition> fromExchange = {
+    {BTCUSDT, Quantity::fromDouble(0.5), Price::fromDouble(99000.0)},
+    {ETHUSDT, Quantity::fromDouble(2.0), Price::fromDouble(3500.0)},
+};
+
+PositionReconciler reconciler;
+auto mismatches = tracker.reconcile(reconciler, fromExchange);
+```
+
+### With Custom Position Source
+
+```cpp
+auto mismatches = reconciler.reconcile(exchangePositions,
+    [&](SymbolId sym) -> std::pair<Quantity, Price> {
+        return {getMyPosition(sym), getMyAvgEntry(sym)};
+    });
+```
+
+### Bidirectional
+
+Pass local symbols to detect positions that exist locally but not at the exchange:
+
+```cpp
+auto mismatches = reconciler.reconcile(exchangePositions, localPosFn,
+    /*localSymbols=*/{BTCUSDT, ETHUSDT, SOLUSDT});
+```
+
+### Auto-Apply
+
+```cpp
+reconciler.setMismatchHandler([](const PositionMismatch& m) {
+    log("Mismatch on {}: local={} exchange={}",
+        m.symbol, m.localQuantity.toDouble(), m.exchangeQuantity.toDouble());
+    return ReconcileAction::ACCEPT_EXCHANGE;
+});
+
+reconciler.reconcileAndApply(exchangePositions, localPosFn,
+    [&](SymbolId sym, Quantity qty, Price avgEntry) {
+        overrideLocalPosition(sym, qty, avgEntry);
+    });
+```
+
+## Reconcile Actions
+
+| Action | Effect |
+|--------|--------|
+| `ACCEPT_EXCHANGE` | Trust exchange, call adjustFn to update local |
+| `ACCEPT_LOCAL` | Trust local, ignore exchange |
+| `FLAG_ONLY` | Log mismatch, do not adjust |
+
+## See Also
+
+- [MultiModePositionTracker](multi_mode_position_tracker.md)

--- a/include/flox/position/multi_mode_position_tracker.h
+++ b/include/flox/position/multi_mode_position_tracker.h
@@ -1,0 +1,741 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+#include "flox/position/position_aggregation_mode.h"
+#include "flox/position/position_group.h"
+#include "flox/position/position_reconciler.h"
+#include "flox/position/position_tracker.h"
+#include "flox/strategy/symbol_state_map.h"
+#include "flox/util/base/move_only_function.h"
+
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+namespace flox
+{
+
+struct CachedPositionState
+{
+  std::deque<Lot> lots;
+  int64_t cachedNetQty{0};
+  Price realizedPnl{};
+
+  Quantity position() const { return Quantity::fromRaw(cachedNetQty); }
+
+  Price avgEntryPrice() const
+  {
+    if (lots.empty())
+    {
+      return Price{};
+    }
+    int64_t totalQty = 0;
+    int64_t totalCost = 0;
+    for (const auto& lot : lots)
+    {
+      int64_t absQty = std::abs(lot.quantity.raw());
+      totalQty += absQty;
+      totalCost += (Quantity::fromRaw(absQty) * lot.price).raw();
+    }
+    if (totalQty == 0)
+    {
+      return Price{};
+    }
+    return Volume::fromRaw(totalCost) / Quantity::fromRaw(totalQty);
+  }
+};
+
+struct PerSidePositionState
+{
+  std::deque<Lot> longLots;
+  std::deque<Lot> shortLots;
+  int64_t cachedLongQty{0};
+  int64_t cachedShortQty{0};
+  Price realizedPnl{};
+
+  Quantity longPosition() const { return Quantity::fromRaw(cachedLongQty); }
+  Quantity shortPosition() const { return Quantity::fromRaw(cachedShortQty); }
+  Quantity netPosition() const { return Quantity::fromRaw(cachedLongQty - cachedShortQty); }
+
+  Price longAvgEntryPrice() const { return avgEntryForLots(longLots); }
+  Price shortAvgEntryPrice() const { return avgEntryForLots(shortLots); }
+
+ private:
+  static Price avgEntryForLots(const std::deque<Lot>& lots)
+  {
+    if (lots.empty())
+    {
+      return Price{};
+    }
+    int64_t totalQty = 0;
+    int64_t totalCost = 0;
+    for (const auto& lot : lots)
+    {
+      int64_t absQty = std::abs(lot.quantity.raw());
+      totalQty += absQty;
+      totalCost += (Quantity::fromRaw(absQty) * lot.price).raw();
+    }
+    if (totalQty == 0)
+    {
+      return Price{};
+    }
+    return Volume::fromRaw(totalCost) / Quantity::fromRaw(totalQty);
+  }
+};
+
+// Thread-safe proxy for accessing PositionGroupTracker.
+// Holds the mutex for its lifetime -- use in limited scope.
+template <typename T>
+class LockedRef
+{
+ public:
+  LockedRef(std::mutex& m, T& ref) : _lock(m), _ref(ref) {}
+  T* operator->() { return &_ref; }
+  T& operator*() { return _ref; }
+
+ private:
+  std::lock_guard<std::mutex> _lock;
+  T& _ref;
+};
+
+template <typename T>
+class LockedConstRef
+{
+ public:
+  LockedConstRef(std::mutex& m, const T& ref) : _lock(m), _ref(ref) {}
+  const T* operator->() const { return &_ref; }
+  const T& operator*() const { return _ref; }
+
+ private:
+  std::lock_guard<std::mutex> _lock;
+  const T& _ref;
+};
+
+class MultiModePositionTracker : public IPositionManager
+{
+ public:
+  MultiModePositionTracker(SubscriberId id,
+                           PositionAggregationMode mode = PositionAggregationMode::NET,
+                           CostBasisMethod costBasis = CostBasisMethod::FIFO)
+      : IPositionManager(id), _mode(mode), _costBasis(costBasis)
+  {
+    switch (_mode)
+    {
+      case PositionAggregationMode::NET:
+        _netStates = std::make_unique<SymbolStateMap<CachedPositionState>>();
+        break;
+      case PositionAggregationMode::PER_SIDE:
+        _perSideStates = std::make_unique<SymbolStateMap<PerSidePositionState>>();
+        break;
+      case PositionAggregationMode::GROUPED:
+        _groups = std::make_unique<PositionGroupTracker>();
+        break;
+    }
+  }
+
+  void start() override {}
+  void stop() override {}
+
+  void openLong(SymbolId symbol, Price price, Quantity qty, uint16_t tag = 0)
+  {
+    applyExplicitFill(symbol, Side::BUY, price, qty, false, tag);
+  }
+
+  void closeLong(SymbolId symbol, Price price, Quantity qty, uint16_t tag = 0)
+  {
+    applyExplicitFill(symbol, Side::SELL, price, qty, true, tag);
+  }
+
+  void openShort(SymbolId symbol, Price price, Quantity qty, uint16_t tag = 0)
+  {
+    applyExplicitFill(symbol, Side::SELL, price, qty, false, tag);
+  }
+
+  void closeShort(SymbolId symbol, Price price, Quantity qty, uint16_t tag = 0)
+  {
+    applyExplicitFill(symbol, Side::BUY, price, qty, true, tag);
+  }
+
+  PositionAggregationMode mode() const { return _mode; }
+  CostBasisMethod costBasisMethod() const { return _costBasis; }
+
+  struct PositionSnapshot
+  {
+    Quantity longQty{};
+    Quantity shortQty{};
+    Price longAvgEntry{};
+    Price shortAvgEntry{};
+    Price realizedPnl{};
+
+    Quantity netQty() const { return Quantity::fromRaw(longQty.raw() - shortQty.raw()); }
+
+    Volume unrealizedPnl(Price currentPrice) const
+    {
+      int64_t pnl = 0;
+      if (longQty.raw() > 0)
+      {
+        pnl += (longQty * (currentPrice - longAvgEntry)).raw();
+      }
+      if (shortQty.raw() > 0)
+      {
+        pnl += (shortQty * (shortAvgEntry - currentPrice)).raw();
+      }
+      return Volume::fromRaw(pnl);
+    }
+  };
+
+  using PositionChangeCallback = MoveOnlyFunction<void(SymbolId, const PositionSnapshot&)>;
+
+  void onPositionChange(PositionChangeCallback cb) { _onChange = std::move(cb); }
+
+  PositionSnapshot snapshot(SymbolId symbol) const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return snapshotUnlocked(symbol);
+  }
+
+  Quantity getPosition(SymbolId symbol) const override
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return getPositionUnlocked(symbol);
+  }
+
+  Quantity getLongPosition(SymbolId symbol) const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_mode == PositionAggregationMode::PER_SIDE)
+    {
+      return (*_perSideStates)[symbol].longPosition();
+    }
+    auto pos = getPositionUnlocked(symbol);
+    return pos.raw() > 0 ? pos : Quantity{};
+  }
+
+  Quantity getShortPosition(SymbolId symbol) const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_mode == PositionAggregationMode::PER_SIDE)
+    {
+      return (*_perSideStates)[symbol].shortPosition();
+    }
+    auto pos = getPositionUnlocked(symbol);
+    return pos.raw() < 0 ? Quantity::fromRaw(-pos.raw()) : Quantity{};
+  }
+
+  Price getLongAvgEntry(SymbolId symbol) const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_mode == PositionAggregationMode::PER_SIDE)
+    {
+      return (*_perSideStates)[symbol].longAvgEntryPrice();
+    }
+    return (*_netStates)[symbol].avgEntryPrice();
+  }
+
+  Price getShortAvgEntry(SymbolId symbol) const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_mode == PositionAggregationMode::PER_SIDE)
+    {
+      return (*_perSideStates)[symbol].shortAvgEntryPrice();
+    }
+    return (*_netStates)[symbol].avgEntryPrice();
+  }
+
+  Volume getUnrealizedPnl(SymbolId symbol, Price currentPrice) const
+  {
+    return snapshot(symbol).unrealizedPnl(currentPrice);
+  }
+
+  LockedRef<PositionGroupTracker> lockedGroups()
+  {
+    return {_mutex, *_groups};
+  }
+
+  LockedConstRef<PositionGroupTracker> lockedGroups() const
+  {
+    return {_mutex, *_groups};
+  }
+
+  // Raw access (caller must ensure thread safety)
+  PositionGroupTracker& groups() { return *_groups; }
+  const PositionGroupTracker& groups() const { return *_groups; }
+
+  Price getRealizedPnl(SymbolId symbol) const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    switch (_mode)
+    {
+      case PositionAggregationMode::NET:
+        return (*_netStates)[symbol].realizedPnl;
+      case PositionAggregationMode::PER_SIDE:
+        return (*_perSideStates)[symbol].realizedPnl;
+      case PositionAggregationMode::GROUPED:
+        return _groups->realizedPnl(symbol);
+    }
+    return Price{};
+  }
+
+  Price getTotalRealizedPnl() const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    int64_t total = 0;
+    switch (_mode)
+    {
+      case PositionAggregationMode::NET:
+        _netStates->forEach([&total](SymbolId, const CachedPositionState& s)
+                            { total += s.realizedPnl.raw(); });
+        break;
+      case PositionAggregationMode::PER_SIDE:
+        _perSideStates->forEach([&total](SymbolId, const PerSidePositionState& s)
+                                { total += s.realizedPnl.raw(); });
+        break;
+      case PositionAggregationMode::GROUPED:
+        total = _groups->totalRealizedPnl().raw();
+        break;
+    }
+    return Price::fromRaw(total);
+  }
+
+  void reset()
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    switch (_mode)
+    {
+      case PositionAggregationMode::NET:
+        _netStates->clear();
+        break;
+      case PositionAggregationMode::PER_SIDE:
+        _perSideStates->clear();
+        break;
+      case PositionAggregationMode::GROUPED:
+        *_groups = PositionGroupTracker{};
+        _tagToGroup.clear();
+        break;
+    }
+    _nextExplicitId = kExplicitFillBaseId;
+  }
+
+  // --- Order execution callbacks ---
+  // Convention: onOrderFilled is called ONCE with the full order quantity when the
+  // entire order fills at once. If an order fills in parts, only
+  // onOrderPartiallyFilled is called for each part -- onOrderFilled is NOT called
+  // after partial fills complete. Calling both will double-count.
+
+  void onOrderPartiallyFilled(const Order& order, Quantity fillQty) override
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    applyFillInternal(order, fillQty, precomputeFill(order, fillQty));
+  }
+
+  void onOrderFilled(const Order& order) override
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    applyFillInternal(order, order.quantity, precomputeFill(order, order.quantity));
+  }
+
+  void onOrderCanceled(const Order& order) override
+  {
+    if (_mode == PositionAggregationMode::GROUPED)
+    {
+      std::lock_guard<std::mutex> lock(_mutex);
+      auto* pos = _groups->getPositionByOrder(order.id);
+      if (pos && pos->quantity.raw() == 0)
+      {
+        _groups->closePosition(pos->positionId, order.price);
+      }
+    }
+  }
+
+  std::vector<PositionMismatch> reconcile(
+      const PositionReconciler& reconciler,
+      const std::vector<ExchangePosition>& exchangePositions) const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return reconciler.reconcile(exchangePositions,
+                                [this](SymbolId sym) -> std::pair<Quantity, Price>
+                                {
+                                  auto snap = snapshotUnlocked(sym);
+                                  Quantity netQty = snap.netQty();
+                                  Price avgEntry = (netQty.raw() >= 0) ? snap.longAvgEntry : snap.shortAvgEntry;
+                                  return {netQty, avgEntry};
+                                });
+  }
+
+ private:
+  static constexpr OrderId kExplicitFillBaseId = 0xFFFF'FFFF'0000'0000ULL;
+  OrderId _nextExplicitId{kExplicitFillBaseId};
+
+  struct PrecomputedFill
+  {
+    int64_t signedQty;
+    bool isClose;
+  };
+
+  static PrecomputedFill precomputeFill(const Order& order, Quantity fillQty)
+  {
+    int64_t signedQty = (order.side == Side::BUY) ? fillQty.raw() : -fillQty.raw();
+    bool isClose = order.flags.reduceOnly || order.flags.closePosition;
+    return {signedQty, isClose};
+  }
+
+  void applyExplicitFill(SymbolId symbol, Side side, Price price, Quantity qty,
+                         bool isClose, uint16_t tag)
+  {
+    Order order{};
+    order.id = _nextExplicitId++;
+    order.symbol = symbol;
+    order.side = side;
+    order.price = price;
+    order.quantity = qty;
+    order.flags.reduceOnly = isClose ? 1 : 0;
+    order.orderTag = tag;
+
+    int64_t signedQty = (side == Side::BUY) ? qty.raw() : -qty.raw();
+    PrecomputedFill pc{signedQty, isClose};
+
+    std::lock_guard<std::mutex> lock(_mutex);
+    applyFillInternal(order, qty, pc);
+  }
+
+  PositionSnapshot snapshotUnlocked(SymbolId symbol) const
+  {
+    PositionSnapshot snap;
+
+    switch (_mode)
+    {
+      case PositionAggregationMode::NET:
+      {
+        const auto& s = (*_netStates)[symbol];
+        int64_t pos = s.cachedNetQty;
+        if (pos > 0)
+        {
+          snap.longQty = Quantity::fromRaw(pos);
+          snap.longAvgEntry = s.avgEntryPrice();
+        }
+        else if (pos < 0)
+        {
+          snap.shortQty = Quantity::fromRaw(-pos);
+          snap.shortAvgEntry = s.avgEntryPrice();
+        }
+        snap.realizedPnl = s.realizedPnl;
+        break;
+      }
+      case PositionAggregationMode::PER_SIDE:
+      {
+        const auto& s = (*_perSideStates)[symbol];
+        snap.longQty = s.longPosition();
+        snap.shortQty = s.shortPosition();
+        snap.longAvgEntry = s.longAvgEntryPrice();
+        snap.shortAvgEntry = s.shortAvgEntryPrice();
+        snap.realizedPnl = s.realizedPnl;
+        break;
+      }
+      case PositionAggregationMode::GROUPED:
+      {
+        int64_t longRaw = 0, shortRaw = 0;
+        int64_t longCost = 0, shortCost = 0;
+        _groups->forEachOpen([&](const IndividualPosition& p)
+                             {
+          if (p.symbol != symbol){ return;
+}
+          if (p.side == Side::BUY)
+          {
+            longRaw += p.quantity.raw();
+            longCost += (p.quantity * p.entryPrice).raw();
+          }
+          else
+          {
+            shortRaw += p.quantity.raw();
+            shortCost += (p.quantity * p.entryPrice).raw();
+          } });
+        snap.longQty = Quantity::fromRaw(longRaw);
+        snap.shortQty = Quantity::fromRaw(shortRaw);
+        if (longRaw > 0)
+        {
+          snap.longAvgEntry = Volume::fromRaw(longCost) / Quantity::fromRaw(longRaw);
+        }
+        if (shortRaw > 0)
+        {
+          snap.shortAvgEntry = Volume::fromRaw(shortCost) / Quantity::fromRaw(shortRaw);
+        }
+        snap.realizedPnl = _groups->realizedPnl(symbol);
+        break;
+      }
+    }
+    return snap;
+  }
+
+  Quantity getPositionUnlocked(SymbolId symbol) const
+  {
+    switch (_mode)
+    {
+      case PositionAggregationMode::NET:
+        return (*_netStates)[symbol].position();
+      case PositionAggregationMode::PER_SIDE:
+        return (*_perSideStates)[symbol].netPosition();
+      case PositionAggregationMode::GROUPED:
+        return _groups->netPosition(symbol);
+    }
+    return Quantity{};
+  }
+
+  void applyFillInternal(const Order& order, Quantity fillQty, const PrecomputedFill& pc)
+  {
+    switch (_mode)
+    {
+      case PositionAggregationMode::NET:
+        updateNet(order.symbol, pc.signedQty, order.price);
+        break;
+      case PositionAggregationMode::PER_SIDE:
+        updatePerSide(order, fillQty, pc.isClose);
+        break;
+      case PositionAggregationMode::GROUPED:
+        updateGrouped(order, fillQty, pc.isClose);
+        break;
+    }
+
+    if (_onChange) [[unlikely]]
+    {
+      _onChange(order.symbol, snapshotUnlocked(order.symbol));
+    }
+  }
+
+  void updateNet(SymbolId symbol, int64_t signedQty, Price price)
+  {
+    auto& s = (*_netStates)[symbol];
+    int64_t currentPos = s.cachedNetQty;
+
+    bool isClosing = (currentPos > 0 && signedQty < 0) || (currentPos < 0 && signedQty > 0);
+
+    if (isClosing)
+    {
+      int64_t absSignedQty = std::abs(signedQty);
+      int64_t absCurrentPos = std::abs(currentPos);
+      int64_t qtyToClose = std::min(absSignedQty, absCurrentPos);
+      Price pnl = closeLots(s.lots, Quantity::fromRaw(qtyToClose), price, currentPos > 0);
+      s.realizedPnl = Price::fromRaw(s.realizedPnl.raw() + pnl.raw());
+      s.cachedNetQty += signedQty;
+
+      int64_t remaining = absSignedQty - qtyToClose;
+      if (remaining > 0)
+      {
+        Quantity remQty = Quantity::fromRaw(signedQty > 0 ? remaining : -remaining);
+        addLot(s.lots, remQty, price);
+      }
+    }
+    else
+    {
+      addLot(s.lots, Quantity::fromRaw(signedQty), price);
+      s.cachedNetQty += signedQty;
+    }
+  }
+
+  void updatePerSide(const Order& order, Quantity qty, bool isClose)
+  {
+    auto& s = (*_perSideStates)[order.symbol];
+
+    if (order.side == Side::BUY)
+    {
+      if (isClose)
+      {
+        int64_t closeRaw = std::min(qty.raw(), s.cachedShortQty);
+        if (closeRaw > 0)
+        {
+          Price pnl = closeLots(s.shortLots, Quantity::fromRaw(closeRaw), order.price, false);
+          s.cachedShortQty -= closeRaw;
+          s.realizedPnl = Price::fromRaw(s.realizedPnl.raw() + pnl.raw());
+        }
+      }
+      else
+      {
+        addLot(s.longLots, qty, order.price);
+        s.cachedLongQty += qty.raw();
+      }
+    }
+    else
+    {
+      if (isClose)
+      {
+        int64_t closeRaw = std::min(qty.raw(), s.cachedLongQty);
+        if (closeRaw > 0)
+        {
+          Price pnl = closeLots(s.longLots, Quantity::fromRaw(closeRaw), order.price, true);
+          s.cachedLongQty -= closeRaw;
+          s.realizedPnl = Price::fromRaw(s.realizedPnl.raw() + pnl.raw());
+        }
+      }
+      else
+      {
+        addLot(s.shortLots, qty, order.price);
+        s.cachedShortQty += qty.raw();
+      }
+    }
+  }
+
+  void updateGrouped(const Order& order, Quantity fillQty, bool isClose)
+  {
+    if (isClose)
+    {
+      if (order.orderTag != 0)
+      {
+        GroupId gid = getOrCreateTagGroup(order.orderTag);
+        const auto* group = _groups->getGroup(gid);
+        if (group)
+        {
+          int64_t remaining = fillQty.raw();
+          for (auto pid : group->positionIds)
+          {
+            if (remaining <= 0)
+            {
+              break;
+            }
+            auto* pos = _groups->getPosition(pid);
+            if (!pos || pos->closed || pos->symbol != order.symbol)
+            {
+              continue;
+            }
+            bool isOpposite = (order.side == Side::SELL && pos->side == Side::BUY) ||
+                              (order.side == Side::BUY && pos->side == Side::SELL);
+            if (!isOpposite)
+            {
+              continue;
+            }
+
+            int64_t closeQty = std::min(remaining, pos->quantity.raw());
+            _groups->partialClose(pid, Quantity::fromRaw(closeQty), order.price);
+            remaining -= closeQty;
+          }
+        }
+      }
+      return;
+    }
+
+    auto* pos = _groups->getPositionByOrder(order.id);
+    if (!pos)
+    {
+      PositionId pid = _groups->openPosition(order.id, order.symbol, order.side, order.price, fillQty);
+      if (order.orderTag != 0)
+      {
+        GroupId gid = getOrCreateTagGroup(order.orderTag);
+        _groups->assignToGroup(pid, gid);
+      }
+    }
+    else
+    {
+      int64_t signedFill = (pos->side == Side::SELL) ? -fillQty.raw() : fillQty.raw();
+      _groups->addToNetCache(pos->symbol, signedFill);
+      pos->quantity = Quantity::fromRaw(pos->quantity.raw() + fillQty.raw());
+    }
+  }
+
+  GroupId getOrCreateTagGroup(uint16_t tag)
+  {
+    auto it = _tagToGroup.find(tag);
+    if (it != _tagToGroup.end())
+    {
+      return it->second;
+    }
+    GroupId gid = _groups->createGroup();
+    _tagToGroup[tag] = gid;
+    return gid;
+  }
+
+  void addLot(std::deque<Lot>& lots, Quantity signedQty, Price price)
+  {
+    if (_costBasis == CostBasisMethod::AVERAGE && !lots.empty())
+    {
+      int64_t newQty = lots.front().quantity.raw() + signedQty.raw();
+      if (newQty != 0)
+      {
+        Quantity absOld = Quantity::fromRaw(std::abs(lots.front().quantity.raw()));
+        Quantity absNew = Quantity::fromRaw(std::abs(signedQty.raw()));
+        Volume oldNotional = absOld * lots.front().price;
+        Volume newNotional = absNew * price;
+        Volume totalNotional = Volume::fromRaw(oldNotional.raw() + newNotional.raw());
+        Quantity absTotal = Quantity::fromRaw(std::abs(newQty));
+        lots.front().quantity = Quantity::fromRaw(newQty);
+        lots.front().price = totalNotional / absTotal;
+      }
+      else
+      {
+        lots.clear();
+      }
+    }
+    else
+    {
+      lots.push_back({signedQty, price});
+    }
+  }
+
+  Price closeLots(std::deque<Lot>& lots, Quantity qtyToClose, Price closePrice, bool wasLong)
+  {
+    int64_t pnl = 0;
+    int64_t remaining = qtyToClose.raw();
+
+    while (remaining > 0 && !lots.empty())
+    {
+      Lot& lot = (_costBasis == CostBasisMethod::LIFO) ? lots.back() : lots.front();
+      int64_t lotQty = std::abs(lot.quantity.raw());
+      int64_t closeQty = std::min(remaining, lotQty);
+
+      Price priceDiff = closePrice - lot.price;
+      Volume lotPnl = Quantity::fromRaw(closeQty) * priceDiff;
+      if (!wasLong)
+      {
+        lotPnl = Volume::fromRaw(-lotPnl.raw());
+      }
+      pnl += lotPnl.raw();
+      remaining -= closeQty;
+
+      if (closeQty >= lotQty)
+      {
+        if (_costBasis == CostBasisMethod::LIFO)
+        {
+          lots.pop_back();
+        }
+        else
+        {
+          lots.pop_front();
+        }
+      }
+      else
+      {
+        int64_t newQty = (lot.quantity.raw() > 0) ? (lotQty - closeQty) : -(lotQty - closeQty);
+        lot.quantity = Quantity::fromRaw(newQty);
+      }
+    }
+
+    return Price::fromRaw(pnl);
+  }
+
+  PositionAggregationMode _mode;
+  CostBasisMethod _costBasis;
+  PositionChangeCallback _onChange;
+  mutable std::mutex _mutex;
+
+  // Only one is allocated (based on _mode)
+  std::unique_ptr<SymbolStateMap<CachedPositionState>> _netStates;
+  std::unique_ptr<SymbolStateMap<PerSidePositionState>> _perSideStates;
+  std::unique_ptr<PositionGroupTracker> _groups;
+  std::unordered_map<uint16_t, GroupId> _tagToGroup;
+};
+
+inline std::vector<PositionMismatch> reconcileWith(
+    const PositionReconciler& reconciler,
+    const MultiModePositionTracker& tracker,
+    const std::vector<ExchangePosition>& exchangePositions)
+{
+  return tracker.reconcile(reconciler, exchangePositions);
+}
+
+}  // namespace flox

--- a/include/flox/position/position_aggregation_mode.h
+++ b/include/flox/position/position_aggregation_mode.h
@@ -1,0 +1,24 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace flox
+{
+
+enum class PositionAggregationMode : uint8_t
+{
+  NET = 0,       // Single net position per symbol (default, broker-style)
+  PER_SIDE = 1,  // Separate long/short positions (FX hedging-style)
+  GROUPED = 2,   // Each order creates individual position, grouped by contingent orders
+};
+
+}  // namespace flox

--- a/include/flox/position/position_group.h
+++ b/include/flox/position/position_group.h
@@ -1,0 +1,409 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+#include "flox/common.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace flox
+{
+
+using PositionId = uint64_t;
+using GroupId = uint64_t;
+
+struct IndividualPosition
+{
+  PositionId positionId{};
+  OrderId originOrderId{};
+  SymbolId symbol{};
+  Side side{};
+  Price entryPrice{};
+  Quantity quantity{};
+  Price realizedPnl{};
+  bool closed{false};
+  GroupId groupId{0};  // 0 = ungrouped
+};
+
+struct PositionGroup
+{
+  GroupId groupId{};
+  GroupId parentGroupId{0};  // 0 = top-level group
+  std::vector<PositionId> positionIds;
+  std::vector<GroupId> subGroupIds;
+
+  Quantity netPosition(const std::unordered_map<PositionId, IndividualPosition>& positions) const
+  {
+    int64_t total = 0;
+    for (auto pid : positionIds)
+    {
+      auto it = positions.find(pid);
+      if (it == positions.end() || it->second.closed)
+      {
+        continue;
+      }
+      int64_t qty = it->second.quantity.raw();
+      if (it->second.side == Side::SELL)
+      {
+        qty = -qty;
+      }
+      total += qty;
+    }
+    return Quantity::fromRaw(total);
+  }
+
+  Price groupRealizedPnl(const std::unordered_map<PositionId, IndividualPosition>& positions) const
+  {
+    int64_t total = 0;
+    for (auto pid : positionIds)
+    {
+      auto it = positions.find(pid);
+      if (it != positions.end())
+      {
+        total += it->second.realizedPnl.raw();
+      }
+    }
+    return Price::fromRaw(total);
+  }
+};
+
+class PositionGroupTracker
+{
+ public:
+  PositionGroupTracker() = default;
+
+  // Open a new individual position from an order fill
+  PositionId openPosition(OrderId orderId, SymbolId symbol, Side side,
+                          Price entryPrice, Quantity qty)
+  {
+    PositionId pid = _nextPositionId++;
+    IndividualPosition pos{};
+    pos.positionId = pid;
+    pos.originOrderId = orderId;
+    pos.symbol = symbol;
+    pos.side = side;
+    pos.entryPrice = entryPrice;
+    pos.quantity = qty;
+    _positions[pid] = pos;
+    _orderToPosition[orderId] = pid;
+    int64_t signedQty = (side == Side::SELL) ? -qty.raw() : qty.raw();
+    _symbolNetQty[symbol] += signedQty;
+    return pid;
+  }
+
+  // Close (or partially close) a position
+  void closePosition(PositionId pid, Price exitPrice)
+  {
+    auto it = _positions.find(pid);
+    if (it == _positions.end())
+    {
+      return;
+    }
+    auto& pos = it->second;
+    Price priceDiff = exitPrice - pos.entryPrice;
+    Volume pnl = pos.quantity * priceDiff;
+    if (pos.side == Side::SELL)
+    {
+      pnl = Volume::fromRaw(-pnl.raw());
+    }
+    pos.realizedPnl = Price::fromRaw(pos.realizedPnl.raw() + pnl.raw());
+    _symbolRealizedPnl[pos.symbol] += pnl.raw();
+    int64_t signedQty = (pos.side == Side::SELL) ? -pos.quantity.raw() : pos.quantity.raw();
+    _symbolNetQty[pos.symbol] -= signedQty;
+    pos.closed = true;
+  }
+
+  void partialClose(PositionId pid, Quantity closeQty, Price exitPrice)
+  {
+    auto it = _positions.find(pid);
+    if (it == _positions.end())
+    {
+      return;
+    }
+    auto& pos = it->second;
+    int64_t closeRaw = std::min(closeQty.raw(), pos.quantity.raw());
+
+    Price priceDiff = exitPrice - pos.entryPrice;
+    Volume pnl = Quantity::fromRaw(closeRaw) * priceDiff;
+    if (pos.side == Side::SELL)
+    {
+      pnl = Volume::fromRaw(-pnl.raw());
+    }
+    pos.realizedPnl = Price::fromRaw(pos.realizedPnl.raw() + pnl.raw());
+    _symbolRealizedPnl[pos.symbol] += pnl.raw();
+    int64_t signedClose = (pos.side == Side::SELL) ? -closeRaw : closeRaw;
+    _symbolNetQty[pos.symbol] -= signedClose;
+    pos.quantity = Quantity::fromRaw(pos.quantity.raw() - closeRaw);
+
+    if (pos.quantity.raw() == 0)
+    {
+      pos.closed = true;
+    }
+  }
+
+  GroupId createGroup(GroupId parentGroupId = 0)
+  {
+    GroupId gid = _nextGroupId++;
+    PositionGroup group{};
+    group.groupId = gid;
+    group.parentGroupId = parentGroupId;
+    _groups[gid] = group;
+
+    if (parentGroupId != 0)
+    {
+      auto it = _groups.find(parentGroupId);
+      if (it != _groups.end())
+      {
+        it->second.subGroupIds.push_back(gid);
+      }
+    }
+    return gid;
+  }
+
+  bool assignToGroup(PositionId pid, GroupId gid)
+  {
+    auto pit = _positions.find(pid);
+    if (pit == _positions.end())
+    {
+      return false;
+    }
+    auto git = _groups.find(gid);
+    if (git == _groups.end())
+    {
+      return false;
+    }
+    pit->second.groupId = gid;
+    git->second.positionIds.push_back(pid);
+    return true;
+  }
+
+  IndividualPosition* getPosition(PositionId pid)
+  {
+    auto it = _positions.find(pid);
+    return it != _positions.end() ? &it->second : nullptr;
+  }
+
+  const IndividualPosition* getPosition(PositionId pid) const
+  {
+    auto it = _positions.find(pid);
+    return it != _positions.end() ? &it->second : nullptr;
+  }
+
+  IndividualPosition* getPositionByOrder(OrderId orderId)
+  {
+    auto it = _orderToPosition.find(orderId);
+    if (it == _orderToPosition.end())
+    {
+      return nullptr;
+    }
+    return getPosition(it->second);
+  }
+
+  const IndividualPosition* getPositionByOrder(OrderId orderId) const
+  {
+    auto it = _orderToPosition.find(orderId);
+    if (it == _orderToPosition.end())
+    {
+      return nullptr;
+    }
+    return getPosition(it->second);
+  }
+
+  const PositionGroup* getGroup(GroupId gid) const
+  {
+    auto it = _groups.find(gid);
+    return it != _groups.end() ? &it->second : nullptr;
+  }
+
+  Quantity netPosition(SymbolId symbol) const
+  {
+    auto it = _symbolNetQty.find(symbol);
+    return it != _symbolNetQty.end() ? Quantity::fromRaw(it->second) : Quantity{};
+  }
+
+  void addToNetCache(SymbolId symbol, int64_t signedQtyRaw)
+  {
+    _symbolNetQty[symbol] += signedQtyRaw;
+  }
+
+  Quantity groupNetPosition(GroupId gid) const
+  {
+    auto it = _groups.find(gid);
+    if (it == _groups.end())
+    {
+      return Quantity{};
+    }
+    Quantity net = it->second.netPosition(_positions);
+    // Include sub-groups recursively
+    for (auto subGid : it->second.subGroupIds)
+    {
+      net = Quantity::fromRaw(net.raw() + groupNetPosition(subGid).raw());
+    }
+    return net;
+  }
+
+  Price realizedPnl(SymbolId symbol) const
+  {
+    auto it = _symbolRealizedPnl.find(symbol);
+    return it != _symbolRealizedPnl.end() ? Price::fromRaw(it->second) : Price{};
+  }
+
+  Price totalRealizedPnl() const
+  {
+    int64_t total = 0;
+    for (const auto& [_, pnl] : _symbolRealizedPnl)
+    {
+      total += pnl;
+    }
+    return Price::fromRaw(total);
+  }
+
+  Price groupRealizedPnl(GroupId gid) const
+  {
+    auto it = _groups.find(gid);
+    if (it == _groups.end())
+    {
+      return Price{};
+    }
+    int64_t total = it->second.groupRealizedPnl(_positions).raw();
+    for (auto subGid : it->second.subGroupIds)
+    {
+      total += groupRealizedPnl(subGid).raw();
+    }
+    return Price::fromRaw(total);
+  }
+
+  Volume groupUnrealizedPnl(GroupId gid, Price currentPrice) const
+  {
+    auto it = _groups.find(gid);
+    if (it == _groups.end())
+    {
+      return Volume{};
+    }
+
+    int64_t pnl = 0;
+    for (auto pid : it->second.positionIds)
+    {
+      auto pit = _positions.find(pid);
+      if (pit == _positions.end() || pit->second.closed)
+      {
+        continue;
+      }
+      const auto& pos = pit->second;
+      Price diff = currentPrice - pos.entryPrice;
+      Volume posPnl = pos.quantity * diff;
+      if (pos.side == Side::SELL)
+      {
+        posPnl = Volume::fromRaw(-posPnl.raw());
+      }
+      pnl += posPnl.raw();
+    }
+    for (auto subGid : it->second.subGroupIds)
+    {
+      pnl += groupUnrealizedPnl(subGid, currentPrice).raw();
+    }
+    return Volume::fromRaw(pnl);
+  }
+
+  size_t openPositionCount() const
+  {
+    size_t count = 0;
+    for (const auto& [_, pos] : _positions)
+    {
+      if (!pos.closed)
+      {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  size_t openPositionCount(SymbolId symbol) const
+  {
+    size_t count = 0;
+    for (const auto& [_, pos] : _positions)
+    {
+      if (pos.symbol == symbol && !pos.closed)
+      {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  // Get all open positions for a symbol
+  std::vector<const IndividualPosition*> getOpenPositions(SymbolId symbol) const
+  {
+    std::vector<const IndividualPosition*> result;
+    for (const auto& [_, pos] : _positions)
+    {
+      if (pos.symbol == symbol && !pos.closed)
+      {
+        result.push_back(&pos);
+      }
+    }
+    return result;
+  }
+
+  // Iterate all open positions
+  template <typename Func>
+  void forEachOpen(Func&& fn) const
+  {
+    for (const auto& [_, pos] : _positions)
+    {
+      if (!pos.closed)
+      {
+        fn(pos);
+      }
+    }
+  }
+
+  void pruneClosedPositions()
+  {
+    std::unordered_set<PositionId> pruned;
+    for (auto it = _positions.begin(); it != _positions.end();)
+    {
+      if (it->second.closed)
+      {
+        pruned.insert(it->first);
+        _orderToPosition.erase(it->second.originOrderId);
+        it = _positions.erase(it);
+      }
+      else
+      {
+        ++it;
+      }
+    }
+
+    if (!pruned.empty())
+    {
+      for (auto& [_, group] : _groups)
+      {
+        std::erase_if(group.positionIds, [&](PositionId pid)
+                      { return pruned.count(pid); });
+      }
+    }
+  }
+
+ private:
+  PositionId _nextPositionId{1};
+  GroupId _nextGroupId{1};
+  std::unordered_map<PositionId, IndividualPosition> _positions;
+  std::unordered_map<OrderId, PositionId> _orderToPosition;
+  std::unordered_map<GroupId, PositionGroup> _groups;
+  std::unordered_map<SymbolId, int64_t> _symbolNetQty;
+  std::unordered_map<SymbolId, int64_t> _symbolRealizedPnl;
+};
+
+}  // namespace flox

--- a/include/flox/position/position_reconciler.h
+++ b/include/flox/position/position_reconciler.h
@@ -1,0 +1,147 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+#include "flox/common.h"
+
+#include <functional>
+#include <vector>
+
+namespace flox
+{
+
+struct ExchangePosition
+{
+  SymbolId symbol{};
+  Quantity quantity{};  // signed: positive=long, negative=short
+  Price avgEntryPrice{};
+};
+
+struct PositionMismatch
+{
+  SymbolId symbol{};
+  Quantity localQuantity{};
+  Quantity exchangeQuantity{};
+  Price localAvgEntry{};
+  Price exchangeAvgEntry{};
+
+  Quantity quantityDiff() const
+  {
+    return Quantity::fromRaw(exchangeQuantity.raw() - localQuantity.raw());
+  }
+};
+
+enum class ReconcileAction : uint8_t
+{
+  ACCEPT_EXCHANGE = 0,  // Trust exchange position, adjust local
+  ACCEPT_LOCAL = 1,     // Trust local position, ignore exchange
+  FLAG_ONLY = 2,        // Log mismatch, do not adjust
+};
+
+class PositionReconciler
+{
+ public:
+  using MismatchCallback = std::function<ReconcileAction(const PositionMismatch&)>;
+
+  void setMismatchHandler(MismatchCallback cb)
+  {
+    _onMismatch = std::move(cb);
+  }
+
+  // localSymbols: if provided, also detects positions that exist locally but not at exchange.
+  template <typename LocalPosFn>
+  std::vector<PositionMismatch> reconcile(
+      const std::vector<ExchangePosition>& exchangePositions,
+      LocalPosFn&& localPositionFn,
+      const std::vector<SymbolId>& localSymbols = {}) const
+  {
+    std::vector<PositionMismatch> mismatches;
+
+    for (const auto& bp : exchangePositions)
+    {
+      auto [localQty, localAvg] = localPositionFn(bp.symbol);
+
+      if (localQty.raw() != bp.quantity.raw())
+      {
+        PositionMismatch m{};
+        m.symbol = bp.symbol;
+        m.localQuantity = localQty;
+        m.exchangeQuantity = bp.quantity;
+        m.localAvgEntry = localAvg;
+        m.exchangeAvgEntry = bp.avgEntryPrice;
+        mismatches.push_back(m);
+      }
+    }
+
+    if (!localSymbols.empty())
+    {
+      for (SymbolId sym : localSymbols)
+      {
+        bool foundAtExchange = false;
+        for (const auto& bp : exchangePositions)
+        {
+          if (bp.symbol == sym)
+          {
+            foundAtExchange = true;
+            break;
+          }
+        }
+        if (foundAtExchange)
+        {
+          continue;
+        }
+
+        auto [localQty, localAvg] = localPositionFn(sym);
+        if (localQty.raw() != 0)
+        {
+          PositionMismatch m{};
+          m.symbol = sym;
+          m.localQuantity = localQty;
+          m.exchangeQuantity = Quantity{};
+          m.localAvgEntry = localAvg;
+          m.exchangeAvgEntry = Price{};
+          mismatches.push_back(m);
+        }
+      }
+    }
+
+    return mismatches;
+  }
+
+  template <typename LocalPosFn, typename AdjustFn>
+  std::vector<PositionMismatch> reconcileAndApply(
+      const std::vector<ExchangePosition>& exchangePositions,
+      LocalPosFn&& localPositionFn,
+      AdjustFn&& adjustFn,
+      const std::vector<SymbolId>& localSymbols = {}) const
+  {
+    auto mismatches = reconcile(exchangePositions, std::forward<LocalPosFn>(localPositionFn),
+                                localSymbols);
+
+    if (_onMismatch)
+    {
+      for (const auto& m : mismatches)
+      {
+        ReconcileAction action = _onMismatch(m);
+        if (action == ReconcileAction::ACCEPT_EXCHANGE)
+        {
+          adjustFn(m.symbol, m.exchangeQuantity, m.exchangeAvgEntry);
+        }
+      }
+    }
+
+    return mismatches;
+  }
+
+ private:
+  MismatchCallback _onMismatch;
+};
+
+}  // namespace flox

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,6 +190,8 @@ nav:
           - Position:
               - IPositionManager: reference/api/position/abstract_position_manager.md
               - PositionTracker: reference/api/position/position_tracker.md
+              - MultiModePositionTracker: reference/api/position/multi_mode_position_tracker.md
+              - PositionReconciler: reference/api/position/position_reconciler.md
           - Validation:
               - IOrderValidator: reference/api/validation/abstract_order_validator.md
           - Net:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,8 @@ add_flox_test(test_replay_connector)
 
 add_flox_test(test_multi_symbol_strategy)
 
+add_flox_test(test_position_aggregator)
+
 # CEX coordination tests
 add_flox_test(test_cex_coordination)
 

--- a/tests/test_position_aggregator.cpp
+++ b/tests/test_position_aggregator.cpp
@@ -1,0 +1,1154 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include <gtest/gtest.h>
+
+#include "flox/execution/multi_execution_listener.h"
+#include "flox/position/multi_mode_position_tracker.h"
+#include "flox/position/position_group.h"
+#include "flox/position/position_reconciler.h"
+
+using namespace flox;
+
+static Order makeOrder(OrderId id, SymbolId sym, Side side, double price, double qty,
+                       bool reduceOnly = false, bool closePos = false, uint16_t tag = 0)
+{
+  Order o{};
+  o.id = id;
+  o.symbol = sym;
+  o.side = side;
+  o.price = Price::fromDouble(price);
+  o.quantity = Quantity::fromDouble(qty);
+  o.flags.reduceOnly = reduceOnly ? 1 : 0;
+  o.flags.closePosition = closePos ? 1 : 0;
+  o.orderTag = tag;
+  return o;
+}
+
+class NetModeTest : public ::testing::Test
+{
+ protected:
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET, CostBasisMethod::FIFO};
+};
+
+TEST_F(NetModeTest, BuyOpensLongPosition)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 50000.0, 1.0));
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 1.0);
+}
+
+TEST_F(NetModeTest, SellOpensShortPosition)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::SELL, 50000.0, 1.0));
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), -1.0);
+}
+
+TEST_F(NetModeTest, BuyThenSellCloses)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 50000.0, 1.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 51000.0, 1.0));
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 0.0);
+  EXPECT_GT(tracker.getRealizedPnl(100).toDouble(), 0.0);
+}
+
+TEST_F(NetModeTest, PartialFillUpdatesPosition)
+{
+  auto order = makeOrder(1, 100, Side::BUY, 50000.0, 2.0);
+  tracker.onOrderPartiallyFilled(order, Quantity::fromDouble(0.5));
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 0.5);
+}
+
+TEST_F(NetModeTest, RealizedPnlOnClose)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 10.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 110.0, 10.0));
+  EXPECT_NEAR(tracker.getRealizedPnl(100).toDouble(), 100.0, 0.01);
+}
+
+TEST_F(NetModeTest, FlipFromLongToShort)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 110.0, 8.0));
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), -3.0);
+  EXPECT_NEAR(tracker.getRealizedPnl(100).toDouble(), 50.0, 0.01);
+}
+
+TEST_F(NetModeTest, MultipleSymbols)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+  tracker.onOrderFilled(makeOrder(2, 200, Side::SELL, 50.0, 3.0));
+  tracker.onOrderFilled(makeOrder(3, 300, Side::BUY, 1000.0, 1.0));
+
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 5.0);
+  EXPECT_DOUBLE_EQ(tracker.getPosition(200).toDouble(), -3.0);
+  EXPECT_DOUBLE_EQ(tracker.getPosition(300).toDouble(), 1.0);
+}
+
+TEST_F(NetModeTest, MultipleSymbolsPnl)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 10.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 110.0, 10.0));
+  tracker.onOrderFilled(makeOrder(3, 200, Side::SELL, 50.0, 4.0));
+  tracker.onOrderFilled(makeOrder(4, 200, Side::BUY, 40.0, 4.0));
+
+  EXPECT_NEAR(tracker.getRealizedPnl(100).toDouble(), 100.0, 0.01);
+  EXPECT_NEAR(tracker.getRealizedPnl(200).toDouble(), 40.0, 0.01);
+  EXPECT_NEAR(tracker.getTotalRealizedPnl().toDouble(), 140.0, 0.01);
+}
+
+TEST_F(NetModeTest, ZeroFillDoesNothing)
+{
+  auto order = makeOrder(1, 100, Side::BUY, 100.0, 0.0);
+  tracker.onOrderPartiallyFilled(order, Quantity::fromDouble(0.0));
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 0.0);
+}
+
+TEST(NetModeLIFO, ClosesNewestFirst)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET, CostBasisMethod::LIFO};
+
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 1.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::BUY, 200.0, 1.0));
+  tracker.onOrderFilled(makeOrder(3, 100, Side::SELL, 250.0, 1.0));
+
+  EXPECT_NEAR(tracker.getRealizedPnl(100).toDouble(), 50.0, 0.01);
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 1.0);
+}
+
+TEST(NetModeFIFO, ClosesOldestFirst)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET, CostBasisMethod::FIFO};
+
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 1.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::BUY, 200.0, 1.0));
+  tracker.onOrderFilled(makeOrder(3, 100, Side::SELL, 250.0, 1.0));
+
+  EXPECT_NEAR(tracker.getRealizedPnl(100).toDouble(), 150.0, 0.01);
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 1.0);
+}
+
+TEST(NetModeAVERAGE, UsesAveragePrice)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET, CostBasisMethod::AVERAGE};
+
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 1.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::BUY, 200.0, 1.0));
+  tracker.onOrderFilled(makeOrder(3, 100, Side::SELL, 250.0, 1.0));
+
+  EXPECT_NEAR(tracker.getRealizedPnl(100).toDouble(), 100.0, 0.01);
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 1.0);
+}
+
+class PerSideModeTest : public ::testing::Test
+{
+ protected:
+  MultiModePositionTracker tracker{1, PositionAggregationMode::PER_SIDE, CostBasisMethod::FIFO};
+};
+
+TEST_F(PerSideModeTest, BuyOpensLong)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 50000.0, 1.0));
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 1.0);
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 0.0);
+}
+
+TEST_F(PerSideModeTest, SellOpensShort)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::SELL, 50000.0, 1.0));
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 0.0);
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 1.0);
+}
+
+TEST_F(PerSideModeTest, SimultaneousLongAndShort)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 50000.0, 2.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 51000.0, 1.0));
+
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 2.0);
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 1.0);
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 1.0);
+}
+
+TEST_F(PerSideModeTest, AvgEntryPricesAreSeparate)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 1.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::BUY, 200.0, 1.0));
+  tracker.onOrderFilled(makeOrder(3, 100, Side::SELL, 300.0, 1.0));
+
+  EXPECT_NEAR(tracker.getLongAvgEntry(100).toDouble(), 150.0, 0.01);
+  EXPECT_NEAR(tracker.getShortAvgEntry(100).toDouble(), 300.0, 0.01);
+}
+
+TEST_F(PerSideModeTest, SellToCloseLong)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 120.0, 3.0, true));
+
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 2.0);
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 0.0);
+  EXPECT_NEAR(tracker.getRealizedPnl(100).toDouble(), 60.0, 0.01);
+}
+
+TEST_F(PerSideModeTest, BuyToCloseShort)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::SELL, 200.0, 4.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::BUY, 180.0, 2.0, false, true));
+
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 2.0);
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 0.0);
+  EXPECT_NEAR(tracker.getRealizedPnl(100).toDouble(), 40.0, 0.01);
+}
+
+TEST_F(PerSideModeTest, CloseMoreThanAvailable)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 3.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 120.0, 5.0, true));
+
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 0.0);
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 0.0);
+  EXPECT_NEAR(tracker.getRealizedPnl(100).toDouble(), 60.0, 0.01);
+}
+
+TEST_F(PerSideModeTest, CloseWithNoOppositePositionOpensInstead)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::SELL, 100.0, 2.0));
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 2.0);
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 0.0);
+}
+
+TEST_F(PerSideModeTest, MultipleSymbolsPerSide)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 1.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 200.0, 2.0));
+  tracker.onOrderFilled(makeOrder(3, 200, Side::BUY, 50.0, 5.0));
+  tracker.onOrderFilled(makeOrder(4, 200, Side::SELL, 60.0, 3.0));
+
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 1.0);
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 2.0);
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(200).toDouble(), 5.0);
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(200).toDouble(), 3.0);
+}
+
+TEST_F(PerSideModeTest, PartialFillPerSide)
+{
+  auto order = makeOrder(1, 100, Side::BUY, 100.0, 10.0);
+  tracker.onOrderPartiallyFilled(order, Quantity::fromDouble(3.0));
+  tracker.onOrderPartiallyFilled(order, Quantity::fromDouble(4.0));
+
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 7.0);
+}
+
+TEST_F(PerSideModeTest, OpenLongExplicit)
+{
+  tracker.openLong(100, Price::fromDouble(100.0), Quantity::fromDouble(5.0));
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 5.0);
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 0.0);
+}
+
+TEST_F(PerSideModeTest, CloseLongExplicit)
+{
+  tracker.openLong(100, Price::fromDouble(100.0), Quantity::fromDouble(5.0));
+  tracker.closeLong(100, Price::fromDouble(120.0), Quantity::fromDouble(3.0));
+
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 2.0);
+  EXPECT_NEAR(tracker.getRealizedPnl(100).toDouble(), 60.0, 0.01);
+}
+
+TEST_F(PerSideModeTest, OpenShortExplicit)
+{
+  tracker.openShort(100, Price::fromDouble(200.0), Quantity::fromDouble(3.0));
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 3.0);
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 0.0);
+}
+
+TEST_F(PerSideModeTest, CloseShortExplicit)
+{
+  tracker.openShort(100, Price::fromDouble(200.0), Quantity::fromDouble(4.0));
+  tracker.closeShort(100, Price::fromDouble(180.0), Quantity::fromDouble(2.0));
+
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 2.0);
+  EXPECT_NEAR(tracker.getRealizedPnl(100).toDouble(), 40.0, 0.01);
+}
+
+TEST_F(PerSideModeTest, ExplicitFullRoundTrip)
+{
+  tracker.openLong(100, Price::fromDouble(100.0), Quantity::fromDouble(10.0));
+  tracker.openShort(100, Price::fromDouble(200.0), Quantity::fromDouble(5.0));
+
+  auto snap = tracker.snapshot(100);
+  EXPECT_DOUBLE_EQ(snap.longQty.toDouble(), 10.0);
+  EXPECT_DOUBLE_EQ(snap.shortQty.toDouble(), 5.0);
+
+  tracker.closeLong(100, Price::fromDouble(110.0), Quantity::fromDouble(10.0));
+  tracker.closeShort(100, Price::fromDouble(190.0), Quantity::fromDouble(5.0));
+
+  snap = tracker.snapshot(100);
+  EXPECT_DOUBLE_EQ(snap.longQty.toDouble(), 0.0);
+  EXPECT_DOUBLE_EQ(snap.shortQty.toDouble(), 0.0);
+  // long PnL = (110-100)*10 = 100, short PnL = (200-190)*5 = 50
+  EXPECT_NEAR(snap.realizedPnl.toDouble(), 150.0, 0.01);
+}
+
+TEST_F(PerSideModeTest, ExplicitWithTag)
+{
+  MultiModePositionTracker grouped{1, PositionAggregationMode::GROUPED};
+  grouped.openLong(100, Price::fromDouble(100.0), Quantity::fromDouble(5.0), 42);
+  grouped.closeLong(100, Price::fromDouble(120.0), Quantity::fromDouble(5.0), 42);
+
+  EXPECT_EQ(grouped.groups().openPositionCount(100), 0);
+  EXPECT_NEAR(grouped.getRealizedPnl(100).toDouble(), 100.0, 0.01);
+}
+
+TEST_F(PerSideModeTest, ReduceOnlyWithNoPositionIsNoop)
+{
+  // reduceOnly SELL with no long position -- should NOT open short
+  tracker.onOrderFilled(makeOrder(1, 100, Side::SELL, 100.0, 2.0, true));
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 0.0);
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 0.0);
+}
+
+class GroupedModeTest : public ::testing::Test
+{
+ protected:
+  MultiModePositionTracker tracker{1, PositionAggregationMode::GROUPED, CostBasisMethod::FIFO};
+};
+
+TEST_F(GroupedModeTest, EachOrderCreatesPosition)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 50000.0, 1.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::BUY, 51000.0, 0.5));
+
+  EXPECT_EQ(tracker.groups().openPositionCount(100), 2);
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 1.5);
+}
+
+TEST_F(GroupedModeTest, ManualGrouping)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 1.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::BUY, 200.0, 1.0));
+
+  auto& groups = tracker.groups();
+
+  auto* p1 = groups.getPositionByOrder(1);
+  auto* p2 = groups.getPositionByOrder(2);
+  ASSERT_NE(p1, nullptr);
+  ASSERT_NE(p2, nullptr);
+
+  GroupId gid = groups.createGroup();
+  groups.assignToGroup(p1->positionId, gid);
+  groups.assignToGroup(p2->positionId, gid);
+
+  EXPECT_DOUBLE_EQ(groups.groupNetPosition(gid).toDouble(), 2.0);
+}
+
+TEST_F(GroupedModeTest, SubGroups)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 1.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::BUY, 200.0, 1.0));
+  tracker.onOrderFilled(makeOrder(3, 100, Side::SELL, 150.0, 2.0));
+
+  auto& groups = tracker.groups();
+
+  GroupId parent = groups.createGroup();
+  GroupId child = groups.createGroup(parent);
+
+  groups.assignToGroup(groups.getPositionByOrder(1)->positionId, parent);
+  groups.assignToGroup(groups.getPositionByOrder(3)->positionId, child);
+
+  EXPECT_DOUBLE_EQ(groups.groupNetPosition(parent).toDouble(), -1.0);
+}
+
+TEST_F(GroupedModeTest, AutoGroupByOrderTag)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 1.0, false, false, 42));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::BUY, 200.0, 1.0, false, false, 42));
+  tracker.onOrderFilled(makeOrder(3, 100, Side::SELL, 150.0, 0.5, false, false, 99));
+
+  const auto& groups = tracker.groups();
+
+  auto* p1 = groups.getPositionByOrder(1);
+  auto* p2 = groups.getPositionByOrder(2);
+  auto* p3 = groups.getPositionByOrder(3);
+  ASSERT_NE(p1, nullptr);
+  ASSERT_NE(p2, nullptr);
+  ASSERT_NE(p3, nullptr);
+
+  EXPECT_EQ(p1->groupId, p2->groupId);
+  EXPECT_NE(p1->groupId, 0u);
+  EXPECT_NE(p3->groupId, p1->groupId);
+  EXPECT_NE(p3->groupId, 0u);
+}
+
+TEST_F(GroupedModeTest, CloseByTagWithReduceOnly)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0, false, false, 10));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 120.0, 3.0, true, false, 10));
+
+  const auto& groups = tracker.groups();
+  auto* p1 = groups.getPositionByOrder(1);
+  ASSERT_NE(p1, nullptr);
+  EXPECT_DOUBLE_EQ(p1->quantity.toDouble(), 2.0);
+  EXPECT_NEAR(p1->realizedPnl.toDouble(), 60.0, 0.01);
+}
+
+TEST_F(GroupedModeTest, CloseFullPositionByTag)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0, false, false, 10));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 130.0, 5.0, true, false, 10));
+
+  const auto& groups = tracker.groups();
+  auto* p1 = groups.getPositionByOrder(1);
+  ASSERT_NE(p1, nullptr);
+  EXPECT_TRUE(p1->closed);
+  EXPECT_NEAR(p1->realizedPnl.toDouble(), 150.0, 0.01);
+  EXPECT_EQ(groups.openPositionCount(100), 0);
+}
+
+TEST_F(GroupedModeTest, MultiplePositionsInGroup)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 3.0, false, false, 10));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::BUY, 200.0, 2.0, false, false, 10));
+  tracker.onOrderFilled(makeOrder(3, 100, Side::SELL, 150.0, 4.0, true, false, 10));
+
+  const auto& groups = tracker.groups();
+  auto* p1 = groups.getPositionByOrder(1);
+  auto* p2 = groups.getPositionByOrder(2);
+  ASSERT_NE(p1, nullptr);
+  ASSERT_NE(p2, nullptr);
+
+  EXPECT_TRUE(p1->closed);
+  EXPECT_NEAR(p1->realizedPnl.toDouble(), 150.0, 0.01);
+
+  EXPECT_FALSE(p2->closed);
+  EXPECT_DOUBLE_EQ(p2->quantity.toDouble(), 1.0);
+  EXPECT_NEAR(p2->realizedPnl.toDouble(), -50.0, 0.01);
+}
+
+TEST_F(GroupedModeTest, PartialFillSameOrder)
+{
+  auto order = makeOrder(1, 100, Side::BUY, 100.0, 10.0, false, false, 5);
+  tracker.onOrderPartiallyFilled(order, Quantity::fromDouble(3.0));
+  tracker.onOrderPartiallyFilled(order, Quantity::fromDouble(4.0));
+
+  const auto& groups = tracker.groups();
+  auto* p = groups.getPositionByOrder(1);
+  ASSERT_NE(p, nullptr);
+  EXPECT_DOUBLE_EQ(p->quantity.toDouble(), 7.0);
+}
+
+// Regression: reduceOnly with no tag should not create a position
+TEST_F(GroupedModeTest, ReduceOnlyWithNoTagDoesNotCreatePosition)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+  size_t before = tracker.groups().openPositionCount();
+
+  // Close order with reduceOnly but no tag -- should not create new position
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 120.0, 3.0, true));
+
+  EXPECT_EQ(tracker.groups().openPositionCount(), before);
+}
+
+// Regression: closePosition flag with no tag should not create position
+TEST_F(GroupedModeTest, ClosePositionFlagNoTagDoesNotCreate)
+{
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+  size_t before = tracker.groups().openPositionCount();
+
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 120.0, 3.0, false, true));
+
+  EXPECT_EQ(tracker.groups().openPositionCount(), before);
+}
+
+TEST(PositionGroupTrackerTest, OpenAndClosePosition)
+{
+  PositionGroupTracker gt;
+
+  PositionId pid = gt.openPosition(42, 100, Side::BUY, Price::fromDouble(100.0),
+                                   Quantity::fromDouble(5.0));
+  EXPECT_EQ(gt.openPositionCount(), 1);
+  EXPECT_DOUBLE_EQ(gt.netPosition(100).toDouble(), 5.0);
+
+  gt.closePosition(pid, Price::fromDouble(110.0));
+  EXPECT_EQ(gt.openPositionCount(), 0);
+  EXPECT_NEAR(gt.totalRealizedPnl().toDouble(), 50.0, 0.01);
+}
+
+TEST(PositionGroupTrackerTest, PartialClosePosition)
+{
+  PositionGroupTracker gt;
+
+  PositionId pid = gt.openPosition(1, 100, Side::BUY, Price::fromDouble(100.0),
+                                   Quantity::fromDouble(10.0));
+  gt.partialClose(pid, Quantity::fromDouble(4.0), Price::fromDouble(120.0));
+
+  auto* pos = gt.getPosition(pid);
+  ASSERT_NE(pos, nullptr);
+  EXPECT_FALSE(pos->closed);
+  EXPECT_DOUBLE_EQ(pos->quantity.toDouble(), 6.0);
+  EXPECT_NEAR(pos->realizedPnl.toDouble(), 80.0, 0.01);
+}
+
+TEST(PositionGroupTrackerTest, PartialCloseThenFullClose)
+{
+  PositionGroupTracker gt;
+
+  PositionId pid = gt.openPosition(1, 100, Side::BUY, Price::fromDouble(100.0),
+                                   Quantity::fromDouble(10.0));
+  gt.partialClose(pid, Quantity::fromDouble(6.0), Price::fromDouble(120.0));
+  gt.partialClose(pid, Quantity::fromDouble(4.0), Price::fromDouble(130.0));
+
+  auto* pos = gt.getPosition(pid);
+  ASSERT_NE(pos, nullptr);
+  EXPECT_TRUE(pos->closed);
+  EXPECT_NEAR(pos->realizedPnl.toDouble(), 240.0, 0.01);
+}
+
+TEST(PositionGroupTrackerTest, ShortPositionPnl)
+{
+  PositionGroupTracker gt;
+
+  PositionId pid = gt.openPosition(1, 100, Side::SELL, Price::fromDouble(200.0),
+                                   Quantity::fromDouble(3.0));
+  gt.closePosition(pid, Price::fromDouble(180.0));
+  EXPECT_NEAR(gt.totalRealizedPnl().toDouble(), 60.0, 0.01);
+}
+
+TEST(PositionGroupTrackerTest, ShortPositionLoss)
+{
+  PositionGroupTracker gt;
+
+  PositionId pid = gt.openPosition(1, 100, Side::SELL, Price::fromDouble(200.0),
+                                   Quantity::fromDouble(3.0));
+  gt.closePosition(pid, Price::fromDouble(220.0));
+  EXPECT_NEAR(gt.totalRealizedPnl().toDouble(), -60.0, 0.01);
+}
+
+TEST(PositionGroupTrackerTest, PruneClosedPositions)
+{
+  PositionGroupTracker gt;
+
+  gt.openPosition(1, 100, Side::BUY, Price::fromDouble(100.0), Quantity::fromDouble(1.0));
+  PositionId pid2 = gt.openPosition(2, 100, Side::BUY, Price::fromDouble(200.0),
+                                    Quantity::fromDouble(1.0));
+
+  gt.closePosition(pid2, Price::fromDouble(210.0));
+  gt.pruneClosedPositions();
+
+  EXPECT_EQ(gt.openPositionCount(), 1);
+  EXPECT_EQ(gt.getPositionByOrder(2), nullptr);
+  EXPECT_NE(gt.getPositionByOrder(1), nullptr);
+}
+
+// Regression: prune should clean up stale IDs in groups
+TEST(PositionGroupTrackerTest, PruneCleanupGroupRefs)
+{
+  PositionGroupTracker gt;
+
+  PositionId p1 = gt.openPosition(1, 100, Side::BUY, Price::fromDouble(100.0),
+                                  Quantity::fromDouble(1.0));
+  PositionId p2 = gt.openPosition(2, 100, Side::BUY, Price::fromDouble(200.0),
+                                  Quantity::fromDouble(1.0));
+
+  GroupId gid = gt.createGroup();
+  gt.assignToGroup(p1, gid);
+  gt.assignToGroup(p2, gid);
+
+  gt.closePosition(p2, Price::fromDouble(210.0));
+  gt.pruneClosedPositions();
+
+  const auto* group = gt.getGroup(gid);
+  ASSERT_NE(group, nullptr);
+  // After prune, only p1 should remain in group
+  EXPECT_EQ(group->positionIds.size(), 1);
+  EXPECT_EQ(group->positionIds[0], p1);
+}
+
+TEST(PositionGroupTrackerTest, MultipleSymbolNetPosition)
+{
+  PositionGroupTracker gt;
+
+  gt.openPosition(1, 100, Side::BUY, Price::fromDouble(100.0), Quantity::fromDouble(3.0));
+  gt.openPosition(2, 100, Side::SELL, Price::fromDouble(110.0), Quantity::fromDouble(1.0));
+  gt.openPosition(3, 200, Side::SELL, Price::fromDouble(50.0), Quantity::fromDouble(5.0));
+
+  EXPECT_DOUBLE_EQ(gt.netPosition(100).toDouble(), 2.0);
+  EXPECT_DOUBLE_EQ(gt.netPosition(200).toDouble(), -5.0);
+  EXPECT_EQ(gt.openPositionCount(100), 2);
+  EXPECT_EQ(gt.openPositionCount(200), 1);
+}
+
+TEST(PositionGroupTrackerTest, GroupPnlRecursive)
+{
+  PositionGroupTracker gt;
+
+  PositionId p1 = gt.openPosition(1, 100, Side::BUY, Price::fromDouble(100.0),
+                                  Quantity::fromDouble(1.0));
+  PositionId p2 = gt.openPosition(2, 100, Side::BUY, Price::fromDouble(200.0),
+                                  Quantity::fromDouble(1.0));
+  PositionId p3 = gt.openPosition(3, 100, Side::BUY, Price::fromDouble(300.0),
+                                  Quantity::fromDouble(1.0));
+
+  GroupId parent = gt.createGroup();
+  GroupId child = gt.createGroup(parent);
+
+  gt.assignToGroup(p1, parent);
+  gt.assignToGroup(p2, child);
+  gt.assignToGroup(p3, child);
+
+  gt.closePosition(p1, Price::fromDouble(150.0));
+  gt.closePosition(p2, Price::fromDouble(180.0));
+  gt.closePosition(p3, Price::fromDouble(350.0));
+
+  EXPECT_NEAR(gt.groupRealizedPnl(child).toDouble(), 30.0, 0.01);
+  EXPECT_NEAR(gt.groupRealizedPnl(parent).toDouble(), 80.0, 0.01);
+}
+
+TEST(PositionGroupTrackerTest, ForEachOpen)
+{
+  PositionGroupTracker gt;
+
+  gt.openPosition(1, 100, Side::BUY, Price::fromDouble(100.0), Quantity::fromDouble(1.0));
+  PositionId p2 = gt.openPosition(2, 100, Side::SELL, Price::fromDouble(200.0),
+                                  Quantity::fromDouble(2.0));
+  gt.openPosition(3, 200, Side::BUY, Price::fromDouble(300.0), Quantity::fromDouble(3.0));
+
+  gt.closePosition(p2, Price::fromDouble(190.0));
+
+  int count = 0;
+  gt.forEachOpen([&count](const IndividualPosition& pos)
+                 {
+    (void)pos;
+    ++count; });
+  EXPECT_EQ(count, 2);
+}
+
+TEST(PositionReconcilerTest, DetectsMismatch)
+{
+  PositionReconciler reconciler;
+
+  std::vector<ExchangePosition> exchange = {
+      {100, Quantity::fromDouble(5.0), Price::fromDouble(100.0)},
+  };
+
+  auto mismatches = reconciler.reconcile(exchange,
+                                         [](SymbolId) -> std::pair<Quantity, Price>
+                                         {
+                                           return {Quantity::fromDouble(3.0), Price::fromDouble(100.0)};
+                                         });
+
+  ASSERT_EQ(mismatches.size(), 1);
+  EXPECT_DOUBLE_EQ(mismatches[0].exchangeQuantity.toDouble(), 5.0);
+  EXPECT_DOUBLE_EQ(mismatches[0].localQuantity.toDouble(), 3.0);
+  EXPECT_DOUBLE_EQ(mismatches[0].quantityDiff().toDouble(), 2.0);
+}
+
+TEST(PositionReconcilerTest, NoMismatchWhenMatching)
+{
+  PositionReconciler reconciler;
+
+  std::vector<ExchangePosition> exchange = {
+      {100, Quantity::fromDouble(5.0), Price::fromDouble(100.0)},
+  };
+
+  auto mismatches = reconciler.reconcile(exchange,
+                                         [](SymbolId) -> std::pair<Quantity, Price>
+                                         {
+                                           return {Quantity::fromDouble(5.0), Price::fromDouble(100.0)};
+                                         });
+
+  EXPECT_TRUE(mismatches.empty());
+}
+
+TEST(PositionReconcilerTest, ReconcileAndApply)
+{
+  PositionReconciler reconciler;
+  reconciler.setMismatchHandler([](const PositionMismatch&)
+                                { return ReconcileAction::ACCEPT_EXCHANGE; });
+
+  std::vector<ExchangePosition> exchange = {
+      {100, Quantity::fromDouble(5.0), Price::fromDouble(100.0)},
+  };
+
+  Quantity adjustedQty{};
+  Price adjustedPrice{};
+
+  reconciler.reconcileAndApply(exchange, [](SymbolId) -> std::pair<Quantity, Price>
+                               { return {Quantity::fromDouble(3.0), Price::fromDouble(95.0)}; }, [&](SymbolId, Quantity qty, Price price)
+                               {
+      adjustedQty = qty;
+      adjustedPrice = price; });
+
+  EXPECT_DOUBLE_EQ(adjustedQty.toDouble(), 5.0);
+  EXPECT_DOUBLE_EQ(adjustedPrice.toDouble(), 100.0);
+}
+
+TEST(PositionReconcilerTest, FlagOnlyDoesNotAdjust)
+{
+  PositionReconciler reconciler;
+  reconciler.setMismatchHandler([](const PositionMismatch&)
+                                { return ReconcileAction::FLAG_ONLY; });
+
+  std::vector<ExchangePosition> exchange = {
+      {100, Quantity::fromDouble(5.0), Price::fromDouble(100.0)},
+  };
+
+  bool adjustCalled = false;
+
+  reconciler.reconcileAndApply(exchange, [](SymbolId) -> std::pair<Quantity, Price>
+                               { return {Quantity::fromDouble(3.0), Price::fromDouble(95.0)}; }, [&](SymbolId, Quantity, Price)
+                               { adjustCalled = true; });
+
+  EXPECT_FALSE(adjustCalled);
+}
+
+TEST(PositionReconcilerTest, AcceptLocalSkipsAdjust)
+{
+  PositionReconciler reconciler;
+  reconciler.setMismatchHandler([](const PositionMismatch&)
+                                { return ReconcileAction::ACCEPT_LOCAL; });
+
+  std::vector<ExchangePosition> exchange = {
+      {100, Quantity::fromDouble(5.0), Price::fromDouble(100.0)},
+  };
+
+  bool adjustCalled = false;
+
+  auto mismatches = reconciler.reconcileAndApply(exchange, [](SymbolId) -> std::pair<Quantity, Price>
+                                                 { return {Quantity::fromDouble(3.0), Price::fromDouble(95.0)}; }, [&](SymbolId, Quantity, Price)
+                                                 { adjustCalled = true; });
+
+  EXPECT_FALSE(adjustCalled);
+  EXPECT_EQ(mismatches.size(), 1);
+}
+
+TEST(PositionReconcilerTest, MultipleSymbolReconciliation)
+{
+  PositionReconciler reconciler;
+  reconciler.setMismatchHandler([](const PositionMismatch&)
+                                { return ReconcileAction::ACCEPT_EXCHANGE; });
+
+  std::vector<ExchangePosition> exchange = {
+      {100, Quantity::fromDouble(5.0), Price::fromDouble(100.0)},
+      {200, Quantity::fromDouble(3.0), Price::fromDouble(50.0)},
+      {300, Quantity::fromDouble(10.0), Price::fromDouble(200.0)},
+  };
+
+  std::vector<std::pair<SymbolId, Quantity>> adjustments;
+
+  reconciler.reconcileAndApply(exchange, [](SymbolId sym) -> std::pair<Quantity, Price>
+                               {
+      if (sym == 100){ return {Quantity::fromDouble(5.0), Price::fromDouble(100.0)};
+}
+      if (sym == 200){ return {Quantity::fromDouble(1.0), Price::fromDouble(50.0)};
+}
+      return {Quantity::fromDouble(8.0), Price::fromDouble(200.0)}; }, [&](SymbolId sym, Quantity qty, Price)
+                               { adjustments.emplace_back(sym, qty); });
+
+  ASSERT_EQ(adjustments.size(), 2);
+  EXPECT_EQ(adjustments[0].first, 200u);
+  EXPECT_DOUBLE_EQ(adjustments[0].second.toDouble(), 3.0);
+  EXPECT_EQ(adjustments[1].first, 300u);
+  EXPECT_DOUBLE_EQ(adjustments[1].second.toDouble(), 10.0);
+}
+
+TEST(PositionReconcilerTest, ReconcileWithRealTracker)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET, CostBasisMethod::FIFO};
+  PositionReconciler reconciler;
+
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 3.0));
+
+  std::vector<ExchangePosition> exchange = {
+      {100, Quantity::fromDouble(5.0), Price::fromDouble(100.0)},
+  };
+
+  auto mismatches = reconciler.reconcile(exchange,
+                                         [&](SymbolId sym) -> std::pair<Quantity, Price>
+                                         {
+                                           return {tracker.getPosition(sym), Price::fromDouble(100.0)};
+                                         });
+
+  ASSERT_EQ(mismatches.size(), 1);
+  EXPECT_DOUBLE_EQ(mismatches[0].localQuantity.toDouble(), 3.0);
+  EXPECT_DOUBLE_EQ(mismatches[0].exchangeQuantity.toDouble(), 5.0);
+}
+
+// Regression: bidirectional reconciliation detects local-only positions
+TEST(PositionReconcilerTest, BidirectionalDetectsLocalOnly)
+{
+  PositionReconciler reconciler;
+
+  std::vector<ExchangePosition> exchange = {
+      {100, Quantity::fromDouble(5.0), Price::fromDouble(100.0)},
+  };
+
+  auto mismatches = reconciler.reconcile(exchange,
+                                         [](SymbolId sym) -> std::pair<Quantity, Price>
+                                         {
+                                           if (sym == 100)
+                                           {
+                                             return {Quantity::fromDouble(5.0), Price::fromDouble(100.0)};
+                                           }
+                                           if (sym == 200)
+                                           {
+                                             return {Quantity::fromDouble(3.0), Price::fromDouble(50.0)};
+                                           }
+                                           return {Quantity{}, Price{}};
+                                         },
+                                         {100, 200});
+
+  ASSERT_EQ(mismatches.size(), 1);
+  EXPECT_EQ(mismatches[0].symbol, 200u);
+  EXPECT_DOUBLE_EQ(mismatches[0].localQuantity.toDouble(), 3.0);
+  EXPECT_DOUBLE_EQ(mismatches[0].exchangeQuantity.toDouble(), 0.0);
+}
+
+// Regression: bidirectional with zero local position is not a mismatch
+TEST(PositionReconcilerTest, BidirectionalIgnoresZeroLocalPositions)
+{
+  PositionReconciler reconciler;
+
+  std::vector<ExchangePosition> exchange = {};
+
+  auto mismatches = reconciler.reconcile(exchange,
+                                         [](SymbolId) -> std::pair<Quantity, Price>
+                                         {
+                                           return {Quantity{}, Price{}};
+                                         },
+                                         {100, 200});
+
+  EXPECT_TRUE(mismatches.empty());
+}
+
+TEST(MultiExecutionListenerTest, DistributesToAllTrackers)
+{
+  MultiExecutionListener dist{0};
+  auto net = std::make_shared<MultiModePositionTracker>(1, PositionAggregationMode::NET);
+  auto perSide = std::make_shared<MultiModePositionTracker>(2, PositionAggregationMode::PER_SIDE);
+  auto grouped = std::make_shared<MultiModePositionTracker>(3, PositionAggregationMode::GROUPED);
+
+  dist.addListener(net.get());
+  dist.addListener(perSide.get());
+  dist.addListener(grouped.get());
+
+  dist.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+
+  EXPECT_DOUBLE_EQ(net->getPosition(100).toDouble(), 5.0);
+  EXPECT_DOUBLE_EQ(perSide->getLongPosition(100).toDouble(), 5.0);
+  EXPECT_DOUBLE_EQ(grouped->getPosition(100).toDouble(), 5.0);
+}
+
+TEST(MultiExecutionListenerTest, PartialFillDistributed)
+{
+  MultiExecutionListener dist{0};
+  auto net = std::make_shared<MultiModePositionTracker>(1, PositionAggregationMode::NET);
+  auto grouped = std::make_shared<MultiModePositionTracker>(2, PositionAggregationMode::GROUPED);
+  dist.addListener(net.get());
+  dist.addListener(grouped.get());
+
+  auto order = makeOrder(1, 100, Side::BUY, 100.0, 10.0);
+  dist.onOrderPartiallyFilled(order, Quantity::fromDouble(3.0));
+  dist.onOrderPartiallyFilled(order, Quantity::fromDouble(4.0));
+
+  EXPECT_DOUBLE_EQ(net->getPosition(100).toDouble(), 7.0);
+  EXPECT_DOUBLE_EQ(grouped->getPosition(100).toDouble(), 7.0);
+}
+
+TEST(MultiExecutionListenerTest, CancelDistributed)
+{
+  MultiExecutionListener dist{0};
+  auto grouped = std::make_shared<MultiModePositionTracker>(1, PositionAggregationMode::GROUPED);
+  dist.addListener(grouped.get());
+
+  auto order = makeOrder(1, 100, Side::BUY, 100.0, 5.0);
+  dist.onOrderFilled(order);
+
+  EXPECT_EQ(grouped->groups().openPositionCount(), 1);
+}
+
+TEST(MultiExecutionListenerTest, ConsistentPnlAcrossTrackers)
+{
+  MultiExecutionListener dist{0};
+  auto net = std::make_shared<MultiModePositionTracker>(1, PositionAggregationMode::NET);
+  auto perSide = std::make_shared<MultiModePositionTracker>(2, PositionAggregationMode::PER_SIDE);
+  dist.addListener(net.get());
+  dist.addListener(perSide.get());
+
+  dist.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 10.0));
+  dist.onOrderFilled(makeOrder(2, 100, Side::SELL, 110.0, 10.0, true));
+
+  double netPnl = net->getRealizedPnl(100).toDouble();
+  double perSidePnl = perSide->getRealizedPnl(100).toDouble();
+  EXPECT_NEAR(netPnl, 100.0, 0.01);
+  EXPECT_NEAR(perSidePnl, 100.0, 0.01);
+}
+
+TEST(SnapshotTest, NetModeSnapshot)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+
+  auto snap = tracker.snapshot(100);
+  EXPECT_DOUBLE_EQ(snap.longQty.toDouble(), 5.0);
+  EXPECT_DOUBLE_EQ(snap.shortQty.toDouble(), 0.0);
+  EXPECT_NEAR(snap.longAvgEntry.toDouble(), 100.0, 0.01);
+  EXPECT_DOUBLE_EQ(snap.netQty().toDouble(), 5.0);
+}
+
+TEST(SnapshotTest, NetModeShortSnapshot)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::SELL, 200.0, 3.0));
+
+  auto snap = tracker.snapshot(100);
+  EXPECT_DOUBLE_EQ(snap.longQty.toDouble(), 0.0);
+  EXPECT_DOUBLE_EQ(snap.shortQty.toDouble(), 3.0);
+  EXPECT_NEAR(snap.shortAvgEntry.toDouble(), 200.0, 0.01);
+  EXPECT_DOUBLE_EQ(snap.netQty().toDouble(), -3.0);
+}
+
+TEST(SnapshotTest, PerSideSnapshot)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::PER_SIDE};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 200.0, 3.0));
+
+  auto snap = tracker.snapshot(100);
+  EXPECT_DOUBLE_EQ(snap.longQty.toDouble(), 5.0);
+  EXPECT_DOUBLE_EQ(snap.shortQty.toDouble(), 3.0);
+  EXPECT_NEAR(snap.longAvgEntry.toDouble(), 100.0, 0.01);
+  EXPECT_NEAR(snap.shortAvgEntry.toDouble(), 200.0, 0.01);
+  EXPECT_DOUBLE_EQ(snap.netQty().toDouble(), 2.0);
+}
+
+TEST(SnapshotTest, GroupedSnapshot)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::GROUPED};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 3.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 200.0, 1.0));
+
+  auto snap = tracker.snapshot(100);
+  EXPECT_DOUBLE_EQ(snap.longQty.toDouble(), 3.0);
+  EXPECT_DOUBLE_EQ(snap.shortQty.toDouble(), 1.0);
+  EXPECT_NEAR(snap.longAvgEntry.toDouble(), 100.0, 0.01);
+  EXPECT_NEAR(snap.shortAvgEntry.toDouble(), 200.0, 0.01);
+}
+
+TEST(SnapshotTest, UnrealizedPnlLong)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 10.0));
+
+  auto upnl = tracker.getUnrealizedPnl(100, Price::fromDouble(120.0));
+  EXPECT_NEAR(upnl.toDouble(), 200.0, 0.01);
+}
+
+TEST(SnapshotTest, UnrealizedPnlShort)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::SELL, 200.0, 5.0));
+
+  auto upnl = tracker.getUnrealizedPnl(100, Price::fromDouble(180.0));
+  EXPECT_NEAR(upnl.toDouble(), 100.0, 0.01);
+}
+
+TEST(SnapshotTest, UnrealizedPnlPerSideBothSides)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::PER_SIDE};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+  tracker.onOrderFilled(makeOrder(2, 100, Side::SELL, 200.0, 3.0));
+
+  // Price at 150: long profit = (150-100)*5=250, short loss = (200-150)*3=150
+  auto upnl = tracker.getUnrealizedPnl(100, Price::fromDouble(150.0));
+  EXPECT_NEAR(upnl.toDouble(), 400.0, 0.01);
+}
+
+TEST(SnapshotTest, EmptyPositionSnapshotIsZero)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+  auto snap = tracker.snapshot(100);
+  EXPECT_DOUBLE_EQ(snap.longQty.toDouble(), 0.0);
+  EXPECT_DOUBLE_EQ(snap.shortQty.toDouble(), 0.0);
+  EXPECT_DOUBLE_EQ(snap.unrealizedPnl(Price::fromDouble(100.0)).toDouble(), 0.0);
+}
+
+TEST(GroupedQueryTest, GetOpenPositionsBySymbol)
+{
+  PositionGroupTracker gt;
+  gt.openPosition(1, 100, Side::BUY, Price::fromDouble(100.0), Quantity::fromDouble(1.0));
+  gt.openPosition(2, 100, Side::SELL, Price::fromDouble(200.0), Quantity::fromDouble(2.0));
+  gt.openPosition(3, 200, Side::BUY, Price::fromDouble(50.0), Quantity::fromDouble(3.0));
+  PositionId p4 = gt.openPosition(4, 100, Side::BUY, Price::fromDouble(150.0), Quantity::fromDouble(1.0));
+  gt.closePosition(p4, Price::fromDouble(160.0));
+
+  auto positions = gt.getOpenPositions(100);
+  EXPECT_EQ(positions.size(), 2);
+
+  auto positions200 = gt.getOpenPositions(200);
+  EXPECT_EQ(positions200.size(), 1);
+}
+
+TEST(ReconcileConvenienceTest, ReconcileWithTracker)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 3.0));
+
+  PositionReconciler reconciler;
+  std::vector<ExchangePosition> exchange = {
+      {100, Quantity::fromDouble(5.0), Price::fromDouble(100.0)},
+  };
+
+  auto mismatches = reconcileWith(reconciler, tracker, exchange);
+  ASSERT_EQ(mismatches.size(), 1);
+  EXPECT_DOUBLE_EQ(mismatches[0].localQuantity.toDouble(), 3.0);
+  EXPECT_DOUBLE_EQ(mismatches[0].exchangeQuantity.toDouble(), 5.0);
+}
+
+TEST(ReconcileConvenienceTest, ReconcileWithMatchingPositions)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+
+  PositionReconciler reconciler;
+  std::vector<ExchangePosition> exchange = {
+      {100, Quantity::fromDouble(5.0), Price::fromDouble(100.0)},
+  };
+
+  auto mismatches = reconcileWith(reconciler, tracker, exchange);
+  EXPECT_TRUE(mismatches.empty());
+}
+
+TEST(ResetTest, NetModeReset)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 5.0);
+
+  tracker.reset();
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 0.0);
+  EXPECT_DOUBLE_EQ(tracker.getRealizedPnl(100).toDouble(), 0.0);
+}
+
+TEST(ResetTest, PerSideReset)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::PER_SIDE};
+  tracker.openLong(100, Price::fromDouble(100.0), Quantity::fromDouble(5.0));
+  tracker.openShort(100, Price::fromDouble(200.0), Quantity::fromDouble(3.0));
+
+  tracker.reset();
+  EXPECT_DOUBLE_EQ(tracker.getLongPosition(100).toDouble(), 0.0);
+  EXPECT_DOUBLE_EQ(tracker.getShortPosition(100).toDouble(), 0.0);
+}
+
+TEST(ResetTest, GroupedReset)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::GROUPED};
+  tracker.openLong(100, Price::fromDouble(100.0), Quantity::fromDouble(1.0), 10);
+  tracker.openLong(100, Price::fromDouble(200.0), Quantity::fromDouble(1.0), 10);
+
+  tracker.reset();
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 0.0);
+  EXPECT_EQ(tracker.groups().openPositionCount(), 0);
+}
+
+TEST(PositionChangeCallbackTest, FiresOnFill)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+
+  SymbolId capturedSym{};
+  double capturedQty = 0;
+  tracker.onPositionChange([&](SymbolId sym, const MultiModePositionTracker::PositionSnapshot& snap)
+                           {
+    capturedSym = sym;
+    capturedQty = snap.netQty().toDouble(); });
+
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+  EXPECT_EQ(capturedSym, 100u);
+  EXPECT_DOUBLE_EQ(capturedQty, 5.0);
+}
+
+TEST(PositionChangeCallbackTest, FiresOnExplicitFill)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::PER_SIDE};
+
+  int callCount = 0;
+  tracker.onPositionChange([&](SymbolId, const MultiModePositionTracker::PositionSnapshot&)
+                           { ++callCount; });
+
+  tracker.openLong(100, Price::fromDouble(100.0), Quantity::fromDouble(5.0));
+  tracker.closeLong(100, Price::fromDouble(110.0), Quantity::fromDouble(5.0));
+  EXPECT_EQ(callCount, 2);
+}
+
+TEST(PositionChangeCallbackTest, NoCallbackNoCrash)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 5.0));
+  EXPECT_DOUBLE_EQ(tracker.getPosition(100).toDouble(), 5.0);
+}
+
+TEST(GroupUnrealizedPnlTest, SingleGroup)
+{
+  PositionGroupTracker gt;
+  PositionId p1 = gt.openPosition(1, 100, Side::BUY, Price::fromDouble(100.0),
+                                  Quantity::fromDouble(5.0));
+  PositionId p2 = gt.openPosition(2, 100, Side::SELL, Price::fromDouble(200.0),
+                                  Quantity::fromDouble(3.0));
+
+  GroupId gid = gt.createGroup();
+  gt.assignToGroup(p1, gid);
+  gt.assignToGroup(p2, gid);
+
+  // Price at 150: long uPnL = (150-100)*5 = 250, short uPnL = -(150-200)*3 = 150
+  auto upnl = gt.groupUnrealizedPnl(gid, Price::fromDouble(150.0));
+  EXPECT_NEAR(upnl.toDouble(), 400.0, 0.01);
+}
+
+TEST(GroupUnrealizedPnlTest, RecursiveSubGroups)
+{
+  PositionGroupTracker gt;
+  PositionId p1 = gt.openPosition(1, 100, Side::BUY, Price::fromDouble(100.0),
+                                  Quantity::fromDouble(1.0));
+  PositionId p2 = gt.openPosition(2, 100, Side::BUY, Price::fromDouble(200.0),
+                                  Quantity::fromDouble(1.0));
+
+  GroupId parent = gt.createGroup();
+  GroupId child = gt.createGroup(parent);
+  gt.assignToGroup(p1, parent);
+  gt.assignToGroup(p2, child);
+
+  // Price 150: p1 uPnL = 50, p2 uPnL = -50. Total = 0
+  auto upnl = gt.groupUnrealizedPnl(parent, Price::fromDouble(150.0));
+  EXPECT_NEAR(upnl.toDouble(), 0.0, 0.01);
+}
+
+TEST(LockedGroupsTest, ThreadSafeAccess)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::GROUPED};
+  tracker.openLong(100, Price::fromDouble(100.0), Quantity::fromDouble(5.0));
+
+  auto positions = tracker.lockedGroups()->getOpenPositions(100);
+  EXPECT_EQ(positions.size(), 1);
+}
+
+TEST(AtomicReconcileTest, ReconcileMethodOnTracker)
+{
+  MultiModePositionTracker tracker{1, PositionAggregationMode::NET};
+  tracker.onOrderFilled(makeOrder(1, 100, Side::BUY, 100.0, 3.0));
+
+  PositionReconciler reconciler;
+  std::vector<ExchangePosition> exchange = {
+      {100, Quantity::fromDouble(5.0), Price::fromDouble(100.0)},
+  };
+
+  auto mismatches = tracker.reconcile(reconciler, exchange);
+  ASSERT_EQ(mismatches.size(), 1);
+  EXPECT_DOUBLE_EQ(mismatches[0].localQuantity.toDouble(), 3.0);
+  EXPECT_DOUBLE_EQ(mismatches[0].exchangeQuantity.toDouble(), 5.0);
+}


### PR DESCRIPTION
Closes #80.

Three aggregation modes:
- NET: single net position, auto open/close/flip
- PER_SIDE: separate long/short with explicit intent (openLong/closeLong/openShort/closeShort)
- GROUPED: per-order positions with tag-based grouping for OCO/OTO/OTOCO

Also includes:
- Exchange position reconciliation (bidirectional)
- Atomic snapshot API with unrealized PnL
- Position change callback