### PR TITLE
Add symbol name resolution to the C API

### DIFF
--- a/include/flox/capi/bridge_strategy.h
+++ b/include/flox/capi/bridge_strategy.h
@@ -20,9 +20,11 @@ class BridgeStrategy : public Strategy
  public:
   BridgeStrategy(SubscriberId id, std::vector<SymbolId> symbols, const SymbolRegistry& registry,
                  FloxStrategyCallbacks callbacks)
-      : Strategy(id, std::move(symbols), registry), _cb(callbacks)
+      : Strategy(id, std::move(symbols), registry), _cb(callbacks), _registry(&registry)
   {
   }
+
+  const SymbolRegistry& registry() const { return *_registry; }
 
   void start() override
   {
@@ -198,6 +200,7 @@ class BridgeStrategy : public Strategy
   }
 
   FloxStrategyCallbacks _cb;
+  const SymbolRegistry* _registry;
 };
 
 }  // namespace flox

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -99,6 +99,14 @@ extern "C"
   uint32_t flox_registry_add_symbol(FloxRegistryHandle registry, const char* exchange,
                                     const char* name, double tick_size);
 
+  // Symbol name resolution
+  uint8_t flox_registry_get_symbol_id(FloxRegistryHandle registry, const char* exchange,
+                                      const char* name, uint32_t* id_out);
+  uint8_t flox_registry_get_symbol_name(FloxRegistryHandle registry, uint32_t symbol_id,
+                                        char* exchange_out, size_t exchange_len, char* name_out,
+                                        size_t name_len);
+  uint32_t flox_registry_symbol_count(FloxRegistryHandle registry);
+
   // ============================================================
   // Strategy lifecycle
   // ============================================================

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -63,6 +63,41 @@ uint32_t flox_registry_add_symbol(FloxRegistryHandle registry, const char* excha
   return reg->registerSymbol(info);
 }
 
+uint8_t flox_registry_get_symbol_id(FloxRegistryHandle registry, const char* exchange,
+                                    const char* name, uint32_t* id_out)
+{
+  auto* reg = toRegistry(registry);
+  auto result = reg->getSymbolId(exchange, name);
+  if (result.has_value())
+  {
+    *id_out = result.value();
+    return 1;
+  }
+  return 0;
+}
+
+uint8_t flox_registry_get_symbol_name(FloxRegistryHandle registry, uint32_t symbol_id,
+                                      char* exchange_out, size_t exchange_len, char* name_out,
+                                      size_t name_len)
+{
+  auto* reg = toRegistry(registry);
+  auto info = reg->getSymbolInfo(symbol_id);
+  if (!info.has_value())
+  {
+    return 0;
+  }
+  std::strncpy(exchange_out, info->exchange.c_str(), exchange_len - 1);
+  exchange_out[exchange_len - 1] = '\0';
+  std::strncpy(name_out, info->symbol.c_str(), name_len - 1);
+  name_out[name_len - 1] = '\0';
+  return 1;
+}
+
+uint32_t flox_registry_symbol_count(FloxRegistryHandle registry)
+{
+  return static_cast<uint32_t>(toRegistry(registry)->size());
+}
+
 // ============================================================
 // Strategy lifecycle
 // ============================================================

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,11 @@ endif()
 
 add_flox_test(test_indicators)
 
+if(FLOX_ENABLE_CAPI)
+  add_flox_test(test_capi_registry)
+  target_link_libraries(test_capi_registry PRIVATE flox_capi)
+endif()
+
 if(FLOX_ENABLE_CPU_AFFINITY)
     add_flox_test(test_cpu_affinity)
 endif()

