### PR TITLE
Indicator framework + python bindings

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -1,0 +1,87 @@
+name: Build Python wheels
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      publish_testpypi:
+        description: "Publish to TestPyPI"
+        type: boolean
+        default: false
+
+jobs:
+  build-wheels:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14, macos-13, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install cibuildwheel
+        run: pip install cibuildwheel==2.22.0
+
+      - name: Build wheels
+        run: cibuildwheel --output-dir wheelhouse python/
+        env:
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_SKIP: "*-musllinux_* pp*"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_WINDOWS: "AMD64"
+          CIBW_BUILD_VERBOSITY: 1
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  build-sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build --sdist python/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: python/dist/*.tar.gz
+
+  publish-testpypi:
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    if: github.event.inputs.publish_testpypi == 'true'
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,11 @@ if (FLOX_ENABLE_TOOLS)
   add_subdirectory(tools)
 endif()
 
+option(FLOX_ENABLE_PYTHON "Build Python bindings" OFF)
+if (FLOX_ENABLE_PYTHON)
+  add_subdirectory(python)
+endif()
+
 target_include_directories(flox PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>

--- a/docs/how-to/indicator-graph.md
+++ b/docs/how-to/indicator-graph.md
@@ -1,0 +1,76 @@
+# Indicator graph
+
+When multiple strategies use the same indicator (e.g. ATR used by both ADX and a normalized slope), `IndicatorGraph` computes it once and caches the result.
+
+## Setup
+
+```cpp
+#include "flox/indicator/indicator_pipeline.h"
+#include "flox/indicator/ema.h"
+#include "flox/indicator/atr.h"
+#include "flox/indicator/slope.h"
+
+using namespace flox;
+using namespace flox::indicator;
+
+IndicatorGraph g;
+g.setBars(symbolId, bars);
+```
+
+## Registering nodes
+
+Each node has a name, a list of dependencies, and a compute function.
+
+```cpp
+g.addNode("atr14", {}, [](IndicatorGraph& g, SymbolId sym) {
+    return ATR(14).compute(g.high(sym), g.low(sym), g.close(sym));
+});
+
+g.addNode("ema50", {}, [](IndicatorGraph& g, SymbolId sym) {
+    return EMA(50).compute(g.close(sym));
+});
+
+g.addNode("norm_slope", {"ema50", "atr14"}, [](IndicatorGraph& g, SymbolId sym) {
+    auto& ema = *g.get(sym, "ema50");
+    auto& atr = *g.get(sym, "atr14");
+    auto slope = Slope(1).compute(ema);
+    std::vector<double> out(slope.size());
+    for (size_t i = 0; i < slope.size(); ++i) {
+        out[i] = (atr[i] > 0 && !std::isnan(slope[i])) ? slope[i] / atr[i] : 0.0;
+    }
+    return out;
+});
+```
+
+## Computing
+
+`require()` resolves dependencies recursively. Only computes what's needed.
+
+```cpp
+auto& result = g.require(symbolId, "norm_slope");
+// atr14 and ema50 computed automatically before norm_slope
+```
+
+Already-computed nodes are returned from cache. Circular dependencies throw `std::logic_error`.
+
+## Invalidation
+
+When new data arrives, call `invalidate()` to clear cached results for a symbol.
+
+```cpp
+g.setBars(symbolId, newBars);  // also invalidates
+// next require() recomputes everything
+```
+
+## Multi-symbol
+
+The graph is per-symbol. Different symbols have independent caches.
+
+```cpp
+g.setBars(0, btcBars);
+g.setBars(1, ethBars);
+
+auto& btcSlope = g.require(0, "norm_slope");
+auto& ethSlope = g.require(1, "norm_slope");
+// computed independently, cached separately
+```

--- a/docs/how-to/multi-symbol-indicators.md
+++ b/docs/how-to/multi-symbol-indicators.md
@@ -1,0 +1,38 @@
+# Multi-symbol indicators
+
+Run the same indicator pipeline across multiple symbols in parallel.
+
+## Partitioning
+
+Split a flat bar array or BarEvent stream into per-symbol groups.
+
+```cpp
+#include "flox/indicator/multi_symbol.h"
+using namespace flox::indicator;
+
+// from BarEvents (carries symbol ID)
+auto data = partitionBySymbol(barEvents);
+
+// from parallel arrays
+auto data = partitionBySymbol(bars, symbolIds);
+```
+
+## Sequential
+
+```cpp
+forEachSymbol(data, [](SymbolId sym, std::span<const Bar> bars) {
+    auto ema = EMA(50).compute(indicator::close(bars));
+    // ...
+});
+```
+
+## Parallel
+
+Same API, runs on a thread pool. The function must be thread-safe (no shared mutable state).
+
+```cpp
+forEachSymbolParallel(data, [](SymbolId sym, std::span<const Bar> bars) {
+    auto ema = EMA(50).compute(indicator::close(bars));
+    // ...
+}, 0);  // 0 = all cores
+```

--- a/docs/how-to/python-bindings.md
+++ b/docs/how-to/python-bindings.md
@@ -1,0 +1,168 @@
+# Python Bindings
+
+Run Flox backtests from Python. Strategies stay in Python (numpy/pandas), execution runs in C++ with GIL released and multi-threaded batch support.
+
+## Build
+
+```bash
+cmake -B build \
+  -DFLOX_ENABLE_BACKTEST=ON \
+  -DFLOX_ENABLE_PYTHON=ON \
+  -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build
+```
+
+Requires: Python 3.9+, pybind11, numpy (`pip install pybind11 numpy`).
+
+The module builds at `build/python/flox_py.cpython-*.so`.
+
+## Quick Start
+
+```python
+import numpy as np
+import flox_py as flox
+
+engine = flox.Engine(initial_capital=100_000, fee_rate=0.0001)
+
+# Load OHLCV data
+engine.load_bars_df(timestamps, opens, highs, lows, closes, volumes)
+
+# Create signals (all market orders)
+signals = flox.make_signals(
+    timestamps=np.array([1704067200000, 1704068400000], dtype=np.int64),
+    sides=np.array([0, 1], dtype=np.uint8),  # 0=buy, 1=sell
+    quantities=np.array([0.5, 0.5]),
+)
+
+stats = engine.run(signals)
+print(f"PnL: {stats['net_pnl']:.2f}, Sharpe: {stats['sharpe']:.4f}")
+```
+
+## Loading Bar Data
+
+Two options:
+
+=== "From numpy arrays"
+
+    ```python
+    engine.load_bars_df(
+        timestamps,  # int64, unix ms or ns (auto-detected)
+        opens,       # float64
+        highs,       # float64
+        lows,        # float64
+        closes,      # float64
+        volumes,     # float64
+    )
+    ```
+
+=== "From structured array"
+
+    ```python
+    bars = np.zeros(n, dtype=flox.PyBar)
+    bars['timestamp_ns'] = ...
+    bars['open_raw'] = (opens * 1e8).astype(np.int64)
+    # ... etc
+    engine.load_bars(bars)
+    ```
+
+Load once, then run as many backtests as needed against the same data.
+
+## Creating Signals
+
+`make_signals()` converts numpy arrays into a packed struct array:
+
+```python
+signals = flox.make_signals(
+    timestamps,   # int64 — unix ms, us, or ns (auto-normalized)
+    sides,        # uint8 — 0=buy, 1=sell
+    quantities,   # float64 — position size
+    prices,       # float64 — limit price (optional, default: market)
+    types,        # uint8 — 0=market, 1=limit (optional, default: market)
+)
+```
+
+For market-only strategies, `prices` and `types` can be omitted:
+
+```python
+signals = flox.make_signals(timestamps, sides, quantities)
+```
+
+## Single Run
+
+```python
+stats = engine.run(signals, symbol=1)
+```
+
+Returns a dict with all backtest metrics:
+
+| Key | Description |
+|-----|-------------|
+| `total_trades` | Round-trip trade count |
+| `net_pnl` | Gross PnL minus all fees |
+| `total_fees` | Total execution fees |
+| `sharpe` | Annualized Sharpe ratio |
+| `sortino` | Annualized Sortino ratio |
+| `calmar` | Calmar ratio |
+| `max_drawdown` | Peak-to-trough drawdown |
+| `max_drawdown_pct` | Drawdown as percentage |
+| `win_rate` | Winning trade fraction |
+| `profit_factor` | Gross profit / gross loss |
+| `return_pct` | Net return percentage |
+
+## Batch Execution
+
+Run N backtests in parallel using C++ threads:
+
+```python
+all_stats = engine.run_batch(
+    [signals_1, signals_2, ..., signals_n],
+    threads=0,   # 0 = use all cores
+    symbol=1,
+)
+```
+
+GIL released. Threads run independent copies, nothing shared.
+
+### Permutation Testing Example
+
+```python
+import flox_py as flox
+import numpy as np
+
+engine = flox.Engine(initial_capital=100_000, fee_rate=0.0001)
+engine.load_bars_df(timestamps, opens, highs, lows, closes, volumes)
+
+rng = np.random.default_rng(42)
+signal_sets = []
+
+for _ in range(1000):
+    # Shuffle returns
+    rets = np.diff(np.log(closes))
+    rng.shuffle(rets)
+    shuffled = closes[0] * np.exp(np.cumsum(np.concatenate(([0], rets))))
+
+    # Your strategy logic here
+    sigs = my_strategy(shuffled, timestamps)
+    signal_sets.append(sigs)
+
+# 1000 backtests in ~50ms
+results = engine.run_batch(signal_sets)
+pnls = [r["net_pnl"] for r in results]
+p_value = np.mean([p >= results[0]["net_pnl"] for p in pnls])
+```
+
+## Performance
+
+Benchmarked on Apple M-series, 100K bars, MA cross strategy:
+
+| Mode | Time | vs Python |
+|------|------|-----------|
+| Single run | 0.6ms | 33x |
+| 1000 permutations | 53ms | 400x |
+| Bar loading | 0.5ms | — |
+
+## See Also
+
+- [Backtesting](backtest.md) — C++ backtest guide
+- [Grid Search](grid-search.md) — parameter optimization

--- a/include/flox/indicator/adx.h
+++ b/include/flox/indicator/adx.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include "flox/aggregator/bar.h"
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+struct AdxResult
+{
+  std::vector<double> adx;
+  std::vector<double> plus_di;
+  std::vector<double> minus_di;
+};
+
+class ADX
+{
+ public:
+  explicit ADX(size_t period) noexcept : _period(period) {}
+
+  // Matches TA-Lib ADX/PLUS_DI/MINUS_DI exactly.
+  AdxResult compute(std::span<const double> high, std::span<const double> low,
+                    std::span<const double> close) const
+  {
+    const size_t n = high.size();
+    const size_t p = _period;
+    const double dp = static_cast<double>(p);
+    AdxResult result;
+    result.adx.resize(n, std::nan(""));
+    result.plus_di.resize(n, std::nan(""));
+    result.minus_di.resize(n, std::nan(""));
+
+    if (n < 2 * p + 1)
+    {
+      return result;
+    }
+
+    std::vector<double> posDm(n, 0.0);
+    std::vector<double> negDm(n, 0.0);
+    std::vector<double> tr(n, 0.0);
+    for (size_t i = 1; i < n; ++i)
+    {
+      double up = high[i] - high[i - 1];
+      double dn = low[i - 1] - low[i];
+      if (up > dn && up > 0)
+      {
+        posDm[i] = up;
+      }
+      if (dn > up && dn > 0)
+      {
+        negDm[i] = dn;
+      }
+      tr[i] = std::max({high[i] - low[i], std::abs(high[i] - close[i - 1]),
+                        std::abs(low[i] - close[i - 1])});
+    }
+
+    double sPdm = 0, sNdm = 0, sTr = 0;
+    for (size_t i = 1; i < p; ++i)
+    {
+      sPdm += posDm[i];
+      sNdm += negDm[i];
+      sTr += tr[i];
+    }
+
+    std::vector<double> dx(n, std::nan(""));
+    for (size_t i = p; i < n; ++i)
+    {
+      sPdm = sPdm - sPdm / dp + posDm[i];
+      sNdm = sNdm - sNdm / dp + negDm[i];
+      sTr = sTr - sTr / dp + tr[i];
+
+      if (sTr > 0)
+      {
+        double pdi = 100.0 * sPdm / sTr;
+        double ndi = 100.0 * sNdm / sTr;
+        result.plus_di[i] = pdi;
+        result.minus_di[i] = ndi;
+        double s = pdi + ndi;
+        dx[i] = s > 0 ? 100.0 * std::abs(pdi - ndi) / s : 0.0;
+      }
+    }
+
+    double dxSum = 0.0;
+    for (size_t i = p; i < 2 * p; ++i)
+    {
+      dxSum += std::isnan(dx[i]) ? 0.0 : dx[i];
+    }
+    size_t adxStart = 2 * p - 1;
+    result.adx[adxStart] = dxSum / dp;
+
+    for (size_t i = adxStart + 1; i < n; ++i)
+    {
+      double v = std::isnan(dx[i]) ? 0.0 : dx[i];
+      result.adx[i] = (result.adx[i - 1] * (dp - 1.0) + v) / dp;
+    }
+
+    return result;
+  }
+
+  AdxResult compute(std::span<const Bar> bars) const
+  {
+    const size_t n = bars.size();
+    std::vector<double> h(n), l(n), c(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+      h[i] = bars[i].high.toDouble();
+      l[i] = bars[i].low.toDouble();
+      c[i] = bars[i].close.toDouble();
+    }
+    return compute(h, l, c);
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::BarIndicator<flox::indicator::ADX>);

--- a/include/flox/indicator/atr.h
+++ b/include/flox/indicator/atr.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include "flox/aggregator/bar.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class ATR
+{
+ public:
+  explicit ATR(size_t period) noexcept : _period(period) {}
+
+  std::vector<double> compute(std::span<const double> high, std::span<const double> low,
+                              std::span<const double> close) const
+  {
+    assert(high.size() == low.size() && low.size() == close.size());
+    std::vector<double> out(high.size(), std::nan(""));
+    if (!high.empty())
+    {
+      compute(high, low, close, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> high, std::span<const double> low,
+               std::span<const double> close, std::span<double> output) const
+  {
+    const size_t n = high.size();
+    assert(output.size() >= n);
+    assert(high.size() == low.size() && low.size() == close.size());
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    // TR[0] has no prev close -- matches TA-Lib seeding from TR[1..period]
+    std::vector<double> tr(n, std::nan(""));
+    for (size_t i = 1; i < n; ++i)
+    {
+      if (std::isnan(high[i]) || std::isnan(low[i]) || std::isnan(close[i - 1]))
+      {
+        continue;
+      }
+      tr[i] = std::max({high[i] - low[i], std::abs(high[i] - close[i - 1]),
+                        std::abs(low[i] - close[i - 1])});
+    }
+
+    if (n < _period + 1)
+    {
+      return;
+    }
+
+    double sum = 0.0;
+    for (size_t i = 1; i <= _period; ++i)
+    {
+      sum += tr[i];
+    }
+    output[_period] = sum / static_cast<double>(_period);
+
+    const double alpha = 1.0 / static_cast<double>(_period);
+    for (size_t i = _period + 1; i < n; ++i)
+    {
+      if (std::isnan(tr[i]))
+      {
+        output[i] = output[i - 1];
+        continue;
+      }
+      output[i] = alpha * tr[i] + (1.0 - alpha) * output[i - 1];
+    }
+  }
+
+  std::vector<double> compute(std::span<const Bar> bars) const
+  {
+    std::vector<double> out(bars.size(), std::nan(""));
+    if (!bars.empty())
+    {
+      compute(bars, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const Bar> bars, std::span<double> output) const
+  {
+    const size_t n = bars.size();
+    assert(output.size() >= n);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    std::vector<double> tr(n, std::nan(""));
+    for (size_t i = 1; i < n; ++i)
+    {
+      double h = bars[i].high.toDouble();
+      double l = bars[i].low.toDouble();
+      double pc = bars[i - 1].close.toDouble();
+      tr[i] = std::max({h - l, std::abs(h - pc), std::abs(l - pc)});
+    }
+
+    if (n < _period + 1)
+    {
+      return;
+    }
+
+    double sum = 0.0;
+    for (size_t i = 1; i <= _period; ++i)
+    {
+      sum += tr[i];
+    }
+    output[_period] = sum / static_cast<double>(_period);
+
+    const double alpha = 1.0 / static_cast<double>(_period);
+    for (size_t i = _period + 1; i < n; ++i)
+    {
+      output[i] = alpha * tr[i] + (1.0 - alpha) * output[i - 1];
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::BarIndicator<flox::indicator::ATR>);

--- a/include/flox/indicator/bar_fields.h
+++ b/include/flox/indicator/bar_fields.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "flox/aggregator/bar.h"
+
+#include <cassert>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+namespace detail
+{
+template <typename Fn>
+inline std::vector<double> extract(std::span<const Bar> bars, Fn fn)
+{
+  std::vector<double> out(bars.size());
+  for (size_t i = 0; i < bars.size(); ++i)
+  {
+    out[i] = fn(bars[i]);
+  }
+  return out;
+}
+
+template <typename Fn>
+inline void extract(std::span<const Bar> bars, std::span<double> out, Fn fn)
+{
+  assert(out.size() >= bars.size());
+  for (size_t i = 0; i < bars.size(); ++i)
+  {
+    out[i] = fn(bars[i]);
+  }
+}
+}  // namespace detail
+
+inline std::vector<double> close(std::span<const Bar> bars)
+{
+  return detail::extract(bars, [](const Bar& b)
+                         { return b.close.toDouble(); });
+}
+inline std::vector<double> high(std::span<const Bar> bars)
+{
+  return detail::extract(bars, [](const Bar& b)
+                         { return b.high.toDouble(); });
+}
+inline std::vector<double> low(std::span<const Bar> bars)
+{
+  return detail::extract(bars, [](const Bar& b)
+                         { return b.low.toDouble(); });
+}
+inline std::vector<double> open(std::span<const Bar> bars)
+{
+  return detail::extract(bars, [](const Bar& b)
+                         { return b.open.toDouble(); });
+}
+inline std::vector<double> volume(std::span<const Bar> bars)
+{
+  return detail::extract(bars, [](const Bar& b)
+                         { return b.volume.toDouble(); });
+}
+
+inline void close(std::span<const Bar> bars, std::span<double> out)
+{
+  detail::extract(bars, out, [](const Bar& b)
+                  { return b.close.toDouble(); });
+}
+inline void high(std::span<const Bar> bars, std::span<double> out)
+{
+  detail::extract(bars, out, [](const Bar& b)
+                  { return b.high.toDouble(); });
+}
+inline void low(std::span<const Bar> bars, std::span<double> out)
+{
+  detail::extract(bars, out, [](const Bar& b)
+                  { return b.low.toDouble(); });
+}
+inline void open(std::span<const Bar> bars, std::span<double> out)
+{
+  detail::extract(bars, out, [](const Bar& b)
+                  { return b.open.toDouble(); });
+}
+inline void volume(std::span<const Bar> bars, std::span<double> out)
+{
+  detail::extract(bars, out, [](const Bar& b)
+                  { return b.volume.toDouble(); });
+}
+
+}  // namespace flox::indicator

--- a/include/flox/indicator/bollinger.h
+++ b/include/flox/indicator/bollinger.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "flox/indicator/sma.h"
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+struct BollingerResult
+{
+  std::vector<double> upper;
+  std::vector<double> middle;
+  std::vector<double> lower;
+};
+
+class Bollinger
+{
+ public:
+  explicit Bollinger(size_t period = 20, double stddev = 2.0) noexcept
+      : _period(period), _stddev(stddev)
+  {
+  }
+
+  BollingerResult compute(std::span<const double> input) const
+  {
+    const size_t n = input.size();
+    BollingerResult result;
+    result.upper.resize(n, std::nan(""));
+    result.middle.resize(n, std::nan(""));
+    result.lower.resize(n, std::nan(""));
+
+    if (n < _period)
+    {
+      return result;
+    }
+
+    SMA sma(_period);
+    sma.compute(input, result.middle);
+
+    for (size_t i = _period - 1; i < n; ++i)
+    {
+      double mean = result.middle[i];
+      double sumSq = 0.0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        double diff = input[j] - mean;
+        sumSq += diff * diff;
+      }
+      double sd = std::sqrt(sumSq / static_cast<double>(_period));
+      result.upper[i] = mean + _stddev * sd;
+      result.lower[i] = mean - _stddev * sd;
+    }
+
+    return result;
+  }
+
+  void compute(std::span<const double> input, std::span<double> upper, std::span<double> middle,
+               std::span<double> lower) const
+  {
+    const size_t n = input.size();
+    assert(upper.size() >= n && middle.size() >= n && lower.size() >= n);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      upper[i] = std::nan("");
+      middle[i] = std::nan("");
+      lower[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    SMA sma(_period);
+    sma.compute(input, middle);
+
+    for (size_t i = _period - 1; i < n; ++i)
+    {
+      double mean = middle[i];
+      double sumSq = 0.0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        double diff = input[j] - mean;
+        sumSq += diff * diff;
+      }
+      double sd = std::sqrt(sumSq / static_cast<double>(_period));
+      upper[i] = mean + _stddev * sd;
+      lower[i] = mean - _stddev * sd;
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+  double _stddev;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::MultiOutputIndicator<flox::indicator::Bollinger>);

--- a/include/flox/indicator/cci.h
+++ b/include/flox/indicator/cci.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "flox/indicator/sma.h"
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class CCI
+{
+ public:
+  explicit CCI(size_t period = 20) noexcept : _period(period) {}
+
+  std::vector<double> compute(std::span<const double> high, std::span<const double> low,
+                              std::span<const double> close) const
+  {
+    const size_t n = high.size();
+    std::vector<double> out(n, std::nan(""));
+
+    if (n < _period)
+    {
+      return out;
+    }
+
+    std::vector<double> tp(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+      tp[i] = (high[i] + low[i] + close[i]) / 3.0;
+    }
+
+    SMA sma(_period);
+    std::vector<double> tpSma(n, std::nan(""));
+    sma.compute(std::span<const double>(tp), tpSma);
+
+    for (size_t i = _period - 1; i < n; ++i)
+    {
+      if (std::isnan(tpSma[i]))
+      {
+        continue;
+      }
+      double md = 0.0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        md += std::abs(tp[j] - tpSma[i]);
+      }
+      md /= static_cast<double>(_period);
+      out[i] = md > 0 ? (tp[i] - tpSma[i]) / (0.015 * md) : 0.0;
+    }
+
+    return out;
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::HasPeriod<flox::indicator::CCI>);

--- a/include/flox/indicator/chop.h
+++ b/include/flox/indicator/chop.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "flox/aggregator/bar.h"
+#include "flox/indicator/atr.h"
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class CHOP
+{
+ public:
+  explicit CHOP(size_t period) noexcept : _period(period) {}
+
+  std::vector<double> compute(std::span<const double> high, std::span<const double> low,
+                              std::span<const double> close) const
+  {
+    const size_t n = high.size();
+    std::vector<double> out(n, std::nan(""));
+    if (n < _period + 1)
+    {
+      return out;
+    }
+
+    ATR atr1(1);
+    std::vector<double> atr1_vals(n);
+    atr1.compute(high, low, close, atr1_vals);
+
+    const double logPeriod = std::log10(static_cast<double>(_period));
+
+    for (size_t i = _period - 1; i < n; ++i)
+    {
+      double atrSum = 0.0;
+      size_t validCount = 0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        if (!std::isnan(atr1_vals[j]))
+        {
+          atrSum += atr1_vals[j];
+          ++validCount;
+        }
+      }
+      if (validCount < _period)
+      {
+        continue;
+      }
+
+      double highest = high[i - _period + 1];
+      double lowest = low[i - _period + 1];
+      for (size_t j = i - _period + 2; j <= i; ++j)
+      {
+        if (high[j] > highest)
+        {
+          highest = high[j];
+        }
+        if (low[j] < lowest)
+        {
+          lowest = low[j];
+        }
+      }
+
+      double diff = highest - lowest;
+      if (diff > 0 && atrSum > 0)
+      {
+        out[i] = 100.0 * std::log10(atrSum / diff) / logPeriod;
+      }
+    }
+
+    return out;
+  }
+
+  std::vector<double> compute(std::span<const Bar> bars) const
+  {
+    const size_t n = bars.size();
+    std::vector<double> h(n), l(n), c(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+      h[i] = bars[i].high.toDouble();
+      l[i] = bars[i].low.toDouble();
+      c[i] = bars[i].close.toDouble();
+    }
+    return compute(h, l, c);
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::BarIndicator<flox::indicator::CHOP>);

--- a/include/flox/indicator/cvd.h
+++ b/include/flox/indicator/cvd.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class CVD
+{
+ public:
+  std::vector<double> compute(std::span<const double> open, std::span<const double> high,
+                              std::span<const double> low, std::span<const double> close,
+                              std::span<const double> volume) const
+  {
+    const size_t n = close.size();
+    std::vector<double> out(n);
+
+    double cumulative = 0.0;
+    for (size_t i = 0; i < n; ++i)
+    {
+      double range = high[i] - low[i];
+      double delta = range > 0 ? volume[i] * (close[i] - open[i]) / range : 0.0;
+      cumulative += delta;
+      out[i] = cumulative;
+    }
+
+    return out;
+  }
+
+  std::vector<double> compute(std::span<const double> volume,
+                              std::span<const double> takerBuyVolume) const
+  {
+    const size_t n = volume.size();
+    std::vector<double> out(n);
+
+    double cumulative = 0.0;
+    for (size_t i = 0; i < n; ++i)
+    {
+      double delta = 2.0 * takerBuyVolume[i] - volume[i];
+      cumulative += delta;
+      out[i] = cumulative;
+    }
+
+    return out;
+  }
+
+  size_t period() const noexcept { return 1; }
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::HasPeriod<flox::indicator::CVD>);

--- a/include/flox/indicator/dema.h
+++ b/include/flox/indicator/dema.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "flox/indicator/ema.h"
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class DEMA
+{
+ public:
+  explicit DEMA(size_t period) noexcept : _ema(period), _period(period) {}
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    auto ema1 = _ema.compute(input);
+    auto ema2 = _ema.compute(std::span<const double>(ema1));
+    const size_t n = input.size();
+    std::vector<double> out(n, std::nan(""));
+    for (size_t i = 0; i < n; ++i)
+    {
+      if (!std::isnan(ema1[i]) && !std::isnan(ema2[i]))
+      {
+        out[i] = 2.0 * ema1[i] - ema2[i];
+      }
+    }
+    return out;
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  EMA _ema;
+  size_t _period;
+};
+
+class TEMA
+{
+ public:
+  explicit TEMA(size_t period) noexcept : _ema(period), _period(period) {}
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    auto ema1 = _ema.compute(input);
+    auto ema2 = _ema.compute(std::span<const double>(ema1));
+    auto ema3 = _ema.compute(std::span<const double>(ema2));
+    const size_t n = input.size();
+    std::vector<double> out(n, std::nan(""));
+    for (size_t i = 0; i < n; ++i)
+    {
+      if (!std::isnan(ema1[i]) && !std::isnan(ema2[i]) && !std::isnan(ema3[i]))
+      {
+        out[i] = 3.0 * ema1[i] - 3.0 * ema2[i] + ema3[i];
+      }
+    }
+    return out;
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  EMA _ema;
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::DEMA>);
+static_assert(flox::indicator::SingleIndicator<flox::indicator::TEMA>);

--- a/include/flox/indicator/ema.h
+++ b/include/flox/indicator/ema.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class EMA
+{
+ public:
+  explicit EMA(size_t period) noexcept : _period(period), _alpha(2.0 / (period + 1.0)) {}
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    std::vector<double> out(input.size(), std::nan(""));
+    if (!input.empty())
+    {
+      compute(input, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> input, std::span<double> output) const
+  {
+    assert(output.size() >= input.size());
+    const size_t n = input.size();
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    size_t validCount = 0;
+    double sum = 0.0;
+    size_t seedIdx = n;  // sentinel
+    for (size_t i = 0; i < n; ++i)
+    {
+      if (std::isnan(input[i]))
+      {
+        validCount = 0;
+        sum = 0.0;
+        continue;
+      }
+      sum += input[i];
+      ++validCount;
+      if (validCount == _period)
+      {
+        seedIdx = i;
+        break;
+      }
+    }
+    if (seedIdx >= n)
+    {
+      return;
+    }
+
+    output[seedIdx] = sum / static_cast<double>(_period);
+
+    for (size_t i = seedIdx + 1; i < n; ++i)
+    {
+      if (std::isnan(input[i]))
+      {
+        output[i] = output[i - 1];
+        continue;
+      }
+      output[i] = _alpha * input[i] + (1.0 - _alpha) * output[i - 1];
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+  double _alpha;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::EMA>);

--- a/include/flox/indicator/indicator.h
+++ b/include/flox/indicator/indicator.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "flox/aggregator/bar.h"
+#include "flox/common.h"
+
+#include <concepts>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+template <typename T>
+concept SingleIndicator = requires(const T& ind, std::span<const double> input) {
+  { ind.compute(input) } -> std::same_as<std::vector<double>>;
+  { ind.period() } noexcept -> std::convertible_to<size_t>;
+};
+
+template <typename T>
+concept MultiOutputIndicator = requires(const T& ind, std::span<const double> input) {
+  { ind.compute(input) };
+  { ind.period() } noexcept -> std::convertible_to<size_t>;
+};
+
+template <typename T>
+concept BarIndicator = requires(const T& ind, std::span<const Bar> bars) {
+  { ind.compute(bars) };
+  { ind.period() } noexcept -> std::convertible_to<size_t>;
+};
+
+template <typename T>
+concept HasPeriod = requires(const T& ind) {
+  { ind.period() } noexcept -> std::convertible_to<size_t>;
+};
+
+inline std::vector<Price> toPrices(const std::vector<double>& values)
+{
+  std::vector<Price> out(values.size());
+  for (size_t i = 0; i < values.size(); ++i)
+  {
+    out[i] = std::isnan(values[i]) ? Price{} : Price::fromDouble(values[i]);
+  }
+  return out;
+}
+
+inline std::vector<Volume> toVolumes(const std::vector<double>& values)
+{
+  std::vector<Volume> out(values.size());
+  for (size_t i = 0; i < values.size(); ++i)
+  {
+    out[i] = std::isnan(values[i]) ? Volume{} : Volume::fromDouble(values[i]);
+  }
+  return out;
+}
+
+}  // namespace flox::indicator

--- a/include/flox/indicator/indicator_pipeline.h
+++ b/include/flox/indicator/indicator_pipeline.h
@@ -1,0 +1,203 @@
+#pragma once
+
+#include <functional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "flox/aggregator/bar.h"
+#include "flox/common.h"
+
+namespace flox::indicator
+{
+
+// Indicator computation graph with dependency resolution.
+//
+// Register nodes with dependencies. require() computes only what's needed,
+// in the right order, caching results.
+//
+//   IndicatorGraph g;
+//   g.setBars(0, myBars);
+//
+//   g.addNode("atr14", {}, [](auto& g, auto sym) {
+//       return ATR(14).compute(g.high(sym), g.low(sym), g.close(sym));
+//   });
+//   g.addNode("ema50", {}, [](auto& g, auto sym) {
+//       return EMA(50).compute(g.close(sym));
+//   });
+//   g.addNode("norm_slope", {"ema50", "atr14"}, [](auto& g, auto sym) {
+//       auto slope = Slope(1).compute(*g.get(sym, "ema50"));
+//       auto& atr = *g.get(sym, "atr14");
+//       // ...
+//   });
+//
+//   auto& ns = g.require(0, "norm_slope");
+//   // computed: ema50, atr14, norm_slope (only what's needed)
+
+class IndicatorGraph
+{
+ public:
+  using ComputeFn = std::function<std::vector<double>(IndicatorGraph&, SymbolId)>;
+
+  void setBars(SymbolId symbol, std::span<const Bar> bars)
+  {
+    _bars[symbol] = {bars.begin(), bars.end()};
+    invalidate(symbol);
+  }
+
+  std::span<const Bar> bars(SymbolId symbol) const
+  {
+    auto it = _bars.find(symbol);
+    return it != _bars.end() ? std::span<const Bar>(it->second) : std::span<const Bar>{};
+  }
+
+  const std::vector<double>& close(SymbolId sym)
+  {
+    return fieldCache(sym, 0, [](const Bar& b)
+                      { return b.close.toDouble(); });
+  }
+  const std::vector<double>& high(SymbolId sym)
+  {
+    return fieldCache(sym, 1, [](const Bar& b)
+                      { return b.high.toDouble(); });
+  }
+  const std::vector<double>& low(SymbolId sym)
+  {
+    return fieldCache(sym, 2, [](const Bar& b)
+                      { return b.low.toDouble(); });
+  }
+  const std::vector<double>& volume(SymbolId sym)
+  {
+    return fieldCache(sym, 3, [](const Bar& b)
+                      { return b.volume.toDouble(); });
+  }
+
+  void addNode(const std::string& name, std::vector<std::string> deps, ComputeFn fn)
+  {
+    _nodes[name] = {std::move(deps), std::move(fn)};
+  }
+
+  const std::vector<double>& require(SymbolId symbol, const std::string& name)
+  {
+    auto key = CacheKey{symbol, name};
+    auto it = _cache.find(key);
+    if (it != _cache.end())
+    {
+      return it->second;
+    }
+
+    auto nodeIt = _nodes.find(name);
+    if (nodeIt == _nodes.end())
+    {
+      throw std::logic_error("unknown node: " + name);
+    }
+
+    auto cycleKey = CacheKey{symbol, name};
+    if (_computing.count(cycleKey))
+    {
+      throw std::logic_error("circular dependency: " + name);
+    }
+    _computing.insert(cycleKey);
+
+    for (const auto& dep : nodeIt->second.deps)
+    {
+      require(symbol, dep);
+    }
+
+    auto result = nodeIt->second.fn(*this, symbol);
+    _computing.erase(cycleKey);
+    return _cache.emplace(key, std::move(result)).first->second;
+  }
+
+  const std::vector<double>* get(SymbolId symbol, const std::string& name) const
+  {
+    auto it = _cache.find(CacheKey{symbol, name});
+    return it != _cache.end() ? &it->second : nullptr;
+  }
+
+  void invalidate(SymbolId symbol)
+  {
+    for (auto it = _cache.begin(); it != _cache.end();)
+    {
+      if (it->first.first == symbol)
+      {
+        it = _cache.erase(it);
+      }
+      else
+      {
+        ++it;
+      }
+    }
+    for (auto it = _fields.begin(); it != _fields.end();)
+    {
+      if (it->first.first == symbol)
+      {
+        it = _fields.erase(it);
+      }
+      else
+      {
+        ++it;
+      }
+    }
+  }
+
+  void invalidateAll()
+  {
+    _cache.clear();
+    _fields.clear();
+  }
+
+ private:
+  struct Node
+  {
+    std::vector<std::string> deps;
+    ComputeFn fn;
+  };
+
+  using CacheKey = std::pair<SymbolId, std::string>;
+  struct CacheKeyHash
+  {
+    size_t operator()(const CacheKey& k) const
+    {
+      return std::hash<SymbolId>{}(k.first) ^ (std::hash<std::string>{}(k.second) * 2654435761u);
+    }
+  };
+
+  using FieldKey = std::pair<SymbolId, int>;
+  struct FieldKeyHash
+  {
+    size_t operator()(const FieldKey& k) const
+    {
+      return std::hash<SymbolId>{}(k.first) ^ (std::hash<int>{}(k.second) * 2654435761u);
+    }
+  };
+
+  template <typename Fn>
+  const std::vector<double>& fieldCache(SymbolId symbol, int fieldIdx, Fn fn)
+  {
+    auto key = FieldKey{symbol, fieldIdx};
+    auto it = _fields.find(key);
+    if (it != _fields.end())
+    {
+      return it->second;
+    }
+    auto b = bars(symbol);
+    std::vector<double> out(b.size());
+    for (size_t i = 0; i < b.size(); ++i)
+    {
+      out[i] = fn(b[i]);
+    }
+    return _fields.emplace(key, std::move(out)).first->second;
+  }
+
+  std::unordered_map<SymbolId, std::vector<Bar>> _bars;
+  std::unordered_map<std::string, Node> _nodes;
+  std::unordered_map<CacheKey, std::vector<double>, CacheKeyHash> _cache;
+  std::unordered_map<FieldKey, std::vector<double>, FieldKeyHash> _fields;
+  std::unordered_set<CacheKey, CacheKeyHash> _computing;
+};
+
+}  // namespace flox::indicator

--- a/include/flox/indicator/kama.h
+++ b/include/flox/indicator/kama.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class KAMA
+{
+ public:
+  explicit KAMA(size_t period, size_t fast = 2, size_t slow = 30) noexcept
+      : _period(period), _fr(2.0 / (fast + 1)), _sr(2.0 / (slow + 1))
+  {
+  }
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    std::vector<double> out(input.size(), std::nan(""));
+    if (!input.empty())
+    {
+      compute(input, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> input, std::span<double> output) const
+  {
+    const size_t n = input.size();
+    assert(output.size() >= n);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n <= _period)
+    {
+      return;
+    }
+
+    // TA-Lib seeds KAMA with close[period-1], first output at index period
+    double prev = input[_period - 1];
+
+    for (size_t i = _period; i < n; ++i)
+    {
+      double direction = std::abs(input[i] - input[i - _period]);
+      double volatility = 0.0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        volatility += std::abs(input[j] - input[j - 1]);
+      }
+      double er = volatility > 0 ? direction / volatility : 0.0;
+      double sc = (er * (_fr - _sr) + _sr);
+      sc *= sc;
+      prev = sc * input[i] + (1.0 - sc) * prev;
+      output[i] = prev;
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+  double _fr;
+  double _sr;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::KAMA>);

--- a/include/flox/indicator/macd.h
+++ b/include/flox/indicator/macd.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "flox/indicator/ema.h"
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+struct MacdResult
+{
+  std::vector<double> line;
+  std::vector<double> signal;
+  std::vector<double> histogram;
+};
+
+class MACD
+{
+ public:
+  MACD(size_t fastPeriod = 12, size_t slowPeriod = 26, size_t signalPeriod = 9) noexcept
+      : _fast(fastPeriod), _slow(slowPeriod), _signal(signalPeriod), _slowPeriod(slowPeriod)
+  {
+  }
+
+  MacdResult compute(std::span<const double> input) const
+  {
+    MacdResult result;
+    result.line.resize(input.size(), std::nan(""));
+    result.signal.resize(input.size(), std::nan(""));
+    result.histogram.resize(input.size(), std::nan(""));
+    compute(input, result.line, result.signal, result.histogram);
+    return result;
+  }
+
+  void compute(std::span<const double> input, std::span<double> line, std::span<double> signal,
+               std::span<double> histogram) const
+  {
+    const size_t n = input.size();
+    assert(line.size() >= n && signal.size() >= n && histogram.size() >= n);
+
+    // TA-Lib MACD seeds fast EMA at slow EMA start point, not independently.
+    // Fast EMA SMA seed = mean(input[slowPeriod-fastPeriod .. slowPeriod-1])
+    size_t fastP = _fast.period();
+    size_t slowP = _slow.period();
+    size_t sigP = _signal.period();
+
+    // Ensure slow >= fast (swap if needed, matching TA-Lib behavior)
+    if (fastP > slowP)
+    {
+      std::swap(fastP, slowP);
+    }
+
+    auto slowEma = EMA(slowP).compute(input);
+
+    std::vector<double> fastEma(n, std::nan(""));
+    if (n >= slowP)
+    {
+      double alpha = 2.0 / (static_cast<double>(fastP) + 1.0);
+      double sum = 0.0;
+      for (size_t i = slowP - fastP; i < slowP; ++i)
+      {
+        sum += input[i];
+      }
+      fastEma[slowP - 1] = sum / static_cast<double>(fastP);
+      for (size_t i = slowP; i < n; ++i)
+      {
+        fastEma[i] = alpha * input[i] + (1.0 - alpha) * fastEma[i - 1];
+      }
+    }
+
+    std::vector<double> macdLine(n, std::nan(""));
+    for (size_t i = 0; i < n; ++i)
+    {
+      if (!std::isnan(fastEma[i]) && !std::isnan(slowEma[i]))
+      {
+        macdLine[i] = fastEma[i] - slowEma[i];
+      }
+    }
+
+    auto signalEma = _signal.compute(std::span<const double>(macdLine));
+
+    // TA-Lib convention: all three outputs start at the same index
+    // (when signal is first valid). Line and histogram are NaN before that.
+    for (size_t i = 0; i < n; ++i)
+    {
+      if (!std::isnan(signalEma[i]))
+      {
+        line[i] = macdLine[i];
+        signal[i] = signalEma[i];
+        histogram[i] = macdLine[i] - signalEma[i];
+      }
+      else
+      {
+        line[i] = std::nan("");
+        signal[i] = std::nan("");
+        histogram[i] = std::nan("");
+      }
+    }
+  }
+
+  size_t period() const noexcept { return _slowPeriod + _signal.period() - 1; }
+
+ private:
+  EMA _fast;
+  EMA _slow;
+  EMA _signal;
+  size_t _slowPeriod;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::MultiOutputIndicator<flox::indicator::MACD>);

--- a/include/flox/indicator/multi_symbol.h
+++ b/include/flox/indicator/multi_symbol.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "flox/aggregator/bar.h"
+#include "flox/aggregator/events/bar_event.h"
+#include "flox/common.h"
+
+#include <atomic>
+#include <span>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+namespace flox::indicator
+{
+
+inline std::unordered_map<SymbolId, std::vector<Bar>> partitionBySymbol(
+    std::span<const Bar> bars, std::span<const SymbolId> symbols)
+{
+  std::unordered_map<SymbolId, std::vector<Bar>> result;
+  for (size_t i = 0; i < bars.size(); ++i)
+  {
+    result[symbols[i]].push_back(bars[i]);
+  }
+  return result;
+}
+
+inline std::unordered_map<SymbolId, std::vector<Bar>> partitionBySymbol(
+    std::span<const BarEvent> events)
+{
+  std::unordered_map<SymbolId, std::vector<Bar>> result;
+  for (const auto& ev : events)
+  {
+    result[ev.symbol].push_back(ev.bar);
+  }
+  return result;
+}
+
+template <typename Fn>
+void forEachSymbol(const std::unordered_map<SymbolId, std::vector<Bar>>& data, Fn&& fn)
+{
+  for (const auto& [sym, bars] : data)
+  {
+    fn(sym, std::span<const Bar>(bars));
+  }
+}
+
+// fn must be thread-safe.
+template <typename Fn>
+void forEachSymbolParallel(const std::unordered_map<SymbolId, std::vector<Bar>>& data,
+                           Fn&& fn, int threads = 0)
+{
+  if (data.empty())
+  {
+    return;
+  }
+  if (threads <= 0)
+  {
+    threads = static_cast<int>(std::thread::hardware_concurrency());
+  }
+
+  std::vector<std::pair<SymbolId, const std::vector<Bar>*>> items;
+  items.reserve(data.size());
+  for (const auto& [sym, bars] : data)
+  {
+    items.emplace_back(sym, &bars);
+  }
+
+  std::atomic<size_t> next{0};
+  auto worker = [&]()
+  {
+    while (true)
+    {
+      size_t idx = next.fetch_add(1, std::memory_order_relaxed);
+      if (idx >= items.size())
+      {
+        break;
+      }
+      fn(items[idx].first, std::span<const Bar>(*items[idx].second));
+    }
+  };
+
+  int actual = std::min(threads, static_cast<int>(items.size()));
+  std::vector<std::thread> pool;
+  pool.reserve(actual);
+  for (int i = 0; i < actual; ++i)
+  {
+    pool.emplace_back(worker);
+  }
+  for (auto& t : pool)
+  {
+    t.join();
+  }
+}
+
+}  // namespace flox::indicator

--- a/include/flox/indicator/obv.h
+++ b/include/flox/indicator/obv.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class OBV
+{
+ public:
+  std::vector<double> compute(std::span<const double> close, std::span<const double> volume) const
+  {
+    assert(close.size() == volume.size());
+    const size_t n = close.size();
+    std::vector<double> out(n, std::nan(""));
+    if (n == 0)
+    {
+      return out;
+    }
+    compute(close, volume, out);
+    return out;
+  }
+
+  void compute(std::span<const double> close, std::span<const double> volume,
+               std::span<double> output) const
+  {
+    const size_t n = close.size();
+    assert(output.size() >= n);
+
+    if (n == 0)
+    {
+      return;
+    }
+
+    output[0] = volume[0];  // TA-Lib convention
+    double cumulative = volume[0];
+    for (size_t i = 1; i < n; ++i)
+    {
+      if (std::isnan(close[i]) || std::isnan(close[i - 1]))
+      {
+        output[i] = cumulative;
+        continue;
+      }
+      if (close[i] > close[i - 1])
+      {
+        cumulative += volume[i];
+      }
+      else if (close[i] < close[i - 1])
+      {
+        cumulative -= volume[i];
+      }
+      output[i] = cumulative;
+    }
+  }
+
+  size_t period() const noexcept { return 1; }
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::HasPeriod<flox::indicator::OBV>);

--- a/include/flox/indicator/rma.h
+++ b/include/flox/indicator/rma.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+// Wilder's Moving Average. alpha = 1/period (not 2/(period+1) like EMA).
+// Used internally by ATR, RSI, ADX. Exposed for direct use.
+class RMA
+{
+ public:
+  explicit RMA(size_t period) noexcept : _period(period) {}
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    std::vector<double> out(input.size(), std::nan(""));
+    if (!input.empty())
+    {
+      compute(input, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> input, std::span<double> output) const
+  {
+    const size_t n = input.size();
+    assert(output.size() >= n);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    double alpha = 1.0 / static_cast<double>(_period);
+
+    double sum = 0.0;
+    for (size_t i = 0; i < _period; ++i)
+    {
+      sum += input[i];
+    }
+    output[_period - 1] = sum / static_cast<double>(_period);
+
+    for (size_t i = _period; i < n; ++i)
+    {
+      output[i] = alpha * input[i] + (1.0 - alpha) * output[i - 1];
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::RMA>);

--- a/include/flox/indicator/rsi.h
+++ b/include/flox/indicator/rsi.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class RSI
+{
+ public:
+  explicit RSI(size_t period) noexcept : _period(period) {}
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    std::vector<double> out(input.size(), std::nan(""));
+    if (!input.empty())
+    {
+      compute(input, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> input, std::span<double> output) const
+  {
+    const size_t n = input.size();
+    assert(output.size() >= n);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period + 1)
+    {
+      return;
+    }
+
+    double avgGain = 0.0;
+    double avgLoss = 0.0;
+    for (size_t i = 1; i <= _period; ++i)
+    {
+      if (std::isnan(input[i]) || std::isnan(input[i - 1]))
+      {
+        continue;
+      }
+      double d = input[i] - input[i - 1];
+      if (d > 0)
+      {
+        avgGain += d;
+      }
+      else
+      {
+        avgLoss -= d;
+      }
+    }
+    avgGain /= static_cast<double>(_period);
+    avgLoss /= static_cast<double>(_period);
+
+    output[_period] = avgLoss > 0 ? 100.0 - 100.0 / (1.0 + avgGain / avgLoss) : 100.0;
+
+    const double pm1 = static_cast<double>(_period - 1);
+    const double pd = static_cast<double>(_period);
+    for (size_t i = _period + 1; i < n; ++i)
+    {
+      if (std::isnan(input[i]) || std::isnan(input[i - 1]))
+      {
+        output[i] = output[i - 1];
+        continue;
+      }
+      double d = input[i] - input[i - 1];
+      double gain = d > 0 ? d : 0.0;
+      double loss = d < 0 ? -d : 0.0;
+      avgGain = (avgGain * pm1 + gain) / pd;
+      avgLoss = (avgLoss * pm1 + loss) / pd;
+      output[i] = avgLoss > 0 ? 100.0 - 100.0 / (1.0 + avgGain / avgLoss) : 100.0;
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::RSI>);

--- a/include/flox/indicator/slope.h
+++ b/include/flox/indicator/slope.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+// (input[i] - input[i-length]) / length
+class Slope
+{
+ public:
+  explicit Slope(size_t length) noexcept : _length(length) {}
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    std::vector<double> out(input.size(), std::nan(""));
+    if (!input.empty())
+    {
+      compute(input, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> input, std::span<double> output) const
+  {
+    const size_t n = input.size();
+    assert(output.size() >= n);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    const double len = static_cast<double>(_length);
+    for (size_t i = _length; i < n; ++i)
+    {
+      if (std::isnan(input[i]) || std::isnan(input[i - _length]))
+      {
+        continue;
+      }
+      output[i] = (input[i] - input[i - _length]) / len;
+    }
+  }
+
+  size_t period() const noexcept { return _length; }
+
+ private:
+  size_t _length;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::Slope>);

--- a/include/flox/indicator/sma.h
+++ b/include/flox/indicator/sma.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class SMA
+{
+ public:
+  explicit SMA(size_t period) noexcept : _period(period) {}
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    std::vector<double> out(input.size(), std::nan(""));
+    if (!input.empty())
+    {
+      compute(input, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> input, std::span<double> output) const
+  {
+    assert(output.size() >= input.size());
+    const size_t n = input.size();
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    double sum = 0.0;
+    for (size_t i = 0; i < _period; ++i)
+    {
+      sum += input[i];
+    }
+    output[_period - 1] = sum / static_cast<double>(_period);
+
+    for (size_t i = _period; i < n; ++i)
+    {
+      sum += input[i] - input[i - _period];
+      output[i] = sum / static_cast<double>(_period);
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::SMA>);

--- a/include/flox/indicator/stochastic.h
+++ b/include/flox/indicator/stochastic.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+struct StochasticResult
+{
+  std::vector<double> k;
+  std::vector<double> d;
+};
+
+class Stochastic
+{
+ public:
+  Stochastic(size_t kPeriod = 14, size_t dPeriod = 3) noexcept
+      : _kPeriod(kPeriod), _dPeriod(dPeriod)
+  {
+  }
+
+  StochasticResult compute(std::span<const double> high, std::span<const double> low,
+                           std::span<const double> close) const
+  {
+    const size_t n = high.size();
+    StochasticResult result;
+    result.k.resize(n, std::nan(""));
+    result.d.resize(n, std::nan(""));
+
+    if (n < _kPeriod)
+    {
+      return result;
+    }
+
+    // TA-Lib aligns K and D output to the same start index
+    size_t firstValid = _kPeriod - 1 + _dPeriod - 1;
+    size_t kStart = firstValid >= _dPeriod - 1 ? firstValid - _dPeriod + 1 : 0;
+    std::vector<double> rawK(n, std::nan(""));
+    for (size_t i = std::max(kStart, _kPeriod - 1); i < n; ++i)
+    {
+      double hh = high[i];
+      double ll = low[i];
+      for (size_t j = i - _kPeriod + 1; j < i; ++j)
+      {
+        if (high[j] > hh)
+        {
+          hh = high[j];
+        }
+        if (low[j] < ll)
+        {
+          ll = low[j];
+        }
+      }
+      double range = hh - ll;
+      rawK[i] = range > 0 ? 100.0 * (close[i] - ll) / range : 50.0;
+    }
+
+    for (size_t i = firstValid; i < n; ++i)
+    {
+      result.k[i] = rawK[i];
+      double sum = 0.0;
+      for (size_t j = i - _dPeriod + 1; j <= i; ++j)
+      {
+        sum += rawK[j];
+      }
+      result.d[i] = sum / static_cast<double>(_dPeriod);
+    }
+
+    return result;
+  }
+
+  size_t period() const noexcept { return _kPeriod; }
+
+ private:
+  size_t _kPeriod;
+  size_t _dPeriod;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::HasPeriod<flox::indicator::Stochastic>);

--- a/include/flox/indicator/vwap.h
+++ b/include/flox/indicator/vwap.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+// Rolling VWAP: sum(price * volume, window) / sum(volume, window)
+class VWAP
+{
+ public:
+  explicit VWAP(size_t window) noexcept : _window(window) {}
+
+  std::vector<double> compute(std::span<const double> close,
+                              std::span<const double> volume) const
+  {
+    assert(close.size() == volume.size());
+    const size_t n = close.size();
+    std::vector<double> out(n, std::nan(""));
+
+    if (n < _window)
+    {
+      return out;
+    }
+
+    double pvSum = 0.0;
+    double vSum = 0.0;
+    for (size_t i = 0; i < _window; ++i)
+    {
+      pvSum += close[i] * volume[i];
+      vSum += volume[i];
+    }
+    out[_window - 1] = vSum > 0 ? pvSum / vSum : close[_window - 1];
+
+    for (size_t i = _window; i < n; ++i)
+    {
+      pvSum += close[i] * volume[i] - close[i - _window] * volume[i - _window];
+      vSum += volume[i] - volume[i - _window];
+      out[i] = vSum > 0 ? pvSum / vSum : close[i];
+    }
+
+    return out;
+  }
+
+  size_t period() const noexcept { return _window; }
+
+ private:
+  size_t _window;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::HasPeriod<flox::indicator::VWAP>);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,9 @@ nav:
       - Backtesting: how-to/backtest.md
       - Interactive Backtest: how-to/interactive-backtest.md
       - Grid Search: how-to/grid-search.md
+      - Python Bindings: how-to/python-bindings.md
+      - Indicator Graph: how-to/indicator-graph.md
+      - Multi-Symbol Indicators: how-to/multi-symbol-indicators.md
       - CPU Affinity: how-to/cpu-affinity.md
       - Custom Connector: how-to/custom-connector.md
       - Custom Bar Policy: how-to/custom-bar-policy.md

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,18 @@
+find_package(pybind11 REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
+
+pybind11_add_module(flox_py flox_py.cpp)
+
+target_link_libraries(flox_py PRIVATE flox)
+target_include_directories(flox_py PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include
+  ${Python3_NumPy_INCLUDE_DIRS}
+)
+
+if(NOT MSVC)
+  target_compile_options(flox_py PRIVATE
+    $<$<CONFIG:Release>:-O3 -march=native -flto>
+  )
+endif()
+
+install(TARGETS flox_py LIBRARY DESTINATION . COMPONENT python_module)

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,64 @@
+# flox-py
+
+Python bindings for the Flox indicator library. Tested against TA-Lib.
+
+## Install
+
+```bash
+pip install flox-py
+```
+
+## Usage
+
+```python
+import flox_py as flox
+import numpy as np
+
+close = np.array([...])
+high = np.array([...])
+low = np.array([...])
+
+ema50 = flox.ema(close, 50)
+atr14 = flox.atr(high, low, close, 14)
+rsi14 = flox.rsi(close, 14)
+
+signal_long = (rsi14 > 70).astype(np.int8)
+signal_short = ((rsi14 < 30) * -1).astype(np.int8)
+
+returns = flox.bar_returns(signal_long, signal_short, log_returns)
+trades = flox.trade_pnl(signal_long, signal_short, log_returns)
+pf = flox.profit_factor(returns)
+wr = flox.win_rate(trades)
+```
+
+## Indicators
+
+| Function | Description |
+|----------|-------------|
+| `flox.ema(input, period)` | Exponential Moving Average |
+| `flox.sma(input, period)` | Simple Moving Average |
+| `flox.rma(input, period)` | Wilder Moving Average |
+| `flox.rsi(input, period)` | Relative Strength Index |
+| `flox.atr(high, low, close, period)` | Average True Range |
+| `flox.adx(high, low, close, period)` | ADX, +DI, -DI |
+| `flox.macd(input, fast, slow, signal)` | MACD line, signal, histogram |
+| `flox.bollinger(input, period, stddev)` | upper, middle, lower bands |
+| `flox.stochastic(high, low, close, k, d)` | %K and %D |
+| `flox.cci(high, low, close, period)` | Commodity Channel Index |
+| `flox.slope(input, length)` | price slope |
+| `flox.kama(input, period)` | Kaufman Adaptive MA |
+| `flox.dema(input, period)` | Double EMA |
+| `flox.tema(input, period)` | Triple EMA |
+| `flox.chop(high, low, close, period)` | Choppiness Index |
+| `flox.obv(close, volume)` | On-Balance Volume |
+| `flox.vwap(close, volume, window)` | rolling VWAP |
+| `flox.cvd(open, high, low, close, volume)` | Cumulative Volume Delta |
+
+## Metrics
+
+| Function | Description |
+|----------|-------------|
+| `flox.bar_returns(sig_long, sig_short, log_ret)` | per-bar returns with signal shift |
+| `flox.trade_pnl(sig_long, sig_short, log_ret)` | per-trade PnL array |
+| `flox.profit_factor(returns)` | sum positive / abs sum negative |
+| `flox.win_rate(trade_pnls)` | fraction of winning trades |

--- a/python/flox_py.cpp
+++ b/python/flox_py.cpp
@@ -1,0 +1,342 @@
+// flox_py -- Python bindings for Flox.
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "flox/backtest/backtest_result.h"
+#include "flox/backtest/simulated_clock.h"
+#include "flox/backtest/simulated_executor.h"
+#include "flox/common.h"
+#include "indicator_bindings.h"
+
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+namespace py = pybind11;
+using namespace flox;
+
+#pragma pack(push, 1)
+struct PySignal
+{
+  int64_t timestamp_ns;
+  int64_t quantity_raw;  // pre-scaled: qty * 1e8
+  int64_t price_raw;     // pre-scaled: price * 1e8, 0 for market
+  uint8_t side;          // 0=buy, 1=sell
+  uint8_t order_type;    // 0=market, 1=limit
+  uint8_t _pad[6];
+};
+#pragma pack(pop)
+static_assert(sizeof(PySignal) == 32);
+
+#pragma pack(push, 1)
+struct PyBar
+{
+  int64_t timestamp_ns;
+  int64_t open_raw;
+  int64_t high_raw;
+  int64_t low_raw;
+  int64_t close_raw;
+  int64_t volume_raw;
+};
+#pragma pack(pop)
+static_assert(sizeof(PyBar) == 48);
+
+static BacktestStats executeSignals(const PyBar* bars, size_t numBars,
+                                    const PySignal* signals, size_t numSignals,
+                                    SymbolId symbolId, const BacktestConfig& config)
+{
+  SimulatedClock clock;
+  SimulatedExecutor executor(clock);
+  OrderId nextOrderId = 1;
+
+  std::vector<size_t> sigOrder(numSignals);
+  std::iota(sigOrder.begin(), sigOrder.end(), 0);
+  std::sort(sigOrder.begin(), sigOrder.end(),
+            [&](size_t a, size_t b)
+            { return signals[a].timestamp_ns < signals[b].timestamp_ns; });
+
+  size_t sigIdx = 0;
+
+  for (size_t i = 0; i < numBars; ++i)
+  {
+    const auto& bar = bars[i];
+    clock.advanceTo(bar.timestamp_ns);
+    executor.onBar(symbolId, Price::fromRaw(bar.close_raw));
+
+    while (sigIdx < numSignals && signals[sigOrder[sigIdx]].timestamp_ns <= bar.timestamp_ns)
+    {
+      const auto& sig = signals[sigOrder[sigIdx]];
+      Order order{.id = nextOrderId++,
+                  .side = sig.side == 0 ? Side::BUY : Side::SELL,
+                  .price = Price::fromRaw(sig.price_raw),
+                  .quantity = Quantity::fromRaw(sig.quantity_raw),
+                  .type = sig.order_type == 0 ? OrderType::MARKET : OrderType::LIMIT,
+                  .symbol = symbolId};
+      executor.submitOrder(order);
+      ++sigIdx;
+    }
+  }
+
+  while (sigIdx < numSignals)
+  {
+    const auto& sig = signals[sigOrder[sigIdx]];
+    Order order{.id = nextOrderId++,
+                .side = sig.side == 0 ? Side::BUY : Side::SELL,
+                .price = Price::fromRaw(sig.price_raw),
+                .quantity = Quantity::fromRaw(sig.quantity_raw),
+                .type = sig.order_type == 0 ? OrderType::MARKET : OrderType::LIMIT,
+                .symbol = symbolId};
+    executor.submitOrder(order);
+    ++sigIdx;
+  }
+
+  BacktestResult result(config, executor.fills().size());
+  for (const auto& fill : executor.fills())
+  {
+    result.recordFill(fill);
+  }
+
+  return result.computeStats();
+}
+
+static py::dict statsToPyDict(const BacktestStats& s)
+{
+  py::dict d;
+  d["total_trades"] = s.totalTrades;
+  d["winning_trades"] = s.winningTrades;
+  d["losing_trades"] = s.losingTrades;
+  d["initial_capital"] = s.initialCapital;
+  d["final_capital"] = s.finalCapital;
+  d["total_pnl"] = s.totalPnl;
+  d["total_fees"] = s.totalFees;
+  d["net_pnl"] = s.netPnl;
+  d["gross_profit"] = s.grossProfit;
+  d["gross_loss"] = s.grossLoss;
+  d["max_drawdown"] = s.maxDrawdown;
+  d["max_drawdown_pct"] = s.maxDrawdownPct;
+  d["win_rate"] = s.winRate;
+  d["profit_factor"] = s.profitFactor;
+  d["avg_win"] = s.avgWin;
+  d["avg_loss"] = s.avgLoss;
+  d["sharpe"] = s.sharpeRatio;
+  d["sortino"] = s.sortinoRatio;
+  d["calmar"] = s.calmarRatio;
+  d["return_pct"] = s.returnPct;
+  return d;
+}
+
+class Engine
+{
+ public:
+  Engine(double initialCapital = 100000.0, double feeRate = 0.0001)
+  {
+    _config.initialCapital = initialCapital;
+    _config.feeRate = feeRate;
+    _config.usePercentageFee = true;
+  }
+
+  void loadBars(py::array_t<PyBar, py::array::c_style> bars)
+  {
+    auto buf = bars.request();
+    _bars.resize(buf.shape[0]);
+    std::memcpy(_bars.data(), buf.ptr, buf.shape[0] * sizeof(PyBar));
+  }
+
+  void loadBarsFromArrays(py::array_t<int64_t> timestamps,
+                          py::array_t<double> open,
+                          py::array_t<double> high,
+                          py::array_t<double> low,
+                          py::array_t<double> close,
+                          py::array_t<double> volume)
+  {
+    auto n = timestamps.size();
+    _bars.resize(n);
+    auto ts = timestamps.unchecked<1>();
+    auto o = open.unchecked<1>();
+    auto h = high.unchecked<1>();
+    auto l = low.unchecked<1>();
+    auto c = close.unchecked<1>();
+    auto v = volume.unchecked<1>();
+
+    for (py::ssize_t i = 0; i < n; ++i)
+    {
+      int64_t t = ts(i);
+      if (t < static_cast<int64_t>(1e12))
+      {
+        t *= 1'000'000'000LL;
+      }
+      else if (t < static_cast<int64_t>(1e15))
+      {
+        t *= 1'000'000LL;
+      }
+      else if (t < static_cast<int64_t>(1e18))
+      {
+        t *= 1'000LL;
+      }
+
+      _bars[i] = {.timestamp_ns = t,
+                  .open_raw = Price::fromDouble(o(i)).raw(),
+                  .high_raw = Price::fromDouble(h(i)).raw(),
+                  .low_raw = Price::fromDouble(l(i)).raw(),
+                  .close_raw = Price::fromDouble(c(i)).raw(),
+                  .volume_raw = Volume::fromDouble(v(i)).raw()};
+    }
+  }
+
+  py::dict run(py::array_t<PySignal, py::array::c_style> signals, uint32_t symbol = 1)
+  {
+    auto buf = signals.request();
+    const auto* sigs = static_cast<const PySignal*>(buf.ptr);
+    size_t n = buf.shape[0];
+
+    BacktestStats stats;
+    {
+      py::gil_scoped_release release;
+      stats = executeSignals(_bars.data(), _bars.size(), sigs, n, symbol, _config);
+    }
+    return statsToPyDict(stats);
+  }
+
+  py::list runBatch(py::list signalSets, int threads = 0, uint32_t symbol = 1)
+  {
+    size_t numRuns = signalSets.size();
+    if (threads <= 0)
+    {
+      threads = static_cast<int>(std::thread::hardware_concurrency());
+    }
+
+    struct RunData
+    {
+      const PySignal* data;
+      size_t count;
+    };
+    std::vector<RunData> runs(numRuns);
+    std::vector<py::array_t<PySignal, py::array::c_style>> refs(numRuns);
+
+    for (size_t i = 0; i < numRuns; ++i)
+    {
+      refs[i] = signalSets[i].cast<py::array_t<PySignal, py::array::c_style>>();
+      auto buf = refs[i].request();
+      runs[i] = {static_cast<const PySignal*>(buf.ptr), static_cast<size_t>(buf.shape[0])};
+    }
+
+    std::vector<BacktestStats> results(numRuns);
+
+    {
+      py::gil_scoped_release release;
+
+      std::atomic<size_t> nextRun{0};
+      auto worker = [&]()
+      {
+        while (true)
+        {
+          size_t idx = nextRun.fetch_add(1, std::memory_order_relaxed);
+          if (idx >= numRuns)
+          {
+            break;
+          }
+          results[idx] = executeSignals(
+              _bars.data(), _bars.size(),
+              runs[idx].data, runs[idx].count,
+              symbol, _config);
+        }
+      };
+
+      int actualThreads = std::min(threads, static_cast<int>(numRuns));
+      std::vector<std::thread> pool;
+      pool.reserve(actualThreads);
+      for (int t = 0; t < actualThreads; ++t)
+      {
+        pool.emplace_back(worker);
+      }
+      for (auto& t : pool)
+      {
+        t.join();
+      }
+    }
+
+    py::list out;
+    for (size_t i = 0; i < numRuns; ++i)
+    {
+      out.append(statsToPyDict(results[i]));
+    }
+    return out;
+  }
+
+  size_t barCount() const { return _bars.size(); }
+
+ private:
+  BacktestConfig _config;
+  std::vector<PyBar> _bars;
+};
+
+PYBIND11_MODULE(flox_py, m)
+{
+  m.doc() = "Flox -- Python bindings";
+
+  PYBIND11_NUMPY_DTYPE(PySignal, timestamp_ns, quantity_raw, price_raw, side, order_type);
+  PYBIND11_NUMPY_DTYPE(PyBar, timestamp_ns, open_raw, high_raw, low_raw, close_raw, volume_raw);
+
+  py::class_<Engine>(m, "Engine")
+      .def(py::init<double, double>(),
+           py::arg("initial_capital") = 100000.0,
+           py::arg("fee_rate") = 0.0001)
+      .def("load_bars", &Engine::loadBars,
+           "Load bars from numpy structured array (PyBar dtype)")
+      .def("load_bars_df", &Engine::loadBarsFromArrays,
+           "Load bars from DataFrame columns",
+           py::arg("timestamps"), py::arg("open"), py::arg("high"),
+           py::arg("low"), py::arg("close"), py::arg("volume"))
+      .def("run", &Engine::run,
+           "Run single backtest, returns stats dict",
+           py::arg("signals"), py::arg("symbol") = 1)
+      .def("run_batch", &Engine::runBatch,
+           "Run N backtests in parallel C++ threads",
+           py::arg("signal_sets"), py::arg("threads") = 0, py::arg("symbol") = 1)
+      .def_property_readonly("bar_count", &Engine::barCount);
+
+  m.def("make_signals", [](py::array_t<int64_t> timestamps, py::array_t<uint8_t> sides, py::array_t<double> quantities, std::optional<py::array_t<double>> prices, std::optional<py::array_t<uint8_t>> types) -> py::array_t<PySignal>
+        {
+          auto n = timestamps.size();
+          auto ts = timestamps.unchecked<1>();
+          auto sd = sides.unchecked<1>();
+          auto qt = quantities.unchecked<1>();
+
+          bool hasPrices = prices.has_value() && prices->size() == n;
+          bool hasTypes = types.has_value() && types->size() == n;
+
+          auto result = py::array_t<PySignal>(n);
+          auto buf = result.mutable_unchecked<1>();
+
+          using DblAccessor = py::detail::unchecked_reference<double, 1>;
+          using U8Accessor = py::detail::unchecked_reference<uint8_t, 1>;
+          std::optional<DblAccessor> px;
+          std::optional<U8Accessor> tp;
+          if (hasPrices){ px.emplace(prices->unchecked<1>());
+}
+          if (hasTypes){ tp.emplace(types->unchecked<1>());
+}
+
+          for (py::ssize_t i = 0; i < n; ++i)
+          {
+            int64_t t = ts(i);
+            if (t < static_cast<int64_t>(1e12)){ t *= 1'000'000'000LL;
+}
+            else if (t < static_cast<int64_t>(1e15)){ t *= 1'000'000LL;
+}
+            else if (t < static_cast<int64_t>(1e18)){ t *= 1'000LL;
+}
+
+            buf(i).timestamp_ns = t;
+            buf(i).quantity_raw = Quantity::fromDouble(qt(i)).raw();
+            buf(i).price_raw = px ? Price::fromDouble((*px)(i)).raw() : 0;
+            buf(i).side = sd(i);
+            buf(i).order_type = tp ? (*tp)(i) : 0;  // default: market
+          }
+          return result; }, "Create signal array from separate numpy arrays", py::arg("timestamps"), py::arg("sides"), py::arg("quantities"), py::arg("prices") = py::none(), py::arg("types") = py::none());
+
+  bindIndicators(m);
+}

--- a/python/indicator_bindings.h
+++ b/python/indicator_bindings.h
@@ -1,0 +1,473 @@
+// python/indicator_bindings.h
+
+#pragma once
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <cstring>
+
+#include "flox/indicator/adx.h"
+#include "flox/indicator/atr.h"
+#include "flox/indicator/bollinger.h"
+#include "flox/indicator/cci.h"
+#include "flox/indicator/chop.h"
+#include "flox/indicator/cvd.h"
+#include "flox/indicator/dema.h"
+#include "flox/indicator/ema.h"
+#include "flox/indicator/kama.h"
+#include "flox/indicator/macd.h"
+#include "flox/indicator/obv.h"
+#include "flox/indicator/rma.h"
+#include "flox/indicator/rsi.h"
+#include "flox/indicator/slope.h"
+#include "flox/indicator/sma.h"
+#include "flox/indicator/stochastic.h"
+#include "flox/indicator/vwap.h"
+
+namespace py = pybind11;
+
+namespace
+{
+
+inline void checkSameSize(size_t a, size_t b, const char* msg)
+{
+  if (a != b)
+  {
+    throw std::invalid_argument(msg);
+  }
+}
+
+template <typename Indicator>
+py::array_t<double> computeSingle(const Indicator& ind, py::array_t<double> input)
+{
+  auto buf = input.request();
+  auto* ptr = static_cast<const double*>(buf.ptr);
+  size_t n = buf.shape[0];
+
+  py::array_t<double> result(n);
+  auto out = result.mutable_data();
+  {
+    py::gil_scoped_release release;
+    ind.compute(std::span<const double>(ptr, n), std::span<double>(out, n));
+  }
+  return result;
+}
+
+}  // namespace
+
+inline void bindIndicators(py::module_& m)
+{
+  m.def(
+      "ema", [](py::array_t<double> input, size_t period)
+      { return computeSingle(flox::indicator::EMA(period), input); },
+      py::arg("input"), py::arg("period"));
+
+  m.def(
+      "sma", [](py::array_t<double> input, size_t period)
+      { return computeSingle(flox::indicator::SMA(period), input); },
+      py::arg("input"), py::arg("period"));
+
+  m.def(
+      "rsi", [](py::array_t<double> input, size_t period)
+      { return computeSingle(flox::indicator::RSI(period), input); },
+      py::arg("input"), py::arg("period"));
+
+  m.def(
+      "atr",
+      [](py::array_t<double> high, py::array_t<double> low, py::array_t<double> close,
+         size_t period) -> py::array_t<double>
+      {
+        size_t n = high.request().shape[0];
+        checkSameSize(n, low.request().shape[0], "high and low must have same size");
+        checkSameSize(n, close.request().shape[0], "high and close must have same size");
+        auto* h = high.data();
+        auto* l = low.data();
+        auto* c = close.data();
+        py::array_t<double> result(n);
+        auto* o = result.mutable_data();
+        {
+          py::gil_scoped_release release;
+          flox::indicator::ATR(period).compute(
+              std::span<const double>(h, n), std::span<const double>(l, n),
+              std::span<const double>(c, n), std::span<double>(o, n));
+        }
+        return result;
+      },
+      py::arg("high"), py::arg("low"), py::arg("close"), py::arg("period"));
+
+  m.def(
+      "macd",
+      [](py::array_t<double> input, size_t fast, size_t slow, size_t signal) -> py::dict
+      {
+        size_t n = input.request().shape[0];
+        auto* inp = input.data();
+        py::array_t<double> line(n), sig(n), hist(n);
+        auto* lp = line.mutable_data();
+        auto* sp = sig.mutable_data();
+        auto* hp = hist.mutable_data();
+        {
+          py::gil_scoped_release release;
+          flox::indicator::MACD(fast, slow, signal)
+              .compute(std::span<const double>(inp, n),
+                       std::span<double>(lp, n), std::span<double>(sp, n), std::span<double>(hp, n));
+        }
+        py::dict d;
+        d["line"] = line;
+        d["signal"] = sig;
+        d["histogram"] = hist;
+        return d;
+      },
+      py::arg("input"), py::arg("fast") = 12, py::arg("slow") = 26, py::arg("signal") = 9);
+
+  m.def(
+      "slope", [](py::array_t<double> input, size_t length)
+      { return computeSingle(flox::indicator::Slope(length), input); },
+      py::arg("input"), py::arg("length") = 1);
+
+  m.def(
+      "kama", [](py::array_t<double> input, size_t period)
+      { return computeSingle(flox::indicator::KAMA(period), input); },
+      py::arg("input"), py::arg("period") = 10);
+
+  m.def(
+      "obv",
+      [](py::array_t<double> close, py::array_t<double> volume) -> py::array_t<double>
+      {
+        size_t n = close.request().shape[0];
+        checkSameSize(n, volume.request().shape[0], "close and volume must have same size");
+        auto* c = close.data();
+        auto* v = volume.data();
+        py::array_t<double> result(n);
+        auto* o = result.mutable_data();
+        {
+          py::gil_scoped_release release;
+          flox::indicator::OBV().compute(
+              std::span<const double>(c, n), std::span<const double>(v, n), std::span<double>(o, n));
+        }
+        return result;
+      },
+      py::arg("close"), py::arg("volume"));
+
+  m.def(
+      "adx",
+      [](py::array_t<double> high, py::array_t<double> low, py::array_t<double> close,
+         size_t period) -> py::dict
+      {
+        size_t n = high.request().shape[0];
+        checkSameSize(n, low.request().shape[0], "arrays must have same size");
+        checkSameSize(n, close.request().shape[0], "arrays must have same size");
+        auto* h = high.data();
+        auto* l = low.data();
+        auto* c = close.data();
+        flox::indicator::AdxResult result;
+        {
+          py::gil_scoped_release release;
+          result = flox::indicator::ADX(period).compute(
+              std::span<const double>(h, n), std::span<const double>(l, n),
+              std::span<const double>(c, n));
+        }
+        py::array_t<double> adx_out(n), pdi(n), ndi(n);
+        std::memcpy(adx_out.mutable_data(), result.adx.data(), n * sizeof(double));
+        std::memcpy(pdi.mutable_data(), result.plus_di.data(), n * sizeof(double));
+        std::memcpy(ndi.mutable_data(), result.minus_di.data(), n * sizeof(double));
+        py::dict d;
+        d["adx"] = adx_out;
+        d["plus_di"] = pdi;
+        d["minus_di"] = ndi;
+        return d;
+      },
+      py::arg("high"), py::arg("low"), py::arg("close"), py::arg("period") = 14);
+
+  m.def(
+      "chop",
+      [](py::array_t<double> high, py::array_t<double> low, py::array_t<double> close,
+         size_t period) -> py::array_t<double>
+      {
+        size_t n = high.request().shape[0];
+        checkSameSize(n, low.request().shape[0], "arrays must have same size");
+        checkSameSize(n, close.request().shape[0], "arrays must have same size");
+        auto* h = high.data();
+        auto* l = low.data();
+        auto* c = close.data();
+        std::vector<double> result;
+        {
+          py::gil_scoped_release release;
+          result = flox::indicator::CHOP(period).compute(
+              std::span<const double>(h, n), std::span<const double>(l, n),
+              std::span<const double>(c, n));
+        }
+        py::array_t<double> out(n);
+        std::memcpy(out.mutable_data(), result.data(), n * sizeof(double));
+        return out;
+      },
+      py::arg("high"), py::arg("low"), py::arg("close"), py::arg("period") = 14);
+
+  m.def(
+      "bollinger",
+      [](py::array_t<double> input, size_t period, double stddev) -> py::dict
+      {
+        size_t n = input.request().shape[0];
+        auto* inp = input.data();
+        flox::indicator::BollingerResult result;
+        {
+          py::gil_scoped_release release;
+          result = flox::indicator::Bollinger(period, stddev)
+                       .compute(std::span<const double>(inp, n));
+        }
+        py::array_t<double> upper(n), middle(n), lower(n);
+        std::memcpy(upper.mutable_data(), result.upper.data(), n * sizeof(double));
+        std::memcpy(middle.mutable_data(), result.middle.data(), n * sizeof(double));
+        std::memcpy(lower.mutable_data(), result.lower.data(), n * sizeof(double));
+
+        py::dict d;
+        d["upper"] = upper;
+        d["middle"] = middle;
+        d["lower"] = lower;
+        return d;
+      },
+      py::arg("input"), py::arg("period") = 20, py::arg("stddev") = 2.0);
+
+  m.def(
+      "bar_returns",
+      [](py::array_t<int8_t> signal_long, py::array_t<int8_t> signal_short,
+         py::array_t<double> log_returns) -> py::array_t<double>
+      {
+        size_t n = signal_long.request().shape[0];
+        auto* sl = signal_long.data();
+        auto* ss = signal_short.data();
+        auto* lr = log_returns.data();
+        py::array_t<double> out(n);
+        auto* o = out.mutable_data();
+        o[0] = 0.0;
+        for (size_t i = 1; i < n; ++i)
+        {
+          o[i] = static_cast<double>(sl[i - 1] + ss[i - 1]) * lr[i];
+        }
+        return out;
+      },
+      py::arg("signal_long"), py::arg("signal_short"), py::arg("log_returns"));
+
+  m.def(
+      "trade_pnl",
+      [](py::array_t<int8_t> signal_long, py::array_t<int8_t> signal_short,
+         py::array_t<double> log_returns) -> py::array_t<double>
+      {
+        size_t n = signal_long.request().shape[0];
+        auto* sl = signal_long.data();
+        auto* ss = signal_short.data();
+        auto* lr = log_returns.data();
+
+        std::vector<double> trades;
+        double pnl = 0.0;
+        int8_t prevPos = 0;
+        bool inTrade = false;
+
+        for (size_t i = 1; i < n; ++i)
+        {
+          int8_t pos = sl[i - 1] + ss[i - 1];
+          double ret = static_cast<double>(pos) * lr[i];
+
+          if (pos != prevPos)
+          {
+            if (inTrade)
+            {
+              trades.push_back(pnl);
+              pnl = 0.0;
+            }
+            inTrade = (pos != 0);
+          }
+          if (pos != 0)
+          {
+            pnl += ret;
+          }
+          prevPos = pos;
+        }
+        if (inTrade)
+        {
+          trades.push_back(pnl);
+        }
+
+        py::array_t<double> out(trades.size());
+        std::memcpy(out.mutable_data(), trades.data(), trades.size() * sizeof(double));
+        return out;
+      },
+      py::arg("signal_long"), py::arg("signal_short"), py::arg("log_returns"));
+
+  m.def(
+      "profit_factor",
+      [](py::array_t<double> returns) -> double
+      {
+        size_t n = returns.request().shape[0];
+        auto* r = returns.data();
+        double pos = 0.0, neg = 0.0;
+        for (size_t i = 0; i < n; ++i)
+        {
+          if (r[i] > 0)
+          {
+            pos += r[i];
+          }
+          else if (r[i] < 0)
+          {
+            neg -= r[i];
+          }
+        }
+        return neg > 0 ? pos / neg : (pos > 0 ? 999.0 : 0.0);
+      },
+      py::arg("returns"));
+
+  m.def(
+      "win_rate",
+      [](py::array_t<double> trade_pnls) -> double
+      {
+        size_t n = trade_pnls.request().shape[0];
+        if (n == 0)
+        {
+          return 0.0;
+        }
+        auto* p = trade_pnls.data();
+        size_t wins = 0;
+        for (size_t i = 0; i < n; ++i)
+        {
+          if (p[i] > 0)
+          {
+            ++wins;
+          }
+        }
+        return static_cast<double>(wins) / n;
+      },
+      py::arg("trade_pnls"));
+
+  m.def(
+      "rma", [](py::array_t<double> input, size_t period)
+      { return computeSingle(flox::indicator::RMA(period), input); },
+      "Wilder's Moving Average (alpha=1/period)", py::arg("input"), py::arg("period"));
+
+  m.def(
+      "dema", [](py::array_t<double> input, size_t period)
+      {
+        auto buf = input.request();
+        size_t n = buf.shape[0];
+        auto* ptr = static_cast<const double*>(buf.ptr);
+        std::vector<double> result;
+        { py::gil_scoped_release r; result = flox::indicator::DEMA(period).compute(std::span<const double>(ptr, n)); }
+        py::array_t<double> out(n);
+        std::memcpy(out.mutable_data(), result.data(), n * sizeof(double));
+        return out; }, "Double EMA: 2*EMA - EMA(EMA)", py::arg("input"), py::arg("period"));
+
+  m.def(
+      "tema", [](py::array_t<double> input, size_t period)
+      {
+        auto buf = input.request();
+        size_t n = buf.shape[0];
+        auto* ptr = static_cast<const double*>(buf.ptr);
+        std::vector<double> result;
+        { py::gil_scoped_release r; result = flox::indicator::TEMA(period).compute(std::span<const double>(ptr, n)); }
+        py::array_t<double> out(n);
+        std::memcpy(out.mutable_data(), result.data(), n * sizeof(double));
+        return out; }, "Triple EMA: 3*EMA - 3*EMA(EMA) + EMA(EMA(EMA))", py::arg("input"), py::arg("period"));
+
+  m.def(
+      "stochastic",
+      [](py::array_t<double> high, py::array_t<double> low, py::array_t<double> close,
+         size_t k_period, size_t d_period) -> py::dict
+      {
+        size_t n = high.request().shape[0];
+        checkSameSize(n, low.request().shape[0], "arrays must have same size");
+        checkSameSize(n, close.request().shape[0], "arrays must have same size");
+        auto* h = high.data();
+        auto* l = low.data();
+        auto* c = close.data();
+        flox::indicator::StochasticResult result;
+        {
+          py::gil_scoped_release r;
+          result = flox::indicator::Stochastic(k_period, d_period).compute(std::span<const double>(h, n), std::span<const double>(l, n), std::span<const double>(c, n));
+        }
+        py::array_t<double> ko(n), dout(n);
+        std::memcpy(ko.mutable_data(), result.k.data(), n * sizeof(double));
+        std::memcpy(dout.mutable_data(), result.d.data(), n * sizeof(double));
+        py::dict d;
+        d["k"] = ko;
+        d["d"] = dout;
+        return d;
+      },
+      "Stochastic %K and %D",
+      py::arg("high"), py::arg("low"), py::arg("close"),
+      py::arg("k_period") = 14, py::arg("d_period") = 3);
+
+  m.def(
+      "cci",
+      [](py::array_t<double> high, py::array_t<double> low, py::array_t<double> close,
+         size_t period)
+      {
+        size_t n = high.request().shape[0];
+        checkSameSize(n, low.request().shape[0], "arrays must have same size");
+        checkSameSize(n, close.request().shape[0], "arrays must have same size");
+        auto* h = high.data();
+        auto* l = low.data();
+        auto* c = close.data();
+        std::vector<double> result;
+        {
+          py::gil_scoped_release r;
+          result = flox::indicator::CCI(period).compute(
+              std::span<const double>(h, n), std::span<const double>(l, n), std::span<const double>(c, n));
+        }
+        py::array_t<double> out(n);
+        std::memcpy(out.mutable_data(), result.data(), n * sizeof(double));
+        return out;
+      },
+      "Commodity Channel Index",
+      py::arg("high"), py::arg("low"), py::arg("close"), py::arg("period") = 20);
+
+  m.def(
+      "vwap",
+      [](py::array_t<double> close, py::array_t<double> volume, size_t window)
+      {
+        size_t n = close.request().shape[0];
+        checkSameSize(n, volume.request().shape[0], "arrays must have same size");
+        auto* c = close.data();
+        auto* v = volume.data();
+        std::vector<double> result;
+        {
+          py::gil_scoped_release r;
+          result = flox::indicator::VWAP(window).compute(
+              std::span<const double>(c, n), std::span<const double>(v, n));
+        }
+        py::array_t<double> out(n);
+        std::memcpy(out.mutable_data(), result.data(), n * sizeof(double));
+        return out;
+      },
+      "Rolling VWAP",
+      py::arg("close"), py::arg("volume"), py::arg("window") = 96);
+
+  m.def(
+      "cvd",
+      [](py::array_t<double> open, py::array_t<double> high, py::array_t<double> low,
+         py::array_t<double> close, py::array_t<double> volume)
+      {
+        size_t n = close.request().shape[0];
+        checkSameSize(n, open.request().shape[0], "arrays must have same size");
+        checkSameSize(n, high.request().shape[0], "arrays must have same size");
+        checkSameSize(n, low.request().shape[0], "arrays must have same size");
+        checkSameSize(n, volume.request().shape[0], "arrays must have same size");
+        auto* o = open.data();
+        auto* h = high.data();
+        auto* l = low.data();
+        auto* c = close.data();
+        auto* v = volume.data();
+        std::vector<double> result;
+        {
+          py::gil_scoped_release r;
+          result = flox::indicator::CVD().compute(
+              std::span<const double>(o, n), std::span<const double>(h, n),
+              std::span<const double>(l, n), std::span<const double>(c, n),
+              std::span<const double>(v, n));
+        }
+        py::array_t<double> out(n);
+        std::memcpy(out.mutable_data(), result.data(), n * sizeof(double));
+        return out;
+      },
+      "Cumulative Volume Delta",
+      py::arg("open"), py::arg("high"), py::arg("low"), py::arg("close"), py::arg("volume"));
+}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["scikit-build-core>=0.10", "pybind11>=2.12"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "flox-py"
+version = "0.1.0"
+authors = [{name = "FLOX Foundation"}]
+description = "Python bindings for the Flox indicator library"
+readme = "README.md"
+license = {text = "MIT"}
+license-files = ["../LICENSE"]
+requires-python = ">=3.9"
+dependencies = ["numpy"]
+keywords = ["trading", "backtest", "indicators", "technical-analysis"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Financial and Insurance Industry",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: C++",
+    "Programming Language :: Python :: 3",
+]
+
+[project.urls]
+Repository = "https://github.com/FLOX-Foundation/flox"
+
+[tool.scikit-build]
+cmake.args = ["-DFLOX_ENABLE_BACKTEST=ON", "-DFLOX_ENABLE_PYTHON=ON"]
+cmake.source-dir = ".."
+wheel.packages = []
+install.components = ["python_module"]

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,8 @@ if(FLOX_ENABLE_BACKTEST)
   add_flox_test(test_grid_search)
 endif()
 
+add_flox_test(test_indicators)
+
 if(FLOX_ENABLE_CPU_AFFINITY)
     add_flox_test(test_cpu_affinity)
 endif()

--- a/tests/test_indicators.cpp
+++ b/tests/test_indicators.cpp
@@ -1,0 +1,743 @@
+#include "flox/indicator/adx.h"
+#include "flox/indicator/atr.h"
+#include "flox/indicator/bar_fields.h"
+#include "flox/indicator/bollinger.h"
+#include "flox/indicator/cci.h"
+#include "flox/indicator/chop.h"
+#include "flox/indicator/cvd.h"
+#include "flox/indicator/dema.h"
+#include "flox/indicator/ema.h"
+#include "flox/indicator/indicator_pipeline.h"
+#include "flox/indicator/kama.h"
+#include "flox/indicator/macd.h"
+#include "flox/indicator/obv.h"
+#include "flox/indicator/rma.h"
+#include "flox/indicator/rsi.h"
+#include "flox/indicator/slope.h"
+#include "flox/indicator/sma.h"
+#include "flox/indicator/stochastic.h"
+#include "flox/indicator/vwap.h"
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <vector>
+
+using namespace flox;
+using namespace flox::indicator;
+
+static std::vector<double> prices()
+{
+  return {44, 44.34, 44.09, 43.61, 44.33, 44.83, 45.10, 45.42, 45.84,
+          46.08, 45.89, 46.03, 45.61, 46.28, 46.28, 46.00, 46.03, 46.41,
+          46.22, 45.64};
+}
+
+TEST(SMA, BasicWindow)
+{
+  SMA sma(5);
+  auto result = sma.compute(prices());
+  ASSERT_EQ(result.size(), 20u);
+  for (int i = 0; i < 4; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_NEAR(result[4], (44 + 44.34 + 44.09 + 43.61 + 44.33) / 5.0, 1e-10);
+}
+
+TEST(SMA, RollingSum)
+{
+  SMA sma(3);
+  std::vector<double> input = {1, 2, 3, 4, 5};
+  auto result = sma.compute(input);
+  EXPECT_NEAR(result[2], 2.0, 1e-10);
+  EXPECT_NEAR(result[3], 3.0, 1e-10);
+  EXPECT_NEAR(result[4], 4.0, 1e-10);
+}
+
+TEST(EMA, SmaSeed)
+{
+  EMA ema(10);
+  auto result = ema.compute(prices());
+  ASSERT_EQ(result.size(), 20u);
+  for (int i = 0; i < 9; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  // Seed = SMA of first 10 values
+  double sum = 0;
+  auto p = prices();
+  for (int i = 0; i < 10; ++i)
+  {
+    sum += p[i];
+  }
+  EXPECT_NEAR(result[9], sum / 10.0, 1e-10);
+}
+
+TEST(EMA, ExponentialDecay)
+{
+  EMA ema(10);
+  auto p = prices();
+  auto result = ema.compute(p);
+  double alpha = 2.0 / 11.0;
+  double expected = result[9];
+  for (size_t i = 10; i < p.size(); ++i)
+  {
+    expected = alpha * p[i] + (1.0 - alpha) * expected;
+    EXPECT_NEAR(result[i], expected, 1e-10);
+  }
+}
+
+TEST(EMA, Composition)
+{
+  // EMA of EMA -- verify compute(span<double>) works
+  EMA ema1(5);
+  EMA ema2(3);
+  auto p = prices();
+  auto first = ema1.compute(p);
+  auto second = ema2.compute(std::span<const double>(first));
+  // second should have NaN where first has NaN + 2 more warmup bars
+  EXPECT_TRUE(std::isnan(second[0]));
+  bool found = false;
+  for (size_t i = 0; i < second.size(); ++i)
+  {
+    if (!std::isnan(second[i]))
+    {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(EMA, WriteToBuffer)
+{
+  EMA ema(5);
+  auto p = prices();
+  std::vector<double> buf(p.size());
+  ema.compute(p, buf);
+  auto alloced = ema.compute(p);
+  for (size_t i = 0; i < p.size(); ++i)
+  {
+    if (std::isnan(alloced[i]))
+    {
+      EXPECT_TRUE(std::isnan(buf[i]));
+    }
+    else
+    {
+      EXPECT_DOUBLE_EQ(buf[i], alloced[i]);
+    }
+  }
+}
+
+TEST(ATR, WilderSmoothing)
+{
+  // Construct bars with known H/L/C
+  std::vector<double> h = {48.70, 48.72, 48.90, 48.87, 48.82, 49.05, 49.20, 49.35, 49.92, 50.19,
+                           50.12, 49.66, 49.88, 50.19, 50.36, 50.57, 50.65, 50.43, 49.63, 50.33};
+  std::vector<double> l = {47.79, 48.14, 48.39, 48.37, 48.24, 48.64, 48.94, 48.86, 49.50, 49.87,
+                           49.20, 48.90, 49.43, 49.73, 49.26, 50.09, 50.30, 49.21, 48.98, 49.61};
+  std::vector<double> c = {48.16, 48.61, 48.75, 48.63, 48.74, 49.03, 49.07, 49.32, 49.91, 50.13,
+                           49.53, 49.50, 49.75, 50.03, 49.99, 50.23, 50.33, 49.24, 49.00, 50.29};
+
+  ATR atr(14);
+  auto result = atr.compute(h, l, c);
+  ASSERT_EQ(result.size(), 20u);
+
+  // TA-Lib: TR[0] = NaN (no prev close), ATR first valid at index period (14)
+  for (int i = 0; i < 14; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_FALSE(std::isnan(result[14]));
+
+  for (size_t i = 14; i < result.size(); ++i)
+  {
+    EXPECT_FALSE(std::isnan(result[i]));
+    EXPECT_GT(result[i], 0.0);
+  }
+}
+
+TEST(ATR, BarOverload)
+{
+  // Create bars and verify Bar overload matches raw span overload
+  std::vector<Bar> bars(10);
+  for (size_t i = 0; i < 10; ++i)
+  {
+    bars[i].open = Price::fromDouble(100.0 + i);
+    bars[i].high = Price::fromDouble(101.0 + i);
+    bars[i].low = Price::fromDouble(99.0 + i);
+    bars[i].close = Price::fromDouble(100.5 + i);
+  }
+
+  ATR atr(5);
+  auto fromBars = atr.compute(std::span<const Bar>(bars));
+
+  auto h = indicator::high(std::span<const Bar>(bars));
+  auto l = indicator::low(std::span<const Bar>(bars));
+  auto c = indicator::close(std::span<const Bar>(bars));
+  auto fromSpans = atr.compute(h, l, c);
+
+  ASSERT_EQ(fromBars.size(), fromSpans.size());
+  for (size_t i = 0; i < fromBars.size(); ++i)
+  {
+    if (std::isnan(fromBars[i]))
+    {
+      EXPECT_TRUE(std::isnan(fromSpans[i]));
+    }
+    else
+    {
+      EXPECT_DOUBLE_EQ(fromBars[i], fromSpans[i]);
+    }
+  }
+}
+
+TEST(RSI, BoundaryValues)
+{
+  // All gains -> RSI should be 100
+  std::vector<double> allUp = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  RSI rsi(14);
+  auto result = rsi.compute(allUp);
+  for (size_t i = 15; i < result.size(); ++i)
+  {
+    EXPECT_NEAR(result[i], 100.0, 1e-10);
+  }
+
+  // All losses -> RSI should be 0
+  std::vector<double> allDown = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+  auto result2 = rsi.compute(allDown);
+  for (size_t i = 15; i < result2.size(); ++i)
+  {
+    EXPECT_NEAR(result2[i], 0.0, 1e-10);
+  }
+}
+
+TEST(RSI, MiddleRange)
+{
+  RSI rsi(14);
+  auto result = rsi.compute(prices());
+  for (size_t i = 0; i < 14; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_FALSE(std::isnan(result[14]));
+  for (size_t i = 14; i < result.size(); ++i)
+  {
+    EXPECT_GE(result[i], 0.0);
+    EXPECT_LE(result[i], 100.0);
+  }
+}
+
+TEST(MACD, ThreeOutputs)
+{
+  MACD macd(12, 26, 9);
+  auto result = macd.compute(prices());
+  ASSERT_EQ(result.line.size(), 20u);
+  ASSERT_EQ(result.signal.size(), 20u);
+  ASSERT_EQ(result.histogram.size(), 20u);
+}
+
+TEST(MACD, Composition)
+{
+  // MACD line values should be finite where signal is valid
+  MACD macd(3, 5, 3);
+  auto p = prices();
+  auto result = macd.compute(p);
+
+  bool hasValid = false;
+  for (size_t i = 0; i < p.size(); ++i)
+  {
+    if (!std::isnan(result.line[i]))
+    {
+      hasValid = true;
+      EXPECT_FALSE(std::isnan(result.signal[i]));
+      EXPECT_FALSE(std::isnan(result.histogram[i]));
+    }
+  }
+  EXPECT_TRUE(hasValid);
+}
+
+TEST(MACD, HistogramIsLineMinusSignal)
+{
+  MACD macd(3, 5, 3);
+  auto result = macd.compute(prices());
+  for (size_t i = 0; i < result.histogram.size(); ++i)
+  {
+    if (!std::isnan(result.histogram[i]))
+    {
+      EXPECT_NEAR(result.histogram[i], result.line[i] - result.signal[i], 1e-10);
+    }
+  }
+}
+
+TEST(MACD, WriteToBuffer)
+{
+  MACD macd(3, 5, 3);
+  auto p = prices();
+  std::vector<double> line(p.size()), signal(p.size()), hist(p.size());
+  macd.compute(p, line, signal, hist);
+  auto result = macd.compute(p);
+  for (size_t i = 0; i < p.size(); ++i)
+  {
+    if (std::isnan(result.line[i]))
+    {
+      EXPECT_TRUE(std::isnan(line[i]));
+    }
+    else
+    {
+      EXPECT_DOUBLE_EQ(line[i], result.line[i]);
+    }
+  }
+}
+
+// Edge cases
+
+TEST(SMA, EmptyInput)
+{
+  SMA sma(5);
+  auto result = sma.compute(std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(EMA, EmptyInput)
+{
+  EMA ema(5);
+  auto result = ema.compute(std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(ATR, EmptyInput)
+{
+  ATR atr(5);
+  auto result = atr.compute(
+      std::span<const double>{}, std::span<const double>{}, std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(RSI, EmptyInput)
+{
+  RSI rsi(14);
+  auto result = rsi.compute(std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(MACD, EmptyInput)
+{
+  MACD macd(3, 5, 3);
+  auto result = macd.compute(std::span<const double>{});
+  EXPECT_TRUE(result.line.empty());
+  EXPECT_TRUE(result.signal.empty());
+  EXPECT_TRUE(result.histogram.empty());
+}
+
+TEST(SMA, InputShorterThanPeriod)
+{
+  SMA sma(10);
+  std::vector<double> input = {1, 2, 3};
+  auto result = sma.compute(input);
+  ASSERT_EQ(result.size(), 3u);
+  for (auto v : result)
+  {
+    EXPECT_TRUE(std::isnan(v));
+  }
+}
+
+TEST(EMA, NaNInputSkipped)
+{
+  EMA ema(3);
+  std::vector<double> input = {std::nan(""), std::nan(""), 1, 2, 3, 4, 5};
+  auto result = ema.compute(input);
+  // First 2 NaN in input, then EMA seeds at index 4 (3 valid values: 1,2,3)
+  EXPECT_TRUE(std::isnan(result[0]));
+  EXPECT_TRUE(std::isnan(result[1]));
+  EXPECT_TRUE(std::isnan(result[2]));
+  EXPECT_TRUE(std::isnan(result[3]));
+  EXPECT_FALSE(std::isnan(result[4]));
+  EXPECT_NEAR(result[4], 2.0, 1e-10);  // SMA(1,2,3) = 2.0
+}
+
+TEST(RSI, NaNInputHandled)
+{
+  RSI rsi(3);
+  std::vector<double> input = {std::nan(""), 1, 2, 3, 4, 5, 4, 3, 2, 1};
+  auto result = rsi.compute(input);
+  // Should not crash, some values should be valid
+  bool hasValid = false;
+  for (auto v : result)
+  {
+    if (!std::isnan(v))
+    {
+      hasValid = true;
+      EXPECT_GE(v, 0.0);
+      EXPECT_LE(v, 100.0);
+    }
+  }
+  EXPECT_TRUE(hasValid);
+}
+
+TEST(BarFields, ExtractClose)
+{
+  std::vector<Bar> bars(5);
+  for (size_t i = 0; i < 5; ++i)
+  {
+    bars[i].close = Price::fromDouble(100.0 + i);
+  }
+  auto closes = indicator::close(std::span<const Bar>(bars));
+  ASSERT_EQ(closes.size(), 5u);
+  for (size_t i = 0; i < 5; ++i)
+  {
+    EXPECT_DOUBLE_EQ(closes[i], 100.0 + i);
+  }
+}
+
+TEST(BarFields, InPlaceExtract)
+{
+  std::vector<Bar> bars(3);
+  bars[0].high = Price::fromDouble(10.0);
+  bars[1].high = Price::fromDouble(20.0);
+  bars[2].high = Price::fromDouble(30.0);
+  std::vector<double> buf(3);
+  indicator::high(std::span<const Bar>(bars), buf);
+  EXPECT_DOUBLE_EQ(buf[0], 10.0);
+  EXPECT_DOUBLE_EQ(buf[1], 20.0);
+  EXPECT_DOUBLE_EQ(buf[2], 30.0);
+}
+
+// Slope
+
+TEST(Slope, Basic)
+{
+  Slope slope(1);
+  std::vector<double> input = {10, 12, 11, 15, 13};
+  auto result = slope.compute(input);
+  EXPECT_TRUE(std::isnan(result[0]));
+  EXPECT_NEAR(result[1], 2.0, 1e-10);
+  EXPECT_NEAR(result[2], -1.0, 1e-10);
+  EXPECT_NEAR(result[3], 4.0, 1e-10);
+  EXPECT_NEAR(result[4], -2.0, 1e-10);
+}
+
+TEST(Slope, LongerPeriod)
+{
+  Slope slope(3);
+  std::vector<double> input = {10, 12, 11, 15, 13};
+  auto result = slope.compute(input);
+  EXPECT_TRUE(std::isnan(result[0]));
+  EXPECT_TRUE(std::isnan(result[1]));
+  EXPECT_TRUE(std::isnan(result[2]));
+  EXPECT_NEAR(result[3], (15 - 10) / 3.0, 1e-10);
+  EXPECT_NEAR(result[4], (13 - 12) / 3.0, 1e-10);
+}
+
+// KAMA
+
+TEST(KAMA, SmaSeed)
+{
+  KAMA kama(10);
+  auto p = prices();
+  auto result = kama.compute(p);
+  ASSERT_EQ(result.size(), p.size());
+  // TA-Lib: KAMA first valid at period (10), seeded from close[period-1]
+  for (int i = 0; i < 10; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_FALSE(std::isnan(result[10]));
+  for (size_t i = 10; i < p.size(); ++i)
+  {
+    EXPECT_FALSE(std::isnan(result[i]));
+  }
+}
+
+// ADX
+
+TEST(ADX, ThreeOutputs)
+{
+  std::vector<double> h = {48.70, 48.72, 48.90, 48.87, 48.82, 49.05, 49.20, 49.35, 49.92, 50.19,
+                           50.12, 49.66, 49.88, 50.19, 50.36, 50.57, 50.65, 50.43, 49.63, 50.33};
+  std::vector<double> l = {47.79, 48.14, 48.39, 48.37, 48.24, 48.64, 48.94, 48.86, 49.50, 49.87,
+                           49.20, 48.90, 49.43, 49.73, 49.26, 50.09, 50.30, 49.21, 48.98, 49.61};
+  std::vector<double> c = {48.16, 48.61, 48.75, 48.63, 48.74, 49.03, 49.07, 49.32, 49.91, 50.13,
+                           49.53, 49.50, 49.75, 50.03, 49.99, 50.23, 50.33, 49.24, 49.00, 50.29};
+
+  // ADX(14) needs 2*14+1 = 29 bars minimum. We have 20 -- not enough for ADX.
+  // Use a larger dataset.
+  std::vector<double> h2, l2, c2;
+  for (int rep = 0; rep < 3; ++rep)
+  {
+    h2.insert(h2.end(), h.begin(), h.end());
+    l2.insert(l2.end(), l.begin(), l.end());
+    c2.insert(c2.end(), c.begin(), c.end());
+  }
+
+  ADX adx(14);
+  auto result = adx.compute(h2, l2, c2);
+  ASSERT_EQ(result.adx.size(), 60u);
+  ASSERT_EQ(result.plus_di.size(), 60u);
+
+  // First valid ADX at index 2*14-1 = 27
+  for (size_t i = 0; i < 27; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result.adx[i]));
+  }
+  EXPECT_FALSE(std::isnan(result.adx[27]));
+  EXPECT_GE(result.adx[27], 0.0);
+}
+
+// CHOP
+
+TEST(CHOP, Range)
+{
+  std::vector<double> h = {48.70, 48.72, 48.90, 48.87, 48.82, 49.05, 49.20, 49.35, 49.92, 50.19,
+                           50.12, 49.66, 49.88, 50.19, 50.36, 50.57, 50.65, 50.43, 49.63, 50.33};
+  std::vector<double> l = {47.79, 48.14, 48.39, 48.37, 48.24, 48.64, 48.94, 48.86, 49.50, 49.87,
+                           49.20, 48.90, 49.43, 49.73, 49.26, 50.09, 50.30, 49.21, 48.98, 49.61};
+  std::vector<double> c = {48.16, 48.61, 48.75, 48.63, 48.74, 49.03, 49.07, 49.32, 49.91, 50.13,
+                           49.53, 49.50, 49.75, 50.03, 49.99, 50.23, 50.33, 49.24, 49.00, 50.29};
+
+  CHOP chop(14);
+  auto result = chop.compute(h, l, c);
+  ASSERT_EQ(result.size(), 20u);
+
+  for (size_t i = 0; i < result.size(); ++i)
+  {
+    if (!std::isnan(result[i]))
+    {
+      // CHOP should be between 0 and 100
+      EXPECT_GE(result[i], 0.0);
+      EXPECT_LE(result[i], 100.0);
+    }
+  }
+}
+
+// OBV
+
+TEST(OBV, CumulativeVolume)
+{
+  std::vector<double> close = {10, 11, 10.5, 12, 11.5};
+  std::vector<double> vol = {100, 200, 150, 300, 250};
+
+  OBV obv;
+  auto result = obv.compute(close, vol);
+  ASSERT_EQ(result.size(), 5u);
+  // TA-Lib: OBV[0] = volume[0]
+  EXPECT_DOUBLE_EQ(result[0], 100.0);        // volume[0]
+  EXPECT_DOUBLE_EQ(result[1], 100.0 + 200);  // up: +200
+  EXPECT_DOUBLE_EQ(result[2], 300.0 - 150);  // down: -150
+  EXPECT_DOUBLE_EQ(result[3], 150.0 + 300);  // up: +300
+  EXPECT_DOUBLE_EQ(result[4], 450.0 - 250);  // down: -250
+}
+
+TEST(OBV, EmptyInput)
+{
+  OBV obv;
+  auto result = obv.compute(std::span<const double>{}, std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+// Bollinger
+
+TEST(Bollinger, ThreeBands)
+{
+  Bollinger bb(5, 2.0);
+  auto p = prices();
+  auto result = bb.compute(p);
+  ASSERT_EQ(result.upper.size(), p.size());
+  ASSERT_EQ(result.middle.size(), p.size());
+  ASSERT_EQ(result.lower.size(), p.size());
+
+  for (size_t i = 4; i < p.size(); ++i)
+  {
+    EXPECT_FALSE(std::isnan(result.middle[i]));
+    EXPECT_FALSE(std::isnan(result.upper[i]));
+    EXPECT_FALSE(std::isnan(result.lower[i]));
+    EXPECT_GT(result.upper[i], result.middle[i]);
+    EXPECT_LT(result.lower[i], result.middle[i]);
+  }
+}
+
+TEST(Bollinger, MiddleIsSma)
+{
+  Bollinger bb(5, 2.0);
+  SMA sma(5);
+  auto p = prices();
+  auto bbResult = bb.compute(p);
+  auto smaResult = sma.compute(p);
+
+  for (size_t i = 0; i < p.size(); ++i)
+  {
+    if (!std::isnan(bbResult.middle[i]))
+    {
+      EXPECT_NEAR(bbResult.middle[i], smaResult[i], 1e-10);
+    }
+  }
+}
+
+TEST(RMA, WilderSmoothing)
+{
+  RMA rma(5);
+  auto p = prices();
+  auto result = rma.compute(p);
+  ASSERT_EQ(result.size(), p.size());
+  for (int i = 0; i < 4; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_FALSE(std::isnan(result[4]));
+  double sum = 0;
+  for (int i = 0; i < 5; ++i)
+  {
+    sum += p[i];
+  }
+  EXPECT_NEAR(result[4], sum / 5.0, 1e-10);
+}
+
+TEST(DEMA, HasOutput)
+{
+  DEMA dema(5);
+  auto result = dema.compute(prices());
+  ASSERT_EQ(result.size(), 20u);
+  bool found = false;
+  for (auto v : result)
+  {
+    if (!std::isnan(v))
+    {
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(TEMA, HasOutput)
+{
+  TEMA tema(5);
+  auto result = tema.compute(prices());
+  ASSERT_EQ(result.size(), 20u);
+  bool found = false;
+  for (auto v : result)
+  {
+    if (!std::isnan(v))
+    {
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(Stochastic, KAndD)
+{
+  std::vector<double> h = {48.70, 48.72, 48.90, 48.87, 48.82, 49.05, 49.20, 49.35, 49.92, 50.19,
+                           50.12, 49.66, 49.88, 50.19, 50.36, 50.57, 50.65, 50.43, 49.63, 50.33};
+  std::vector<double> l = {47.79, 48.14, 48.39, 48.37, 48.24, 48.64, 48.94, 48.86, 49.50, 49.87,
+                           49.20, 48.90, 49.43, 49.73, 49.26, 50.09, 50.30, 49.21, 48.98, 49.61};
+  std::vector<double> c = {48.16, 48.61, 48.75, 48.63, 48.74, 49.03, 49.07, 49.32, 49.91, 50.13,
+                           49.53, 49.50, 49.75, 50.03, 49.99, 50.23, 50.33, 49.24, 49.00, 50.29};
+  Stochastic stoch(5, 3);
+  auto result = stoch.compute(h, l, c);
+  ASSERT_EQ(result.k.size(), 20u);
+  for (size_t i = 6; i < 20; ++i)
+  {
+    EXPECT_FALSE(std::isnan(result.k[i]));
+    EXPECT_GE(result.k[i], 0.0);
+    EXPECT_LE(result.k[i], 100.0);
+  }
+}
+
+TEST(CCI, Range)
+{
+  std::vector<double> h = {48.70, 48.72, 48.90, 48.87, 48.82, 49.05, 49.20, 49.35, 49.92, 50.19,
+                           50.12, 49.66, 49.88, 50.19, 50.36, 50.57, 50.65, 50.43, 49.63, 50.33};
+  std::vector<double> l = {47.79, 48.14, 48.39, 48.37, 48.24, 48.64, 48.94, 48.86, 49.50, 49.87,
+                           49.20, 48.90, 49.43, 49.73, 49.26, 50.09, 50.30, 49.21, 48.98, 49.61};
+  std::vector<double> c = {48.16, 48.61, 48.75, 48.63, 48.74, 49.03, 49.07, 49.32, 49.91, 50.13,
+                           49.53, 49.50, 49.75, 50.03, 49.99, 50.23, 50.33, 49.24, 49.00, 50.29};
+  CCI cci(14);
+  auto result = cci.compute(h, l, c);
+  ASSERT_EQ(result.size(), 20u);
+  for (size_t i = 13; i < 20; ++i)
+  {
+    EXPECT_FALSE(std::isnan(result[i]));
+  }
+}
+
+TEST(VWAP, Rolling)
+{
+  std::vector<double> close = {100, 101, 102, 103, 104};
+  std::vector<double> volume = {1000, 2000, 1500, 3000, 2500};
+  VWAP vwap(3);
+  auto result = vwap.compute(close, volume);
+  ASSERT_EQ(result.size(), 5u);
+  EXPECT_TRUE(std::isnan(result[0]));
+  EXPECT_FALSE(std::isnan(result[2]));
+  double expected = (100 * 1000.0 + 101 * 2000.0 + 102 * 1500.0) / (1000.0 + 2000.0 + 1500.0);
+  EXPECT_NEAR(result[2], expected, 1e-10);
+}
+
+TEST(CVD, Cumulative)
+{
+  std::vector<double> o = {100, 100, 100, 100, 100};
+  std::vector<double> h = {102, 102, 102, 102, 102};
+  std::vector<double> l = {98, 98, 98, 98, 98};
+  std::vector<double> c = {101, 99, 101, 99, 101};
+  std::vector<double> v = {100, 100, 100, 100, 100};
+  CVD cvd;
+  auto result = cvd.compute(o, h, l, c, v);
+  ASSERT_EQ(result.size(), 5u);
+  EXPECT_GT(result[0], 0);
+  EXPECT_LT(result[1], result[0]);
+}
+
+TEST(IndicatorGraph, DependencyResolution)
+{
+  IndicatorGraph g;
+  std::vector<Bar> bars(20);
+  for (size_t i = 0; i < 20; ++i)
+  {
+    bars[i].close = Price::fromDouble(100.0 + i);
+    bars[i].high = Price::fromDouble(101.0 + i);
+    bars[i].low = Price::fromDouble(99.0 + i);
+  }
+  g.setBars(0, bars);
+  g.addNode("ema5", {}, [](IndicatorGraph& g, SymbolId sym)
+            { return EMA(5).compute(g.close(sym)); });
+  g.addNode("slope1", {"ema5"}, [](IndicatorGraph& g, SymbolId sym)
+            { return Slope(1).compute(*g.get(sym, "ema5")); });
+  auto& slope = g.require(0, "slope1");
+  ASSERT_EQ(slope.size(), 20u);
+  auto* ema = g.get(0, "ema5");
+  ASSERT_NE(ema, nullptr);
+}
+
+TEST(IndicatorGraph, CircularDependencyThrows)
+{
+  IndicatorGraph g;
+  std::vector<Bar> bars(10);
+  for (auto& b : bars)
+  {
+    b.close = Price::fromDouble(100.0);
+  }
+  g.setBars(0, bars);
+  g.addNode("a", {"b"}, [](IndicatorGraph&, SymbolId)
+            { return std::vector<double>{}; });
+  g.addNode("b", {"a"}, [](IndicatorGraph&, SymbolId)
+            { return std::vector<double>{}; });
+  EXPECT_THROW(g.require(0, "a"), std::logic_error);
+}
+
+TEST(IndicatorGraph, CacheInvalidation)
+{
+  IndicatorGraph g;
+  std::vector<Bar> bars(10);
+  for (size_t i = 0; i < 10; ++i)
+  {
+    bars[i].close = Price::fromDouble(100.0 + i);
+  }
+  g.setBars(0, bars);
+  g.addNode("ema3", {}, [](IndicatorGraph& g, SymbolId sym)
+            { return EMA(3).compute(g.close(sym)); });
+  auto& r1 = g.require(0, "ema3");
+  double first = r1[9];
+  bars[9].close = Price::fromDouble(200.0);
+  g.setBars(0, bars);
+  auto& r2 = g.require(0, "ema3");
+  EXPECT_NE(r2[9], first);
+}


### PR DESCRIPTION
Closes #36, #85, #86, #87, #88, #89.

C++ indicators (EMA, SMA, RMA, KAMA, DEMA, TEMA, Slope, RSI, ATR, ADX, MACD, Bollinger, Stochastic, CCI, CHOP, OBV, VWAP, CVD) with pybind11 module that takes numpy arrays and doesn't block python threads while computing.

output matches TA-Lib, tested against it.

pip install flox-py, CI wheels in workflow.

also: IndicatorGraph for caching, multi-symbol thread dispatch, backtest python bindings.