--- a/tests/test_capi_registry.cpp
+++ b/tests/test_capi_registry.cpp
@@ -1,0 +1,117 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include "flox/capi/flox_capi.h"
+
+#include <gtest/gtest.h>
+#include <cstring>
+
+TEST(CapiRegistryTest, CreateAndDestroy)
+{
+  FloxRegistryHandle reg = flox_registry_create();
+  ASSERT_NE(reg, nullptr);
+  flox_registry_destroy(reg);
+}
+
+TEST(CapiRegistryTest, AddSymbolAndCount)
+{
+  FloxRegistryHandle reg = flox_registry_create();
+
+  EXPECT_EQ(flox_registry_symbol_count(reg), 0u);
+
+  uint32_t id1 = flox_registry_add_symbol(reg, "Binance", "BTCUSDT", 0.01);
+  EXPECT_GT(id1, 0u);
+  EXPECT_EQ(flox_registry_symbol_count(reg), 1u);
+
+  uint32_t id2 = flox_registry_add_symbol(reg, "Binance", "ETHUSDT", 0.01);
+  EXPECT_NE(id1, id2);
+  EXPECT_EQ(flox_registry_symbol_count(reg), 2u);
+
+  flox_registry_destroy(reg);
+}
+
+TEST(CapiRegistryTest, GetSymbolId)
+{
+  FloxRegistryHandle reg = flox_registry_create();
+
+  uint32_t added_id = flox_registry_add_symbol(reg, "Binance", "BTCUSDT", 0.01);
+
+  uint32_t found_id = 0;
+  EXPECT_EQ(flox_registry_get_symbol_id(reg, "Binance", "BTCUSDT", &found_id), 1);
+  EXPECT_EQ(found_id, added_id);
+
+  // Not found
+  uint32_t missing_id = 0;
+  EXPECT_EQ(flox_registry_get_symbol_id(reg, "Binance", "DOGEUSDT", &missing_id), 0);
+
+  // Wrong exchange
+  EXPECT_EQ(flox_registry_get_symbol_id(reg, "Bybit", "BTCUSDT", &missing_id), 0);
+
+  flox_registry_destroy(reg);
+}
+
+TEST(CapiRegistryTest, GetSymbolName)
+{
+  FloxRegistryHandle reg = flox_registry_create();
+
+  uint32_t id = flox_registry_add_symbol(reg, "Binance", "BTCUSDT", 0.01);
+
+  char exchange[64] = {};
+  char name[64] = {};
+  EXPECT_EQ(flox_registry_get_symbol_name(reg, id, exchange, sizeof(exchange), name, sizeof(name)),
+            1);
+  EXPECT_STREQ(exchange, "Binance");
+  EXPECT_STREQ(name, "BTCUSDT");
+
+  // Invalid symbol ID
+  EXPECT_EQ(flox_registry_get_symbol_name(reg, 9999, exchange, sizeof(exchange), name,
+                                          sizeof(name)),
+            0);
+
+  flox_registry_destroy(reg);
+}
+
+TEST(CapiRegistryTest, GetSymbolNameTruncation)
+{
+  FloxRegistryHandle reg = flox_registry_create();
+
+  flox_registry_add_symbol(reg, "Binance", "BTCUSDT", 0.01);
+
+  uint32_t id = 0;
+  flox_registry_get_symbol_id(reg, "Binance", "BTCUSDT", &id);
+
+  // Small buffer — should truncate safely
+  char exchange[4] = {};
+  char name[4] = {};
+  EXPECT_EQ(flox_registry_get_symbol_name(reg, id, exchange, sizeof(exchange), name, sizeof(name)),
+            1);
+  EXPECT_STREQ(exchange, "Bin");
+  EXPECT_STREQ(name, "BTC");
+
+  flox_registry_destroy(reg);
+}
+
+TEST(CapiRegistryTest, MultipleExchangesSameSymbol)
+{
+  FloxRegistryHandle reg = flox_registry_create();
+
+  uint32_t binance_id = flox_registry_add_symbol(reg, "Binance", "BTCUSDT", 0.01);
+  uint32_t bybit_id = flox_registry_add_symbol(reg, "Bybit", "BTCUSDT", 0.01);
+
+  EXPECT_NE(binance_id, bybit_id);
+
+  uint32_t found = 0;
+  EXPECT_EQ(flox_registry_get_symbol_id(reg, "Binance", "BTCUSDT", &found), 1);
+  EXPECT_EQ(found, binance_id);
+
+  EXPECT_EQ(flox_registry_get_symbol_id(reg, "Bybit", "BTCUSDT", &found), 1);
+  EXPECT_EQ(found, bybit_id);
+
+  flox_registry_destroy(reg);
+}


### PR DESCRIPTION
Let language bindings resolve string symbol names to numeric IDs
and back, so strategies can use "BTCUSDT" instead of raw uint32.