### PR TITLE
feat: statistical indicators + streaming API improvements + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ profiling_results
 .vscode
 .cache
 .clangd
+.venv
+
+node_modules
 
 compile_commands.json

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -24,6 +24,7 @@ add_flox_benchmark(event_bus_benchmark)
 add_flox_benchmark(multi_symbol_benchmark)
 add_flox_benchmark(cex_benchmark)
 add_flox_benchmark(position_aggregator_benchmark)
+add_flox_benchmark(statistical_indicator_benchmark)
 
 if(FLOX_ENABLE_CPU_AFFINITY)
     add_flox_benchmark(cpu_affinity_benchmark)

--- a/benchmarks/statistical_indicator_benchmark.cpp
+++ b/benchmarks/statistical_indicator_benchmark.cpp
@@ -1,0 +1,122 @@
+#include "flox/indicator/correlation.h"
+#include "flox/indicator/kurtosis.h"
+#include "flox/indicator/parkinson_vol.h"
+#include "flox/indicator/rogers_satchell_vol.h"
+#include "flox/indicator/rolling_zscore.h"
+#include "flox/indicator/shannon_entropy.h"
+#include "flox/indicator/skewness.h"
+
+#include <benchmark/benchmark.h>
+#include <random>
+#include <vector>
+
+using namespace flox::indicator;
+
+static std::vector<double> randomData(size_t n, double base = 100.0)
+{
+  std::mt19937 rng(42);
+  std::normal_distribution<double> dist(0.0, 1.0);
+  std::vector<double> data(n);
+  data[0] = base;
+  for (size_t i = 1; i < n; ++i)
+  {
+    data[i] = data[i - 1] + dist(rng);
+  }
+  return data;
+}
+
+static void BM_Skewness(benchmark::State& state)
+{
+  auto data = randomData(state.range(0));
+  Skewness ind(20);
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(ind.compute(data));
+  }
+}
+BENCHMARK(BM_Skewness)->RangeMultiplier(4)->Range(1024, 131072);
+
+static void BM_Kurtosis(benchmark::State& state)
+{
+  auto data = randomData(state.range(0));
+  Kurtosis ind(20);
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(ind.compute(data));
+  }
+}
+BENCHMARK(BM_Kurtosis)->RangeMultiplier(4)->Range(1024, 131072);
+
+static void BM_RollingZScore(benchmark::State& state)
+{
+  auto data = randomData(state.range(0));
+  RollingZScore ind(20);
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(ind.compute(data));
+  }
+}
+BENCHMARK(BM_RollingZScore)->RangeMultiplier(4)->Range(1024, 131072);
+
+static void BM_ShannonEntropy(benchmark::State& state)
+{
+  auto data = randomData(state.range(0));
+  ShannonEntropy ind(20, 10);
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(ind.compute(data));
+  }
+}
+BENCHMARK(BM_ShannonEntropy)->RangeMultiplier(4)->Range(1024, 131072);
+
+static void BM_ParkinsonVol(benchmark::State& state)
+{
+  size_t n = state.range(0);
+  auto base = randomData(n);
+  std::vector<double> high(n), low(n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    high[i] = base[i] + 1.0;
+    low[i] = base[i] - 1.0;
+  }
+  ParkinsonVol ind(20);
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(ind.compute(high, low));
+  }
+}
+BENCHMARK(BM_ParkinsonVol)->RangeMultiplier(4)->Range(1024, 131072);
+
+static void BM_RogersSatchellVol(benchmark::State& state)
+{
+  size_t n = state.range(0);
+  auto base = randomData(n);
+  std::vector<double> o(n), h(n), l(n), c(n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    o[i] = base[i];
+    h[i] = base[i] + 1.5;
+    l[i] = base[i] - 1.5;
+    c[i] = base[i] + 0.5;
+  }
+  RogersSatchellVol ind(20);
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(ind.compute(o, h, l, c));
+  }
+}
+BENCHMARK(BM_RogersSatchellVol)->RangeMultiplier(4)->Range(1024, 131072);
+
+static void BM_Correlation(benchmark::State& state)
+{
+  auto x = randomData(state.range(0), 100.0);
+  auto y = randomData(state.range(0), 50.0);
+  Correlation ind(20);
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(ind.compute(x, y));
+  }
+}
+BENCHMARK(BM_Correlation)->RangeMultiplier(4)->Range(1024, 131072);
+
+BENCHMARK_MAIN();

--- a/codon/flox/indicators.codon
+++ b/codon/flox/indicators.codon
@@ -1,5 +1,7 @@
-# flox/indicators.codon -- All 18 indicators via C API.
+# flox/indicators.codon -- All 25 indicators via C API.
 # Each has a batch function and a streaming class.
+
+import math
 
 from C import flox_indicator_sma(Ptr[f64], int, int, Ptr[f64])
 from C import flox_indicator_ema(Ptr[f64], int, int, Ptr[f64])
@@ -24,6 +26,13 @@ from C import flox_indicator_obv(Ptr[f64], Ptr[f64], int, Ptr[f64])
 from C import flox_indicator_vwap(Ptr[f64], Ptr[f64], int, int, Ptr[f64])
 from C import flox_indicator_cvd(Ptr[f64], Ptr[f64], Ptr[f64], Ptr[f64], Ptr[f64],
                                   int, Ptr[f64])
+from C import flox_indicator_skewness(Ptr[f64], int, int, Ptr[f64])
+from C import flox_indicator_kurtosis(Ptr[f64], int, int, Ptr[f64])
+from C import flox_indicator_rolling_zscore(Ptr[f64], int, int, Ptr[f64])
+from C import flox_indicator_shannon_entropy(Ptr[f64], int, int, int, Ptr[f64])
+from C import flox_indicator_parkinson_vol(Ptr[f64], Ptr[f64], int, int, Ptr[f64])
+from C import flox_indicator_rogers_satchell_vol(Ptr[f64], Ptr[f64], Ptr[f64], Ptr[f64], int, int, Ptr[f64])
+from C import flox_indicator_correlation(Ptr[f64], Ptr[f64], int, int, Ptr[f64])
 
 
 # ======================================================================
@@ -62,6 +71,12 @@ class SMA:
     @property
     def ready(self) -> bool:
         return self._count >= self._period
+
+    def reset(self):
+        self._buffer = [0.0] * self._period
+        self._sum = 0.0
+        self._count = 0
+        self._index = 0
 
     @staticmethod
     def compute(data: List[float], period: int) -> List[float]:
@@ -102,6 +117,11 @@ class EMA:
     def ready(self) -> bool:
         return self._count >= self._period
 
+    def reset(self):
+        self._value = 0.0
+        self._count = 0
+        self._sum = 0.0
+
     @staticmethod
     def compute(data: List[float], period: int) -> List[float]:
         n = len(data)
@@ -140,6 +160,11 @@ class RMA:
     @property
     def ready(self) -> bool:
         return self._count >= self._period
+
+    def reset(self):
+        self._value = 0.0
+        self._count = 0
+        self._sum = 0.0
 
     @staticmethod
     def compute(data: List[float], period: int) -> List[float]:
@@ -196,6 +221,13 @@ class RSI:
     def ready(self) -> bool:
         return self._count > self._period
 
+    def reset(self):
+        self._count = 0
+        self._prev = 0.0
+        self._avg_gain = 0.0
+        self._avg_loss = 0.0
+        self._value = 50.0
+
     @staticmethod
     def compute(data: List[float], period: int) -> List[float]:
         n = len(data)
@@ -240,6 +272,12 @@ class ATR:
     @property
     def ready(self) -> bool:
         return self._count >= self._period
+
+    def reset(self):
+        self._count = 0
+        self._prev_close = 0.0
+        self._value = 0.0
+        self._sum = 0.0
 
     @staticmethod
     def compute(high: List[float], low: List[float], close: List[float],
@@ -440,6 +478,11 @@ class DEMA:
     def ready(self) -> bool:
         return self._ema2.ready
 
+    def reset(self):
+        self._ema1 = EMA(self._ema1._period)
+        self._ema2 = EMA(self._ema2._period)
+        self._value = 0.0
+
 
 class TEMA:
     _ema1: EMA
@@ -468,6 +511,12 @@ class TEMA:
     def ready(self) -> bool:
         return self._ema3.ready
 
+    def reset(self):
+        self._ema1 = EMA(self._ema1._period)
+        self._ema2 = EMA(self._ema2._period)
+        self._ema3 = EMA(self._ema3._period)
+        self._value = 0.0
+
 
 class Slope:
     _length: int
@@ -494,6 +543,10 @@ class Slope:
     @property
     def ready(self) -> bool:
         return len(self._buffer) > self._length
+
+    def reset(self):
+        self._buffer = list[float]()
+        self._value = 0.0
 
 
 class MACD:
@@ -543,6 +596,15 @@ class MACD:
     @property
     def ready(self) -> bool:
         return self._ready
+
+    def reset(self):
+        self._fast_ema = EMA(self._fast_ema._period)
+        self._slow_ema = EMA(self._slow_ema._period)
+        self._signal_ema = EMA(self._signal_ema._period)
+        self._line = 0.0
+        self._signal = 0.0
+        self._histogram = 0.0
+        self._ready = False
 
 
 class Bollinger:
@@ -598,6 +660,13 @@ class Bollinger:
     def ready(self) -> bool:
         return self._sma.ready
 
+    def reset(self):
+        self._sma = SMA(self._period)
+        self._buffer = list[float]()
+        self._upper = 0.0
+        self._middle = 0.0
+        self._lower = 0.0
+
 
 class OBV:
     _value: float
@@ -627,6 +696,11 @@ class OBV:
     @property
     def ready(self) -> bool:
         return self._count > 0
+
+    def reset(self):
+        self._value = 0.0
+        self._prev_close = 0.0
+        self._count = 0
 
 
 class VWAP:
@@ -663,6 +737,11 @@ class VWAP:
     def ready(self) -> bool:
         return len(self._prices) >= self._window
 
+    def reset(self):
+        self._prices = list[float]()
+        self._volumes = list[float]()
+        self._value = 0.0
+
 
 class CVD:
     _value: float
@@ -687,6 +766,402 @@ class CVD:
     @property
     def ready(self) -> bool:
         return self._count > 0
+
+    def reset(self):
+        self._value = 0.0
+        self._count = 0
+
+
+class Skewness:
+    _period: int
+    _buffer: List[float]
+    _value: float
+
+    def __init__(self, period: int):
+        self._period = period
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    def update(self, value: float) -> float:
+        self._buffer.append(value)
+        if len(self._buffer) > self._period:
+            self._buffer.pop(0)
+        if len(self._buffer) >= self._period:
+            n = len(self._buffer)
+            mean = 0.0
+            for v in self._buffer:
+                mean += v
+            mean /= float(n)
+            m2 = 0.0
+            m3 = 0.0
+            for v in self._buffer:
+                d = v - mean
+                m2 += d * d
+                m3 += d * d * d
+            m2 /= float(n)
+            m3 /= float(n)
+            std = math.sqrt(m2)
+            if std == 0.0:
+                self._value = math.nan
+            else:
+                self._value = (float(n * n) / float((n - 1) * (n - 2))) * (m3 / (std * std * std))
+        return self._value
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @property
+    def ready(self) -> bool:
+        return len(self._buffer) >= self._period
+
+    def reset(self):
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    @staticmethod
+    def compute(data: List[float], period: int) -> List[float]:
+        n = len(data)
+        result = [0.0] * n
+        flox_indicator_skewness(data.arr.ptr, n, period, result.arr.ptr)
+        return result
+
+
+class Kurtosis:
+    _period: int
+    _buffer: List[float]
+    _value: float
+
+    def __init__(self, period: int):
+        self._period = period
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    def update(self, value: float) -> float:
+        self._buffer.append(value)
+        if len(self._buffer) > self._period:
+            self._buffer.pop(0)
+        if len(self._buffer) >= self._period:
+            n = len(self._buffer)
+            mean = 0.0
+            for v in self._buffer:
+                mean += v
+            mean /= float(n)
+            m2 = 0.0
+            m4 = 0.0
+            for v in self._buffer:
+                d = v - mean
+                d2 = d * d
+                m2 += d2
+                m4 += d2 * d2
+            m2 /= float(n)
+            m4 /= float(n)
+            if m2 == 0.0:
+                self._value = math.nan
+            else:
+                kurt = m4 / (m2 * m2)
+                self._value = (float(n - 1) / float((n - 2) * (n - 3))) * (float(n + 1) * kurt - 3.0 * float(n - 1))
+        return self._value
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @property
+    def ready(self) -> bool:
+        return len(self._buffer) >= self._period
+
+    def reset(self):
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    @staticmethod
+    def compute(data: List[float], period: int) -> List[float]:
+        n = len(data)
+        result = [0.0] * n
+        flox_indicator_kurtosis(data.arr.ptr, n, period, result.arr.ptr)
+        return result
+
+
+class RollingZScore:
+    _period: int
+    _buffer: List[float]
+    _value: float
+
+    def __init__(self, period: int):
+        self._period = period
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    def update(self, value: float) -> float:
+        self._buffer.append(value)
+        if len(self._buffer) > self._period:
+            self._buffer.pop(0)
+        if len(self._buffer) >= self._period:
+            n = len(self._buffer)
+            mean = 0.0
+            for v in self._buffer:
+                mean += v
+            mean /= float(n)
+            var = 0.0
+            for v in self._buffer:
+                d = v - mean
+                var += d * d
+            var /= float(n)
+            std = math.sqrt(var)
+            if std == 0.0:
+                self._value = math.nan
+            else:
+                self._value = (value - mean) / std
+        return self._value
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @property
+    def ready(self) -> bool:
+        return len(self._buffer) >= self._period
+
+    def reset(self):
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    @staticmethod
+    def compute(data: List[float], period: int) -> List[float]:
+        n = len(data)
+        result = [0.0] * n
+        flox_indicator_rolling_zscore(data.arr.ptr, n, period, result.arr.ptr)
+        return result
+
+
+class ShannonEntropy:
+    _period: int
+    _bins: int
+    _buffer: List[float]
+    _value: float
+
+    def __init__(self, period: int, bins: int = 10):
+        self._period = period
+        self._bins = bins
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    def update(self, value: float) -> float:
+        self._buffer.append(value)
+        if len(self._buffer) > self._period:
+            self._buffer.pop(0)
+        if len(self._buffer) >= self._period:
+            mn = self._buffer[0]
+            mx = self._buffer[0]
+            for v in self._buffer:
+                if v < mn:
+                    mn = v
+                if v > mx:
+                    mx = v
+            rng = mx - mn
+            if rng == 0.0:
+                self._value = 0.0
+            else:
+                counts = [0] * self._bins
+                n = len(self._buffer)
+                for v in self._buffer:
+                    b = int((v - mn) / rng * float(self._bins))
+                    if b >= self._bins:
+                        b = self._bins - 1
+                    counts[b] += 1
+                entropy = 0.0
+                for c in counts:
+                    if c > 0:
+                        p = float(c) / float(n)
+                        entropy -= p * math.log(p)
+                self._value = entropy
+        return self._value
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @property
+    def ready(self) -> bool:
+        return len(self._buffer) >= self._period
+
+    def reset(self):
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    @staticmethod
+    def compute(data: List[float], period: int, bins: int = 10) -> List[float]:
+        n = len(data)
+        result = [0.0] * n
+        flox_indicator_shannon_entropy(data.arr.ptr, n, period, bins,
+                                       result.arr.ptr)
+        return result
+
+
+class ParkinsonVol:
+    _period: int
+    _buffer: List[float]
+    _value: float
+
+    def __init__(self, period: int):
+        self._period = period
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    def update(self, high: float, low: float) -> float:
+        if low > 0.0 and high > 0.0:
+            ln_hl = math.log(high / low)
+            self._buffer.append(ln_hl * ln_hl)
+        else:
+            self._buffer.append(0.0)
+        if len(self._buffer) > self._period:
+            self._buffer.pop(0)
+        if len(self._buffer) >= self._period:
+            s = 0.0
+            for v in self._buffer:
+                s += v
+            self._value = math.sqrt(s / (float(len(self._buffer)) * 4.0 * math.log(2.0)))
+        return self._value
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @property
+    def ready(self) -> bool:
+        return len(self._buffer) >= self._period
+
+    def reset(self):
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    @staticmethod
+    def compute(high: List[float], low: List[float],
+                period: int) -> List[float]:
+        n = len(high)
+        result = [0.0] * n
+        flox_indicator_parkinson_vol(high.arr.ptr, low.arr.ptr,
+                                     n, period, result.arr.ptr)
+        return result
+
+
+class RogersSatchellVol:
+    _period: int
+    _buffer: List[float]
+    _value: float
+
+    def __init__(self, period: int):
+        self._period = period
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    def update(self, open_: float, high: float,
+               low: float, close: float) -> float:
+        if open_ > 0.0 and high > 0.0 and low > 0.0 and close > 0.0:
+            rs = (math.log(high / close) * math.log(high / open_)
+                  + math.log(low / close) * math.log(low / open_))
+            self._buffer.append(rs)
+        else:
+            self._buffer.append(0.0)
+        if len(self._buffer) > self._period:
+            self._buffer.pop(0)
+        if len(self._buffer) >= self._period:
+            s = 0.0
+            for v in self._buffer:
+                s += v
+            mean = s / float(len(self._buffer))
+            self._value = math.sqrt(mean) if mean >= 0.0 else 0.0
+        return self._value
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @property
+    def ready(self) -> bool:
+        return len(self._buffer) >= self._period
+
+    def reset(self):
+        self._buffer = list[float]()
+        self._value = 0.0
+
+    @staticmethod
+    def compute(open_: List[float], high: List[float],
+                low: List[float], close: List[float],
+                period: int) -> List[float]:
+        n = len(open_)
+        result = [0.0] * n
+        flox_indicator_rogers_satchell_vol(open_.arr.ptr, high.arr.ptr,
+                                           low.arr.ptr, close.arr.ptr,
+                                           n, period, result.arr.ptr)
+        return result
+
+
+class Correlation:
+    _period: int
+    _buf_x: List[float]
+    _buf_y: List[float]
+    _value: float
+
+    def __init__(self, period: int):
+        self._period = period
+        self._buf_x = list[float]()
+        self._buf_y = list[float]()
+        self._value = 0.0
+
+    def update(self, x: float, y: float) -> float:
+        self._buf_x.append(x)
+        self._buf_y.append(y)
+        if len(self._buf_x) > self._period:
+            self._buf_x.pop(0)
+            self._buf_y.pop(0)
+        if len(self._buf_x) >= self._period:
+            n = len(self._buf_x)
+            mean_x = 0.0
+            mean_y = 0.0
+            for i in range(n):
+                mean_x += self._buf_x[i]
+                mean_y += self._buf_y[i]
+            mean_x /= float(n)
+            mean_y /= float(n)
+            cov = 0.0
+            var_x = 0.0
+            var_y = 0.0
+            for i in range(n):
+                dx = self._buf_x[i] - mean_x
+                dy = self._buf_y[i] - mean_y
+                cov += dx * dy
+                var_x += dx * dx
+                var_y += dy * dy
+            denom = math.sqrt(var_x * var_y)
+            if denom == 0.0:
+                self._value = math.nan
+            else:
+                self._value = cov / denom
+        return self._value
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @property
+    def ready(self) -> bool:
+        return len(self._buf_x) >= self._period
+
+    def reset(self):
+        self._buf_x = list[float]()
+        self._buf_y = list[float]()
+        self._value = 0.0
+
+    @staticmethod
+    def compute(x: List[float], y: List[float],
+                period: int) -> List[float]:
+        n = len(x)
+        result = [0.0] * n
+        flox_indicator_correlation(x.arr.ptr, y.arr.ptr,
+                                   n, period, result.arr.ptr)
+        return result
 
 
 # Backward compatibility aliases

--- a/docs/explanation/README.md
+++ b/docs/explanation/README.md
@@ -10,6 +10,7 @@ Understand concepts and design decisions behind FLOX.
 | [Disruptor Pattern](disruptor.md) | Why we use ring buffers |
 | [Memory Model](memory-model.md) | Zero-allocation event delivery |
 | [Integration Flow](integration-flow.md) | End-to-end data flow through the system |
+| [Indicators](indicators.md) | What each indicator measures and when to use it |
 
 ## When to Read These
 

--- a/docs/explanation/indicators.md
+++ b/docs/explanation/indicators.md
@@ -1,0 +1,273 @@
+# Indicators
+
+flox has around 25 indicators, split across moving averages, oscillators, volatility, volume, and statistics. Each works in two modes: batch (pass an array, get an array back) and streaming (call `.update()` each tick, check `.ready` before reading `.value`).
+
+This page covers what each one actually measures and when you'd want it.
+
+---
+
+## Moving averages
+
+### SMA
+
+Arithmetic mean over a sliding window. Every bar gets equal weight.
+
+```
+SMA(n) = (x₁ + x₂ + ... + xₙ) / n
+```
+
+Responds slowly to recent price movement — which makes it less useful for short-term signals but reasonable for long-term trend reference. If you need a baseline to compare against, this is the simplest one.
+
+### EMA
+
+Weighted average where recent bars count more. Smoothing factor: `α = 2/(period+1)`.
+
+```
+EMA = α × price + (1 − α) × EMA_prev
+```
+
+Responds faster than SMA. MACD, ATR smoothing, and most other indicators build on it. The default choice when you need a moving average and have no strong reason to pick something else.
+
+### RMA
+
+Same structure as EMA but `α = 1/period` — slower. RSI and ATR use it internally (it's Wilder's smoothing).
+
+You probably won't use RMA directly unless you're reimplementing RSI/ATR from scratch or need exact TradingView parity.
+
+### DEMA
+
+```
+DEMA = 2 × EMA − EMA(EMA)
+```
+
+Less lag than EMA. Warmup takes `2 × period` bars. Worth trying when EMA crossover signals are consistently arriving a bar or two late.
+
+### TEMA
+
+```
+TEMA = 3 × EMA − 3 × EMA(EMA) + EMA(EMA(EMA))
+```
+
+More lag reduction than DEMA. Warmup is `3 × period`. Very reactive — expect more false signals in choppy markets.
+
+### KAMA
+
+Kaufman Adaptive Moving Average. Adjusts the smoothing factor based on an "efficiency ratio": how much price moved versus how much it oscillated. Goes fast in trending markets, slow in sideways ones.
+
+Useful if you want one MA that self-adjusts across regimes rather than manually switching between a fast and a slow EMA.
+
+### Slope
+
+Linear regression slope over a rolling window. Not exactly a moving average, but used in similar ways.
+
+```
+slope = Σ(x − x̄)(y − ȳ) / Σ(x − x̄)²
+```
+
+Positive = upward trend. Magnitude is the steepness. Good for momentum filtering.
+
+---
+
+## Oscillators
+
+### RSI
+
+Ratio of average gains to average losses over `period` bars, scaled to 0–100.
+
+```
+RSI = 100 − 100 / (1 + RS)
+RS  = avg_gain / avg_loss   (Wilder's RMA)
+```
+
+The classic levels (70 = overbought, 30 = oversold) work well in ranging markets. In a strong trend, RSI can stay above 70 for a long time — which is a feature, not a bug, depending on your strategy. Period 14 is standard; shorter periods make it noisier.
+
+### MACD
+
+Difference between a fast EMA and a slow EMA, with a signal line on top.
+
+```
+MACD line   = EMA(fast) − EMA(slow)    [default: 12, 26]
+signal line = EMA(MACD line, 9)
+histogram   = MACD line − signal line
+```
+
+Crossing zero signals a momentum shift. The histogram slope shows whether momentum is accelerating or fading. Watching the histogram flatten before the line crossover is a common entry filter.
+
+### Stochastic
+
+Where is the close relative to the recent high-low range?
+
+```
+%K = 100 × (close − lowest_low) / (highest_high − lowest_low)
+%D = SMA(%K, d_period)
+```
+
+Ranges 0–100. Common levels: 80 overbought, 20 oversold. The %D line smooths %K. Main signals are the %K/%D crossover and divergence between price and the indicator.
+
+### CCI
+
+Distance of the typical price from its SMA, divided by mean absolute deviation.
+
+```
+TP  = (high + low + close) / 3
+CCI = (TP − SMA(TP)) / (0.015 × mean_deviation)
+```
+
+Scaled so roughly 70% of values fall between −100 and +100. Values outside that band signal unusual strength or weakness. Often used as a momentum filter rather than a primary entry signal.
+
+### Bollinger Bands
+
+SMA with bands at ±N standard deviations.
+
+```
+middle = SMA(price, period)
+upper  = middle + multiplier × std(price, period)
+lower  = middle − multiplier × std(price, period)
+```
+
+Bands widen in volatile markets and contract when price quiets down. The squeeze — when bands get unusually narrow — often comes before a directional move. Price touching a band is context, not a signal by itself.
+
+---
+
+## Trend
+
+### ADX
+
+Measures trend strength, not direction. Comes with two directional indicators.
+
+```
++DI  = Wilder(upward movement, period)
+−DI  = Wilder(downward movement, period)
+ADX  = Wilder(|+DI − −DI| / (+DI + −DI), period)
+```
+
+ADX above 25 typically means there's a trend worth following. Below 20 is choppy. +DI and −DI tell you direction; ADX tells you whether to care.
+
+### CHOP
+
+How much price moved as a fraction of the maximum possible range over the period.
+
+```
+CHOP = 100 × log₁₀(Σ ATR / (highest_high − lowest_low)) / log₁₀(period)
+```
+
+High CHOP (near 100) means directionless. Low (near 0) means trending. More useful for switching between strategy modes than as a signal itself.
+
+---
+
+## Volatility
+
+### ATR
+
+Average range per bar, accounting for gaps.
+
+```
+true_range = max(high − low, |high − prev_close|, |low − prev_close|)
+ATR        = RMA(true_range, period)
+```
+
+Not directional. Standard use: position sizing (stop = N × ATR from entry) and filtering signals by volatility regime.
+
+### Parkinson volatility
+
+Uses high-low ranges instead of close-to-close returns.
+
+```
+σ = sqrt(mean(ln(H/L)²) / (4 × ln(2)))
+```
+
+More efficient than close-to-close when you have intraday OHLC data. Underestimates if the market gaps frequently, since gaps don't show in the H-L range.
+
+### Rogers-Satchell volatility
+
+OHLC volatility estimator designed to handle drift (trending markets) without bias.
+
+```
+σ² = mean(ln(H/C) × ln(H/O) + ln(L/C) × ln(L/O))
+```
+
+Better than Parkinson for trending assets. Both can be annualized by multiplying by `sqrt(periods_per_year)`.
+
+---
+
+## Volume
+
+### OBV
+
+Running total: add volume on up bars, subtract on down bars.
+
+```
+OBV = OBV_prev + (close > prev_close ? +volume : −volume)
+```
+
+The absolute value is meaningless — you're looking at the trend of OBV and divergences from price. Price makes a new high but OBV doesn't: the rally may not have conviction.
+
+### VWAP
+
+Average price weighted by volume, over a rolling window.
+
+```
+VWAP = Σ(price × volume) / Σ(volume)
+```
+
+Price above VWAP = buyers have been in control over that window. Used as a fair-value reference and order execution benchmark. Institutions care about VWAP when filling large orders.
+
+### CVD
+
+Running total of buying minus selling volume, inferred from OHLCV.
+
+```
+CVD = CVD_prev + buy_volume − sell_volume
+```
+
+Similar to OBV but directional. Divergence between CVD and price is one of the more reliable short-term signals when it appears.
+
+---
+
+## Statistical
+
+### Rolling z-score
+
+How many standard deviations is the current value from the rolling mean?
+
+```
+z = (x − mean(x, period)) / std(x, period)
+```
+
+Standard use is mean-reversion signals: z > 2 or < −2 marks statistically unusual levels. Returns NaN when std = 0.
+
+### Skewness
+
+Fisher-Pearson skewness of a rolling window — measures distribution asymmetry.
+
+```
+skew = (n / ((n−1)(n−2))) × Σ((x − mean) / std)³
+```
+
+Positive = right tail (large gains skew the distribution). Negative = left tail. Common in volatility forecasting and regime detection. Requires period ≥ 3; NaN if std = 0.
+
+### Kurtosis
+
+Tail heaviness relative to a normal distribution (Fisher excess kurtosis, so a normal distribution = 0).
+
+High kurtosis means fat tails — more outliers than a normal distribution would predict. Used in risk models to understand tail exposure. Requires period ≥ 4; NaN if std = 0.
+
+### Shannon entropy
+
+How random is the recent price distribution? Normalized to [0, 1] using histogram binning.
+
+```
+H = −Σ p(x) × ln(p(x)) / ln(bins)
+```
+
+1 = uniform distribution (maximum uncertainty). 0 = all values identical. Entropy tends to drop before trends develop and rise in choppy, uncertain markets — useful as a regime filter.
+
+### Correlation
+
+Rolling Pearson correlation between two series.
+
+```
+r = Σ(x − x̄)(y − ȳ) / sqrt(Σ(x − x̄)² × Σ(y − ȳ)²)
+```
+
+Range [−1, 1]. Used for pairs construction, cross-asset filters, or detecting when a relationship is breaking down. Returns NaN when either series is constant within the window.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,21 +1,81 @@
 # FLOX
 
-**C++ framework for building trading systems.**
+**High-performance trading framework with bindings for Python, Node.js, Codon, and C++.**
 
 [![GitHub](https://img.shields.io/badge/GitHub-FLOX--Foundation%2Fflox-blue?logo=github)](https://github.com/FLOX-Foundation/flox)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/FLOX-Foundation/flox/blob/main/LICENSE)
 
 ---
 
-## Getting Started
+## Getting started
+
+Pick your language:
 
 | | |
 |---|---|
-| [**Quickstart**](tutorials/quickstart.md) | Build FLOX and run the demo in 5 minutes |
-| [**First Strategy**](tutorials/first-strategy.md) | Write and run your first trading strategy |
-| [**Architecture**](explanation/architecture.md) | Understand how components work together |
-| [**Language Bindings**](bindings/README.md) | Python, Node.js, Codon, JavaScript |
-| [**API Reference**](reference/README.md) | Complete technical documentation |
+| [**Python quickstart**](tutorials/python-quickstart.md) | Indicators, strategies, and backtesting from Python |
+| [**Node.js quickstart**](tutorials/node-quickstart.md) | Same API from JavaScript/TypeScript |
+| [**C++ quickstart**](tutorials/quickstart.md) | Build FLOX and run the demo |
+| [**Architecture**](explanation/architecture.md) | How the components fit together |
+
+---
+
+## Quick example
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+
+    ema = flox.EMA(20)
+    rsi = flox.RSI(14)
+
+    for price in prices:
+        e = ema.update(price)
+        r = rsi.update(price)
+        if e is not None and r is not None:
+            print(f"EMA {e:.2f}  RSI {r:.1f}")
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const flox = require('./build/node');
+
+    const ema = new flox.EMA(20);
+    const rsi = new flox.RSI(14);
+
+    for (const price of prices) {
+        const e = ema.update(price);
+        const r = rsi.update(price);
+        if (e !== null && r !== null) {
+            console.log(`EMA ${e.toFixed(2)}  RSI ${r.toFixed(1)}`);
+        }
+    }
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/strategy/istrategy.h"
+    #include "flox/book/event/trade_event.h"
+
+    class MyStrategy : public flox::IStrategy {
+    public:
+        void onTrade(const flox::TradeEvent& event) override {
+            if (event.trade.symbol == _targetSymbol) {
+                processSignal(event.trade.price);
+            }
+        }
+
+        void start() override { _running = true; }
+        void stop() override  { _running = false; }
+
+    private:
+        flox::SymbolId _targetSymbol;
+        bool _running = false;
+    };
+    ```
 
 ---
 
@@ -68,33 +128,6 @@
 | Platform | Linux (recommended) |
 
 Optional: LZ4 for log compression
-
----
-
-## Quick Example
-
-```cpp
-#include "flox/strategy/istrategy.h"
-#include "flox/book/event/trade_event.h"
-
-class MyStrategy : public flox::IStrategy {
-public:
-    void onTrade(const flox::TradeEvent& event) override {
-        if (event.trade.symbol == _targetSymbol) {
-            processSignal(event.trade.price);
-        }
-    }
-
-    void start() override { _running = true; }
-    void stop() override { _running = false; }
-
-private:
-    flox::SymbolId _targetSymbol;
-    bool _running = false;
-};
-```
-
-[Full tutorial →](tutorials/first-strategy.md)
 
 ---
 

--- a/docs/reference/codon/indicators.md
+++ b/docs/reference/codon/indicators.md
@@ -9,28 +9,30 @@ Technical indicators for Codon strategies. Two types:
 
 ## Batch indicators
 
-Use these for historical data processing outside the hot path.
-
 ```codon
 from flox.indicators import ema, sma, rsi, atr, macd, bollinger
+from flox.indicators import Skewness, Kurtosis, RollingZScore, ShannonEntropy
+from flox.indicators import ParkinsonVol, RogersSatchellVol, Correlation
 ```
 
-| Function | Returns | Description |
-|----------|---------|-------------|
-| `ema(data, period)` | `List[float]` | Exponential Moving Average |
-| `sma(data, period)` | `List[float]` | Simple Moving Average |
-| `rsi(data, period)` | `List[float]` | Relative Strength Index |
-| `atr(high, low, close, period)` | `List[float]` | Average True Range |
-| `macd(data, fast=12, slow=26, signal=9)` | `MacdResult` | MACD |
-| `bollinger(data, period=20, multiplier=2.0)` | `BollingerResult` | Bollinger Bands |
+**Single value** — returns `List[float]`:
 
-`MacdResult` fields: `.line`, `.signal`, `.histogram`.
+`ema(data, period)`, `sma(data, period)`, `rma(data, period)`, `rsi(data, period)`, `dema(data, period)`, `tema(data, period)`, `kama(data, period)`
 
-`BollingerResult` fields: `.upper`, `.middle`, `.lower`.
+**OHLC / multi-input** — returns `List[float]`:
+
+`atr(high, low, close, period)`, `ParkinsonVol.compute(high, low, period)`, `RogersSatchellVol.compute(open, high, low, close, period)`, `Correlation.compute(x, y, period)`
+
+**Statistical** — returns `List[float]`:
+
+`Skewness.compute(data, period)`, `Kurtosis.compute(data, period)`, `RollingZScore.compute(data, period)`, `ShannonEntropy.compute(data, period, bins)`
+
+**Multi-output:**
+
+`macd(data, fast=12, slow=26, signal=9)` — returns `MacdResult`: `.line`, `.signal`, `.histogram`  
+`bollinger(data, period=20, multiplier=2.0)` — returns `BollingerResult`: `.upper`, `.middle`, `.lower`
 
 ```codon
-from flox.indicators import ema, atr, macd
-
 values = ema(prices, 20)
 
 m = macd(prices, 12, 26, 9)
@@ -43,12 +45,14 @@ ranges = atr(highs, lows, closes, 14)
 
 ## Streaming indicators
 
-All streaming indicators share the same pattern: call `update()` each tick, read `.value`, check `.ready`.
+All streaming indicators share the same pattern: call `update()` each tick, read `.value`, check `.ready`. All support `.reset()` to clear state.
 
 ```codon
 from flox.indicators import EMA, SMA, RSI, ATR, MACD, Bollinger
 from flox.indicators import RMA, DEMA, TEMA, KAMA, Slope
 from flox.indicators import OBV, VWAP, CVD
+from flox.indicators import Skewness, Kurtosis, RollingZScore, ShannonEntropy
+from flox.indicators import ParkinsonVol, RogersSatchellVol, Correlation
 ```
 
 ### Single-price indicators
@@ -62,16 +66,9 @@ if ema.ready:
     print(ema.value)
 ```
 
-| Method / Property | Returns | Description |
-|-------------------|---------|-------------|
-| `__init__(period)` | | |
-| `update(value)` | `float` | Feed new value, returns current EMA |
-| `value` | `float` | Current value |
-| `ready` | `bool` | True after `period` values |
-
 #### `SMA`
 
-Same API as `EMA`. Uses a circular buffer for O(1) updates.
+Uses a circular buffer for O(1) updates.
 
 ```codon
 sma = SMA(period=20)
@@ -87,29 +84,23 @@ rma = RMA(period=14)
 value = rma.update(price)
 ```
 
-Same API as `EMA`.
-
 #### `DEMA`
 
-Double Exponential Moving Average.
+Double Exponential Moving Average. `.ready` is true after `2 * period` values.
 
 ```codon
 dema = DEMA(period=20)
 value = dema.update(price)
 ```
 
-Same API as `EMA`. `.ready` is true after `2 * period` values.
-
 #### `TEMA`
 
-Triple Exponential Moving Average.
+Triple Exponential Moving Average. `.ready` is true after `3 * period` values.
 
 ```codon
 tema = TEMA(period=20)
 value = tema.update(price)
 ```
-
-Same API as `EMA`. `.ready` is true after `3 * period` values.
 
 #### `KAMA`
 
@@ -120,8 +111,6 @@ kama = KAMA(period=10)
 value = kama.update(price)
 ```
 
-Same API as `EMA`.
-
 #### `Slope`
 
 Linear regression slope over a rolling window.
@@ -130,8 +119,6 @@ Linear regression slope over a rolling window.
 slope = Slope(period=20)
 value = slope.update(price)
 ```
-
-Same API as `EMA`.
 
 #### `RSI`
 
@@ -142,7 +129,41 @@ if rsi.ready:
     print(rsi.value)  # 0..100
 ```
 
-Same API as `EMA`.
+#### `Skewness`
+
+Fisher-Pearson skewness. Requires period >= 3.
+
+```codon
+skew = Skewness(period=20)
+value = skew.update(price)
+```
+
+#### `Kurtosis`
+
+Fisher excess kurtosis. Requires period >= 4.
+
+```codon
+kurt = Kurtosis(period=20)
+value = kurt.update(price)
+```
+
+#### `RollingZScore`
+
+`(x - mean) / std`.
+
+```codon
+zscore = RollingZScore(period=20)
+value = zscore.update(price)
+```
+
+#### `ShannonEntropy`
+
+Rolling Shannon entropy, normalized to [0, 1].
+
+```codon
+ent = ShannonEntropy(period=20, bins=10)
+value = ent.update(price)
+```
 
 ---
 
@@ -153,16 +174,7 @@ Same API as `EMA`.
 ```codon
 atr = ATR(period=14)
 value = atr.update(high, low, close)
-if atr.ready:
-    print(atr.value)
 ```
-
-| Method / Property | Returns | Description |
-|-------------------|---------|-------------|
-| `__init__(period)` | | |
-| `update(high, low, close)` | `float` | Feed OHLC values |
-| `value` | `float` | Current ATR |
-| `ready` | `bool` | True after `period` bars |
 
 #### `MACD`
 
@@ -173,15 +185,6 @@ if macd.ready:
     print(macd.line, macd.signal, macd.histogram)
 ```
 
-| Method / Property | Returns | Description |
-|-------------------|---------|-------------|
-| `__init__(fast, slow, signal)` | | |
-| `update(value)` | `None` | Feed new value |
-| `line` | `float` | MACD line (fast EMA − slow EMA) |
-| `signal` | `float` | Signal line (EMA of MACD line) |
-| `histogram` | `float` | `line − signal` |
-| `ready` | `bool` | True after `slow + signal` values |
-
 #### `Bollinger`
 
 ```codon
@@ -191,14 +194,32 @@ if bb.ready:
     print(bb.upper, bb.middle, bb.lower)
 ```
 
-| Method / Property | Returns | Description |
-|-------------------|---------|-------------|
-| `__init__(period, multiplier=2.0)` | | |
-| `update(value)` | `None` | Feed new value |
-| `upper` | `float` | Upper band |
-| `middle` | `float` | Middle band (SMA) |
-| `lower` | `float` | Lower band |
-| `ready` | `bool` | True after `period` values |
+#### `ParkinsonVol`
+
+Parkinson high-low volatility estimator.
+
+```codon
+pvol = ParkinsonVol(period=20)
+value = pvol.update(high, low)
+```
+
+#### `RogersSatchellVol`
+
+Rogers-Satchell OHLC volatility estimator.
+
+```codon
+rsv = RogersSatchellVol(period=20)
+value = rsv.update(open_, high, low, close)
+```
+
+#### `Correlation`
+
+Rolling Pearson correlation between two series.
+
+```codon
+corr = Correlation(period=20)
+value = corr.update(x, y)
+```
 
 ---
 
@@ -213,12 +234,6 @@ obv = OBV()
 value = obv.update(price, volume, is_buy)
 ```
 
-| Method / Property | Returns | Description |
-|-------------------|---------|-------------|
-| `__init__()` | | |
-| `update(price, volume, is_buy)` | `float` | Feed trade data |
-| `value` | `float` | Current OBV |
-
 #### `VWAP`
 
 Volume Weighted Average Price.
@@ -228,13 +243,6 @@ vwap = VWAP()
 value = vwap.update(price, volume)
 ```
 
-| Method / Property | Returns | Description |
-|-------------------|---------|-------------|
-| `__init__()` | | |
-| `update(price, volume)` | `float` | Feed price and volume |
-| `value` | `float` | Current VWAP |
-| `reset()` | `None` | Reset accumulator (e.g. session start) |
-
 #### `CVD`
 
 Cumulative Volume Delta.
@@ -243,13 +251,6 @@ Cumulative Volume Delta.
 cvd = CVD()
 value = cvd.update(volume, is_buy)
 ```
-
-| Method / Property | Returns | Description |
-|-------------------|---------|-------------|
-| `__init__()` | | |
-| `update(volume, is_buy)` | `float` | Feed volume |
-| `value` | `float` | Current CVD (buy vol − sell vol) |
-| `reset()` | `None` | Reset accumulator |
 
 ---
 

--- a/docs/reference/node/indicators.md
+++ b/docs/reference/node/indicators.md
@@ -4,28 +4,32 @@
 
 ## Batch functions
 
-Take `Float64Array` inputs, return `Float64Array` (or object for multi-output).
+Input arrays are `Float64Array`. Single-output functions return `Float64Array`.
 
-| Function | Signature | Returns |
-|----------|-----------|---------|
-| `sma(input, period)` | | `Float64Array` |
-| `ema(input, period)` | | `Float64Array` |
-| `rsi(input, period)` | | `Float64Array` |
-| `rma(input, period)` | Wilder's MA | `Float64Array` |
-| `dema(input, period)` | | `Float64Array` |
-| `tema(input, period)` | | `Float64Array` |
-| `kama(input, period)` | | `Float64Array` |
-| `slope(input, length)` | | `Float64Array` |
-| `atr(high, low, close, period)` | | `Float64Array` |
-| `adx(high, low, close, period)` | | `{ adx, plusDi, minusDi }` |
-| `macd(input, fast, slow, signal)` | | `{ line, signal, histogram }` |
-| `bollinger(input, period, stdDev)` | | `{ upper, middle, lower }` |
-| `stochastic(high, low, close, kPeriod, dPeriod)` | | `{ k, d }` |
-| `cci(high, low, close, period)` | | `Float64Array` |
-| `chop(high, low, close, period)` | | `Float64Array` |
-| `obv(close, volume)` | | `Float64Array` |
-| `vwap(close, volume, window)` | | `Float64Array` |
-| `cvd(open, high, low, close, volume)` | Cumulative volume delta | `Float64Array` |
+```javascript
+const ema  = flox.ema(closes, 20);
+const macd = flox.macd(closes, 12, 26, 9);       // { line, signal, histogram }
+const bb   = flox.bollinger(closes, 20, 2.0);     // { upper, middle, lower }
+const st   = flox.stochastic(hi, lo, cl, 14, 3); // { k, d }
+const adx  = flox.adx(hi, lo, cl, 14);           // { adx, plusDi, minusDi }
+```
+
+**Single value** — `(input, period)`:
+
+`sma`, `ema`, `rma`, `rsi`, `dema`, `tema`, `kama`, `slope`
+
+**OHLC input:**
+
+`atr(high, low, close, period)`, `cci(high, low, close, period)`, `chop(high, low, close, period)`,
+`parkinson_vol(high, low, period)`, `rogers_satchell_vol(open, high, low, close, period)`
+
+**Statistical** — `(input, period)`:
+
+`skewness`, `kurtosis`, `rolling_zscore`, `shannon_entropy(input, period, bins)`, `correlation(x, y, period)`
+
+**Volume:**
+
+`obv(close, volume)`, `vwap(close, volume, window)`, `cvd(open, high, low, close, volume)`
 
 ---
 
@@ -35,28 +39,34 @@ All streaming indicators share the same interface:
 
 ```javascript
 const ind = new flox.EMA(14);
-ind.update(price);   // returns current value
-ind.value            // current value (property)
-ind.ready            // true once warmed up (property)
+ind.update(price);   // returns current value (null during warmup)
+ind.value            // current value
+ind.ready            // true once warmed up
+ind.reset()          // clear state, keep config
 ```
 
-Multi-output indicators have additional properties instead of `value`:
+**Single value** — `update(value)`:
 
-| Class | Constructor | Extra properties |
-|-------|-------------|-----------------|
-| `SMA(period)` | | |
-| `EMA(period)` | | |
-| `RSI(period)` | | |
-| `RMA(period)` | Wilder's MA | |
-| `DEMA(period)` | | |
-| `TEMA(period)` | | |
-| `KAMA(period, fast?, slow?)` | | |
-| `Slope(length)` | | |
-| `ATR(period)` | `update(high, low, close)` | |
-| `MACD(fast?, slow?, signal?)` | defaults: 12/26/9 | `line`, `signal`, `histogram` |
-| `Bollinger(period, stdDev?)` | default stdDev: 2.0 | `upper`, `middle`, `lower` |
-| `Stochastic(kPeriod, dPeriod?)` | default d: 3 | `k`, `d` |
-| `CCI(period)` | `update(high, low, close)` | |
-| `OBV()` | `update(close, volume)` | |
-| `VWAP(window)` | `update(close, volume)` | |
-| `CVD()` | `update(open, high, low, close, volume)` | |
+`SMA(period)`, `EMA(period)`, `RMA(period)`, `RSI(period)`, `DEMA(period)`, `TEMA(period)`,
+`KAMA(period, fast?, slow?)`, `Slope(length)`, `Skewness(period)`, `Kurtosis(period)`,
+`RollingZScore(period)`, `ShannonEntropy(period, bins)`
+
+**Multi-output** — `update(value)`, named properties instead of `.value`:
+
+`MACD(fast?, slow?, signal?)` — defaults 12/26/9 → `.line`, `.signal`, `.histogram`  
+`Bollinger(period, stdDev?)` — default stdDev 2.0 → `.upper`, `.middle`, `.lower`
+
+**OHLC / multi-input:**
+
+`ATR(period)` — `update(high, low, close)`  
+`Stochastic(kPeriod, dPeriod?)` — `update(high, low, close)` → `.k`, `.d`  
+`CCI(period)` — `update(high, low, close)`  
+`ParkinsonVol(period)` — `update(high, low)`  
+`RogersSatchellVol(period)` — `update(open, high, low, close)`  
+`Correlation(period)` — `update(x, y)`
+
+**Volume:**
+
+`OBV()` — `update(close, volume)`  
+`VWAP(window)` — `update(close, volume)`  
+`CVD()` — `update(open, high, low, close, volume)`

--- a/docs/reference/python/indicators.md
+++ b/docs/reference/python/indicators.md
@@ -2,6 +2,49 @@
 
 Vectorized technical indicators operating on numpy arrays. All functions release the GIL for parallel computation.
 
+## Streaming classes
+
+All streaming indicators share the same interface:
+
+```python
+ind = flox.EMA(20)
+result = ind.update(price)  # None during warmup, float when ready
+ind.value                   # None or float
+ind.ready                   # bool
+ind.reset()                 # clear state, keep config
+ind2 = ind.fresh()          # new independent instance, same config
+```
+
+During warmup, `update()` and `.value` return `None`. Check with `if result is not None` or use `.ready`.
+
+**Single value** — `update(value) -> float | None`:
+
+`SMA(period)`, `EMA(period)`, `RMA(period)`, `RSI(period)`, `DEMA(period)`, `TEMA(period)`, `KAMA(period, fast=2, slow=30)`, `Slope(length)`, `Skewness(period)`, `Kurtosis(period)`, `RollingZScore(period)`, `ShannonEntropy(period, bins=10)`
+
+**Multi-output** — `update(value) -> float | None`, named properties instead of `.value`:
+
+`MACD(fast=12, slow=26, signal=9)` → `.line`, `.signal`, `.histogram`  
+`Bollinger(period=20, multiplier=2.0)` → `.upper`, `.middle`, `.lower`
+
+**OHLC / multi-input:**
+
+`ATR(period)` — `update(high, low, close)`  
+`Stochastic(k_period=14, d_period=3)` — `update(high, low, close)` → `.k`, `.d`  
+`CCI(period=20)` — `update(high, low, close)`  
+`ParkinsonVol(period)` — `update(high, low)`  
+`RogersSatchellVol(period)` — `update(open, high, low, close)`  
+`Correlation(period)` — `update(x, y)`
+
+**Volume:**
+
+`OBV()` — `update(close, volume)`  
+`VWAP(window)` — `update(close, volume)`  
+`CVD()` — `update(open, high, low, close, volume)`
+
+---
+
+## Batch functions
+
 ## Moving Averages
 
 ### `ema(input, period) -> ndarray`
@@ -70,16 +113,8 @@ Moving Average Convergence Divergence. Returns a dict with three arrays.
 
 ```python
 result = flox.macd(closes, fast=12, slow=26, signal=9)
-macd_line = result['line']
-signal_line = result['signal']
-histogram = result['histogram']
+# result['line'], result['signal'], result['histogram']
 ```
-
-| Key | Description |
-|-----|-------------|
-| `line` | MACD line (fast EMA - slow EMA) |
-| `signal` | Signal line (EMA of MACD line) |
-| `histogram` | MACD - Signal |
 
 ### `stochastic(high, low, close, k_period=14, d_period=3) -> dict`
 
@@ -109,16 +144,8 @@ Average Directional Index with directional indicators.
 
 ```python
 result = flox.adx(highs, lows, closes, period=14)
-adx_values = result['adx']
-plus_di = result['plus_di']
-minus_di = result['minus_di']
+# result['adx'], result['plus_di'], result['minus_di']
 ```
-
-| Key | Description |
-|-----|-------------|
-| `adx` | ADX values |
-| `plus_di` | +DI (positive directional indicator) |
-| `minus_di` | -DI (negative directional indicator) |
 
 ### `chop(high, low, close, period=14) -> ndarray`
 
@@ -154,16 +181,68 @@ Bollinger Bands.
 
 ```python
 result = flox.bollinger(closes, period=20, stddev=2.0)
-upper = result['upper']
-middle = result['middle']
-lower = result['lower']
+# result['upper'], result['middle'], result['lower']
 ```
 
-| Key | Description |
-|-----|-------------|
-| `upper` | Upper band (middle + stddev * std) |
-| `middle` | Middle band (SMA) |
-| `lower` | Lower band (middle - stddev * std) |
+---
+
+## Statistical
+
+### `skewness(input, period) -> ndarray`
+
+Rolling Fisher-Pearson skewness. Measures distribution asymmetry. Requires period >= 3. NaN if std = 0.
+
+```python
+result = flox.skewness(closes, period=20)
+```
+
+### `kurtosis(input, period) -> ndarray`
+
+Rolling Fisher excess kurtosis. Measures tail heaviness. Requires period >= 4. NaN if std = 0.
+
+```python
+result = flox.kurtosis(closes, period=20)
+```
+
+### `rolling_zscore(input, period) -> ndarray`
+
+Rolling z-score normalization: `(x - mean) / std`. NaN if std = 0.
+
+```python
+result = flox.rolling_zscore(closes, period=20)
+```
+
+### `shannon_entropy(input, period, bins=10) -> ndarray`
+
+Rolling Shannon entropy with histogram binning, normalized to [0, 1]. Zero = all values identical, 1 = uniform distribution.
+
+```python
+result = flox.shannon_entropy(closes, period=20, bins=10)
+```
+
+### `parkinson_vol(high, low, period) -> ndarray`
+
+Parkinson high-low volatility estimator: `sqrt(mean(ln(H/L)^2) / (4*ln(2)))`. More efficient than close-to-close volatility.
+
+```python
+result = flox.parkinson_vol(highs, lows, period=20)
+```
+
+### `rogers_satchell_vol(open, high, low, close, period) -> ndarray`
+
+Rogers-Satchell OHLC volatility estimator. Unbiased with drift, suitable for trending markets.
+
+```python
+result = flox.rogers_satchell_vol(opens, highs, lows, closes, period=20)
+```
+
+### `correlation(x, y, period) -> ndarray`
+
+Rolling Pearson correlation between two series. NaN if either series is constant within the window.
+
+```python
+result = flox.correlation(closes_btc, closes_eth, period=20)
+```
 
 ---
 
@@ -205,11 +284,7 @@ Compute per-bar returns given position signals and log returns.
 returns = flox.bar_returns(signal_long, signal_short, log_returns)
 ```
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `signal_long` | `int8[]` | Long position flags (+1 or 0) |
-| `signal_short` | `int8[]` | Short position flags (-1 or 0) |
-| `log_returns` | `float64[]` | Log returns of the asset |
+`signal_long` and `signal_short` are `int8[]` (+1 or 0 / -1 or 0). `log_returns` is `float64[]`.
 
 ### `trade_pnl(signal_long, signal_short, log_returns) -> ndarray`
 

--- a/docs/reference/quickjs/indicators.md
+++ b/docs/reference/quickjs/indicators.md
@@ -1,25 +1,58 @@
 # Indicators
 
-Each indicator has `.update()` for per-tick use and a static `.compute()` for batch.
-
-| Single-value | OHLC | Volume |
-|---|---|---|
-| SMA, EMA, RMA, DEMA, TEMA, KAMA | ATR, ADX, Stochastic, CCI, CHOP | OBV, VWAP, CVD |
-| RSI, Slope, MACD, Bollinger | | |
+Each indicator has `.update()` for per-tick use and a static `.compute()` for batch. All classes support `.reset()` to clear state.
 
 ```javascript
-// Per-tick
-const sma = new SMA(20);
-sma.update(price);          // returns current value
+// Single value
+const ema = new EMA(20);
+ema.update(price);        // returns current value (NaN during warmup)
+ema.reset();
 
+// Multi-output
 const macd = new MACD(12, 26, 9);
 macd.update(price);
 macd.line; macd.signal; macd.histogram;
 
+// OHLC input
 const atr = new ATR(14);
 atr.update(high, low, close);
 
+const stoch = new Stochastic(14, 3);
+stoch.update(high, low, close);
+stoch.k; stoch.d;
+
+// Multi-input
+const corr = new Correlation(20);
+corr.update(x, y);
+
+const pvol = new ParkinsonVol(20);
+pvol.update(high, low);
+
 // Batch
-const result = ADX.compute(highs, lows, closes, 14);
-result.adx; result.plusDi; result.minusDi;
+const adxResult = ADX.compute(highs, lows, closes, 14);
+adxResult.adx; adxResult.plusDi; adxResult.minusDi;
+
+const skewArr = Skewness.compute(prices, 20);
 ```
+
+**Single value** — `update(value)`:
+
+`SMA`, `EMA`, `RMA`, `DEMA`, `TEMA`, `KAMA`, `RSI`, `Slope`, `Skewness`, `Kurtosis`, `RollingZScore`, `ShannonEntropy`
+
+**Multi-output** — named properties instead of `.value`:
+
+`MACD` → `.line`, `.signal`, `.histogram`  
+`Bollinger` → `.upper`, `.middle`, `.lower`
+
+**OHLC / multi-input:**
+
+`ATR`, `CCI`, `CHOP` — `update(high, low, close)`  
+`Stochastic` — `update(high, low, close)` → `.k`, `.d`  
+`ADX` — batch only: `ADX.compute(highs, lows, closes, period)` → `.adx`, `.plusDi`, `.minusDi`  
+`ParkinsonVol` — `update(high, low)`  
+`RogersSatchellVol` — `update(open, high, low, close)`  
+`Correlation` — `update(x, y)`
+
+**Volume:**
+
+`OBV`, `VWAP`, `CVD`

--- a/docs/tutorials/node-quickstart.md
+++ b/docs/tutorials/node-quickstart.md
@@ -1,0 +1,118 @@
+# Node.js quickstart
+
+## Requirements
+
+- Node.js 20+
+
+## 1. Install
+
+```bash
+npm install @flox-foundation/flox
+```
+
+## 2. First indicator
+
+```javascript
+const flox = require('@flox-foundation/flox');
+
+const ema = new flox.EMA(20);
+
+const prices = Array.from({ length: 50 }, (_, i) => 100 + i * 0.1);
+for (const price of prices) {
+    const value = ema.update(price);
+    if (value !== null) {
+        console.log(`EMA(20): ${value.toFixed(4)}`);
+    }
+}
+```
+
+All streaming indicators return `null` during warmup and the current value once ready. Use `.ready` to check without calling update.
+
+## 3. First strategy
+
+```javascript
+const flox = require('@flox-foundation/flox');
+
+const registry = new flox.SymbolRegistry();
+const btc = registry.addSymbol('binance', 'BTCUSDT', 0.01);
+
+const fast = new flox.SMA(10);
+const slow = new flox.SMA(30);
+
+const strategy = {
+    symbols: [btc],
+
+    onTrade(ctx, trade, emit) {
+        const f = fast.update(trade.price);
+        const s = slow.update(trade.price);
+        if (f === null || s === null) return;
+
+        if (f > s && ctx.position === 0) {
+            emit.marketBuy(0.01);
+        } else if (f < s && ctx.position > 0) {
+            emit.closePosition();
+        }
+    },
+};
+
+function onSignal(sig) {
+    console.log(sig.side, sig.orderType, sig.quantity);
+}
+
+const runner = new flox.Runner(registry, onSignal);
+runner.addStrategy(strategy);
+runner.start();
+
+// Feed market data from your source:
+// runner.onTrade(btc, price, qty, isBuy, tsNs)
+
+runner.stop();
+```
+
+## 4. Backtest
+
+```javascript
+const bt = new flox.BacktestRunner(registry, 0.0004, 10_000);
+bt.setStrategy(strategy);
+
+const stats = bt.runCsv('./data/btcusdt_trades.csv', 'BTCUSDT');
+console.log(stats.returnPct, stats.sharpeRatio, stats.maxDrawdownPct);
+```
+
+---
+
+## Building from source
+
+Use this if you need the current `main` branch before a release is published.
+
+### Requirements
+
+- GCC 14+ or Clang 18+
+- CMake 3.22+
+- Node.js 20+
+
+```bash
+git clone https://github.com/FLOX-Foundation/flox.git
+cd flox
+
+cmake -B build \
+  -DFLOX_ENABLE_CAPI=ON \
+  -DFLOX_ENABLE_BACKTEST=ON \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+
+cd node && npm install && npm run build
+```
+
+Then require the local build instead of the npm package:
+
+```javascript
+const flox = require('./node/build/Release/flox_node');
+```
+
+---
+
+## Next steps
+
+- [Indicators reference](../reference/node/indicators.md) — full indicator API
+- [Node.js bindings guide](../bindings/node.md) — runner, backtest runner, order types

--- a/docs/tutorials/python-quickstart.md
+++ b/docs/tutorials/python-quickstart.md
@@ -1,0 +1,105 @@
+# Python quickstart
+
+## Requirements
+
+- Python 3.9+
+
+## 1. Install
+
+```bash
+pip install flox-py
+```
+
+## 2. First indicator
+
+```python
+import flox_py as flox
+
+ema = flox.EMA(20)
+
+prices = [100 + i * 0.1 for i in range(50)]
+for price in prices:
+    value = ema.update(price)
+    if value is not None:
+        print(f"EMA(20): {value:.4f}")
+```
+
+All streaming indicators return `None` during warmup and a float once ready. Check `.ready` to test without calling update.
+
+## 3. First strategy
+
+```python
+import flox_py as flox
+
+registry = flox.SymbolRegistry()
+btc = registry.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+
+class SMACross(flox.Strategy):
+    def __init__(self, symbols):
+        super().__init__(symbols)
+        self.fast = flox.SMA(10)
+        self.slow = flox.SMA(30)
+
+    def on_trade(self, ctx, trade):
+        f = self.fast.update(trade.price)
+        s = self.slow.update(trade.price)
+        if f is None or s is None:
+            return
+        if f > s and ctx.is_flat():
+            self.market_buy(0.01)
+        elif f < s and ctx.is_long():
+            self.close_position()
+
+def on_signal(sig):
+    print(sig.side, sig.order_type, sig.quantity)
+
+runner = flox.Runner(registry, on_signal)
+runner.add_strategy(SMACross([btc]))
+runner.start()
+
+# Feed market data from your source:
+# runner.on_trade(btc, price, qty, is_buy, ts_ns)
+
+runner.stop()
+```
+
+## 4. Backtest
+
+```python
+bt = flox.BacktestRunner(registry, fee_rate=0.0004, initial_capital=10_000)
+bt.set_strategy(SMACross([btc]))
+
+stats = bt.run_csv("btcusdt_trades.csv")
+print(stats["return_pct"], stats["sharpe"], stats["max_drawdown_pct"])
+```
+
+The CSV format is `timestamp,price,qty,is_buy` — one trade per row.
+
+---
+
+## Building from source
+
+Use this if you need the current `main` branch before a release is published.
+
+### Requirements
+
+- GCC 14+ or Clang 18+
+- CMake 3.22+
+- Python 3.10+
+
+```bash
+git clone https://github.com/FLOX-Foundation/flox.git
+cd flox
+pip install scikit-build-core pybind11 numpy
+pip install ./python
+```
+
+That's it — `scikit-build-core` handles the cmake build internally. The module installs into your environment the same way as the PyPI package.
+
+---
+
+## Next steps
+
+- [Indicators reference](../reference/python/indicators.md) — full indicator API
+- [Python bindings guide](../bindings/python.md) — batch backtest engine, grid search, live runner
+- [Backtesting how-to](../how-to/backtest.md)

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -222,6 +222,21 @@ extern "C"
   void flox_indicator_cvd(const double* open, const double* high, const double* low,
                           const double* close, const double* volume, size_t len, double* output);
 
+  // Statistical
+  void flox_indicator_skewness(const double* input, size_t len, size_t period, double* output);
+  void flox_indicator_kurtosis(const double* input, size_t len, size_t period, double* output);
+  void flox_indicator_parkinson_vol(const double* high, const double* low, size_t len,
+                                    size_t period, double* output);
+  void flox_indicator_rogers_satchell_vol(const double* open, const double* high, const double* low,
+                                          const double* close, size_t len, size_t period,
+                                          double* output);
+  void flox_indicator_rolling_zscore(const double* input, size_t len, size_t period,
+                                     double* output);
+  void flox_indicator_shannon_entropy(const double* input, size_t len, size_t period, size_t bins,
+                                      double* output);
+  void flox_indicator_correlation(const double* x, const double* y, size_t len, size_t period,
+                                  double* output);
+
   // ============================================================
   // Order book
   // ============================================================

--- a/include/flox/indicator/correlation.h
+++ b/include/flox/indicator/correlation.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class Correlation
+{
+ public:
+  explicit Correlation(size_t period) noexcept : _period(period) { assert(period >= 2); }
+
+  std::vector<double> compute(std::span<const double> x, std::span<const double> y) const
+  {
+    assert(x.size() == y.size());
+    const size_t n = x.size();
+    std::vector<double> out(n, std::nan(""));
+    if (n > 0)
+    {
+      compute(x, y, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> x, std::span<const double> y,
+               std::span<double> output) const
+  {
+    assert(x.size() == y.size());
+    assert(output.size() >= x.size());
+    const size_t n = x.size();
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    const double p = static_cast<double>(_period);
+
+    for (size_t i = _period - 1; i < n; ++i)
+    {
+      double sx = 0, sy = 0, sxy = 0, sx2 = 0, sy2 = 0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        sx += x[j];
+        sy += y[j];
+        sxy += x[j] * y[j];
+        sx2 += x[j] * x[j];
+        sy2 += y[j] * y[j];
+      }
+
+      double num = p * sxy - sx * sy;
+      double den = std::sqrt((p * sx2 - sx * sx) * (p * sy2 - sy * sy));
+
+      if (den == 0.0)
+      {
+        output[i] = std::nan("");
+        continue;
+      }
+
+      output[i] = num / den;
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::HasPeriod<flox::indicator::Correlation>);

--- a/include/flox/indicator/kurtosis.h
+++ b/include/flox/indicator/kurtosis.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class Kurtosis
+{
+ public:
+  explicit Kurtosis(size_t period) noexcept : _period(period) { assert(period >= 4); }
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    std::vector<double> out(input.size(), std::nan(""));
+    if (!input.empty())
+    {
+      compute(input, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> input, std::span<double> output) const
+  {
+    assert(output.size() >= input.size());
+    const size_t n = input.size();
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    const double p = static_cast<double>(_period);
+
+    for (size_t i = _period - 1; i < n; ++i)
+    {
+      double mean = 0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        mean += input[j];
+      }
+      mean /= p;
+
+      double m2 = 0, m4 = 0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        double d = input[j] - mean;
+        double d2 = d * d;
+        m2 += d2;
+        m4 += d2 * d2;
+      }
+
+      double variance = m2 / (p - 1.0);
+      if (variance == 0.0)
+      {
+        output[i] = std::nan("");
+        continue;
+      }
+
+      double s2 = variance;
+      double term1 = (p * (p + 1.0)) / ((p - 1.0) * (p - 2.0) * (p - 3.0));
+      double term2 = m4 / (s2 * s2);
+      double term3 = (3.0 * (p - 1.0) * (p - 1.0)) / ((p - 2.0) * (p - 3.0));
+      output[i] = term1 * term2 - term3;
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::Kurtosis>);

--- a/include/flox/indicator/parkinson_vol.h
+++ b/include/flox/indicator/parkinson_vol.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+#include "flox/aggregator/bar.h"
+
+namespace flox::indicator
+{
+
+class ParkinsonVol
+{
+ public:
+  explicit ParkinsonVol(size_t period) noexcept : _period(period) { assert(period >= 1); }
+
+  std::vector<double> compute(std::span<const double> high, std::span<const double> low) const
+  {
+    assert(high.size() == low.size());
+    const size_t n = high.size();
+    std::vector<double> out(n, std::nan(""));
+    if (n > 0)
+    {
+      compute(high, low, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> high, std::span<const double> low,
+               std::span<double> output) const
+  {
+    assert(high.size() == low.size());
+    assert(output.size() >= high.size());
+    const size_t n = high.size();
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    const double inv4ln2 = 1.0 / (4.0 * std::log(2.0));
+
+    for (size_t i = _period - 1; i < n; ++i)
+    {
+      double sum = 0;
+      bool valid = true;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        if (low[j] <= 0.0 || high[j] < low[j])
+        {
+          valid = false;
+          break;
+        }
+        double lnhl = std::log(high[j] / low[j]);
+        sum += lnhl * lnhl;
+      }
+
+      if (!valid)
+      {
+        continue;
+      }
+
+      output[i] = std::sqrt(sum / static_cast<double>(_period) * inv4ln2);
+    }
+  }
+
+  std::vector<double> compute(std::span<const Bar> bars) const
+  {
+    const size_t n = bars.size();
+    std::vector<double> h(n), l(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+      h[i] = bars[i].high.toDouble();
+      l[i] = bars[i].low.toDouble();
+    }
+    return compute(std::span<const double>(h), std::span<const double>(l));
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::HasPeriod<flox::indicator::ParkinsonVol>);

--- a/include/flox/indicator/rogers_satchell_vol.h
+++ b/include/flox/indicator/rogers_satchell_vol.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+#include "flox/aggregator/bar.h"
+
+namespace flox::indicator
+{
+
+class RogersSatchellVol
+{
+ public:
+  explicit RogersSatchellVol(size_t period) noexcept : _period(period) { assert(period >= 1); }
+
+  std::vector<double> compute(std::span<const double> open, std::span<const double> high,
+                              std::span<const double> low, std::span<const double> close) const
+  {
+    assert(open.size() == high.size() && high.size() == low.size() && low.size() == close.size());
+    const size_t n = open.size();
+    std::vector<double> out(n, std::nan(""));
+    if (n > 0)
+    {
+      compute(open, high, low, close, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> open, std::span<const double> high,
+               std::span<const double> low, std::span<const double> close,
+               std::span<double> output) const
+  {
+    assert(open.size() == high.size() && high.size() == low.size() && low.size() == close.size());
+    assert(output.size() >= open.size());
+    const size_t n = open.size();
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    for (size_t i = _period - 1; i < n; ++i)
+    {
+      double sum = 0;
+      bool valid = true;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        if (open[j] <= 0.0 || close[j] <= 0.0)
+        {
+          valid = false;
+          break;
+        }
+        double lnHC = std::log(high[j] / close[j]);
+        double lnHO = std::log(high[j] / open[j]);
+        double lnLC = std::log(low[j] / close[j]);
+        double lnLO = std::log(low[j] / open[j]);
+        sum += lnHC * lnHO + lnLC * lnLO;
+      }
+
+      if (!valid)
+      {
+        continue;
+      }
+
+      double avg = sum / static_cast<double>(_period);
+      output[i] = avg >= 0.0 ? std::sqrt(avg) : 0.0;
+    }
+  }
+
+  std::vector<double> compute(std::span<const Bar> bars) const
+  {
+    const size_t n = bars.size();
+    std::vector<double> o(n), h(n), l(n), c(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+      o[i] = bars[i].open.toDouble();
+      h[i] = bars[i].high.toDouble();
+      l[i] = bars[i].low.toDouble();
+      c[i] = bars[i].close.toDouble();
+    }
+    return compute(std::span<const double>(o), std::span<const double>(h),
+                   std::span<const double>(l), std::span<const double>(c));
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::BarIndicator<flox::indicator::RogersSatchellVol>);

--- a/include/flox/indicator/rolling_zscore.h
+++ b/include/flox/indicator/rolling_zscore.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class RollingZScore
+{
+ public:
+  explicit RollingZScore(size_t period) noexcept : _period(period) { assert(period >= 2); }
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    std::vector<double> out(input.size(), std::nan(""));
+    if (!input.empty())
+    {
+      compute(input, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> input, std::span<double> output) const
+  {
+    assert(output.size() >= input.size());
+    const size_t n = input.size();
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    const double p = static_cast<double>(_period);
+
+    for (size_t i = _period - 1; i < n; ++i)
+    {
+      double mean = 0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        mean += input[j];
+      }
+      mean /= p;
+
+      double sumSq = 0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        double d = input[j] - mean;
+        sumSq += d * d;
+      }
+
+      double std = std::sqrt(sumSq / (p - 1.0));
+      if (std == 0.0)
+      {
+        output[i] = std::nan("");
+        continue;
+      }
+
+      output[i] = (input[i] - mean) / std;
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::RollingZScore>);

--- a/include/flox/indicator/shannon_entropy.h
+++ b/include/flox/indicator/shannon_entropy.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class ShannonEntropy
+{
+ public:
+  explicit ShannonEntropy(size_t period, size_t bins = 10) noexcept : _period(period), _bins(bins)
+  {
+    assert(period >= 2);
+    assert(bins >= 2);
+  }
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    std::vector<double> out(input.size(), std::nan(""));
+    if (!input.empty())
+    {
+      compute(input, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> input, std::span<double> output) const
+  {
+    assert(output.size() >= input.size());
+    const size_t n = input.size();
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    std::vector<size_t> counts(_bins);
+
+    for (size_t i = _period - 1; i < n; ++i)
+    {
+      size_t start = i - _period + 1;
+
+      double lo = input[start], hi = input[start];
+      for (size_t j = start + 1; j <= i; ++j)
+      {
+        if (input[j] < lo)
+        {
+          lo = input[j];
+        }
+        if (input[j] > hi)
+        {
+          hi = input[j];
+        }
+      }
+
+      if (lo == hi)
+      {
+        output[i] = 0.0;
+        continue;
+      }
+
+      std::fill(counts.begin(), counts.end(), 0);
+      double range = hi - lo;
+
+      for (size_t j = start; j <= i; ++j)
+      {
+        size_t bin = static_cast<size_t>(((input[j] - lo) / range) * _bins);
+        if (bin >= _bins)
+        {
+          bin = _bins - 1;
+        }
+        counts[bin]++;
+      }
+
+      double entropy = 0;
+      double p_denom = static_cast<double>(_period);
+      for (size_t b = 0; b < _bins; ++b)
+      {
+        if (counts[b] > 0)
+        {
+          double p = static_cast<double>(counts[b]) / p_denom;
+          entropy -= p * std::log(p);
+        }
+      }
+
+      output[i] = entropy / std::log(static_cast<double>(_bins));
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+  size_t _bins;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::ShannonEntropy>);

--- a/include/flox/indicator/skewness.h
+++ b/include/flox/indicator/skewness.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class Skewness
+{
+ public:
+  explicit Skewness(size_t period) noexcept : _period(period) { assert(period >= 3); }
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    std::vector<double> out(input.size(), std::nan(""));
+    if (!input.empty())
+    {
+      compute(input, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> input, std::span<double> output) const
+  {
+    assert(output.size() >= input.size());
+    const size_t n = input.size();
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n < _period)
+    {
+      return;
+    }
+
+    const double p = static_cast<double>(_period);
+
+    for (size_t i = _period - 1; i < n; ++i)
+    {
+      double mean = 0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        mean += input[j];
+      }
+      mean /= p;
+
+      double m2 = 0, m3 = 0;
+      for (size_t j = i - _period + 1; j <= i; ++j)
+      {
+        double d = input[j] - mean;
+        double d2 = d * d;
+        m2 += d2;
+        m3 += d2 * d;
+      }
+
+      double variance = m2 / (p - 1.0);
+      if (variance == 0.0)
+      {
+        output[i] = std::nan("");
+        continue;
+      }
+
+      double s = std::sqrt(variance);
+      output[i] = (p / ((p - 1.0) * (p - 2.0))) * (m3 / (s * s * s));
+    }
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::Skewness>);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,9 @@ nav:
 
   - Tutorials:
       - tutorials/README.md
-      - Quickstart: tutorials/quickstart.md
+      - Python quickstart: tutorials/python-quickstart.md
+      - Node.js quickstart: tutorials/node-quickstart.md
+      - C++ quickstart: tutorials/quickstart.md
       - First Strategy: tutorials/first-strategy.md
       - Multi-Timeframe Strategy: tutorials/multi-timeframe-strategy.md
       - Recording Data: tutorials/recording-data.md
@@ -128,6 +130,7 @@ nav:
       - Disruptor Pattern: explanation/disruptor.md
       - Memory Model: explanation/memory-model.md
       - Integration Flow: explanation/integration-flow.md
+      - Indicators: explanation/indicators.md
 
   - Reference:
       - reference/README.md

--- a/node/src/indicators.h
+++ b/node/src/indicators.h
@@ -21,6 +21,16 @@
 #include "flox/indicator/stochastic.h"
 #include "flox/indicator/vwap.h"
 
+#include "flox/indicator/correlation.h"
+#include "flox/indicator/kurtosis.h"
+#include "flox/indicator/parkinson_vol.h"
+#include "flox/indicator/rogers_satchell_vol.h"
+#include "flox/indicator/rolling_zscore.h"
+#include "flox/indicator/shannon_entropy.h"
+#include "flox/indicator/skewness.h"
+
+#include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <span>
 
@@ -209,6 +219,74 @@ inline Napi::Value batch_cvd(const Napi::CallbackInfo& info)
   return vec2arr(info.Env(), r);
 }
 
+// ── Batch: statistical / volatility ─────────────────────────────────
+
+inline Napi::Value batch_skewness(const Napi::CallbackInfo& info)
+{
+  auto in = info[0].As<Napi::Float64Array>();
+  size_t p = info[1].As<Napi::Number>().Uint32Value();
+  auto r = flox::indicator::Skewness(p).compute(arr2span(in));
+  return vec2arr(info.Env(), r);
+}
+
+inline Napi::Value batch_kurtosis(const Napi::CallbackInfo& info)
+{
+  auto in = info[0].As<Napi::Float64Array>();
+  size_t p = info[1].As<Napi::Number>().Uint32Value();
+  auto r = flox::indicator::Kurtosis(p).compute(arr2span(in));
+  return vec2arr(info.Env(), r);
+}
+
+inline Napi::Value batch_rolling_zscore(const Napi::CallbackInfo& info)
+{
+  auto in = info[0].As<Napi::Float64Array>();
+  size_t p = info[1].As<Napi::Number>().Uint32Value();
+  auto r = flox::indicator::RollingZScore(p).compute(arr2span(in));
+  return vec2arr(info.Env(), r);
+}
+
+inline Napi::Value batch_shannon_entropy(const Napi::CallbackInfo& info)
+{
+  auto in = info[0].As<Napi::Float64Array>();
+  size_t p = info[1].As<Napi::Number>().Uint32Value();
+  size_t bins = info[2].As<Napi::Number>().Uint32Value();
+  auto r = flox::indicator::ShannonEntropy(p, bins).compute(arr2span(in));
+  return vec2arr(info.Env(), r);
+}
+
+inline Napi::Value batch_parkinson_vol(const Napi::CallbackInfo& info)
+{
+  auto h = info[0].As<Napi::Float64Array>();
+  auto l = info[1].As<Napi::Float64Array>();
+  size_t n = h.ElementLength(), p = info[2].As<Napi::Number>().Uint32Value();
+  std::vector<double> out(n);
+  flox::indicator::ParkinsonVol(p).compute({h.Data(), n}, {l.Data(), n}, {out.data(), n});
+  return vec2arr(info.Env(), out);
+}
+
+inline Napi::Value batch_rogers_satchell_vol(const Napi::CallbackInfo& info)
+{
+  auto o = info[0].As<Napi::Float64Array>();
+  auto h = info[1].As<Napi::Float64Array>();
+  auto l = info[2].As<Napi::Float64Array>();
+  auto c = info[3].As<Napi::Float64Array>();
+  size_t n = o.ElementLength(), p = info[4].As<Napi::Number>().Uint32Value();
+  std::vector<double> out(n);
+  flox::indicator::RogersSatchellVol(p).compute({o.Data(), n}, {h.Data(), n}, {l.Data(), n},
+                                                {c.Data(), n}, {out.data(), n});
+  return vec2arr(info.Env(), out);
+}
+
+inline Napi::Value batch_correlation(const Napi::CallbackInfo& info)
+{
+  auto x = info[0].As<Napi::Float64Array>();
+  auto y = info[1].As<Napi::Float64Array>();
+  size_t n = x.ElementLength(), p = info[2].As<Napi::Number>().Uint32Value();
+  std::vector<double> out(n);
+  flox::indicator::Correlation(p).compute({x.Data(), n}, {y.Data(), n}, {out.data(), n});
+  return vec2arr(info.Env(), out);
+}
+
 // ── Streaming indicator classes ─────────────────────────────────────
 
 #define STREAMING_SINGLE(Name, updExpr)                                                                                                \
@@ -241,6 +319,7 @@ class SMAWrap : public Napi::ObjectWrap<SMAWrap>
   {
     return DefineClass(env, "SMA",
                        {InstanceMethod("update", &SMAWrap::Update),
+                        InstanceMethod("reset", &SMAWrap::Reset),
                         InstanceAccessor("value", &SMAWrap::Value, nullptr),
                         InstanceAccessor("ready", &SMAWrap::Ready, nullptr)});
   }
@@ -270,6 +349,14 @@ class SMAWrap : public Napi::ObjectWrap<SMAWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _val); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _count >= _period); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _count = 0;
+    _idx = 0;
+    _sum = 0;
+    _val = 0;
+    std::fill(_buf.begin(), _buf.end(), 0);
+  }
   size_t _period, _count = 0, _idx = 0;
   std::vector<double> _buf;
   double _sum = 0, _val = 0;
@@ -283,6 +370,7 @@ class EMAWrap : public Napi::ObjectWrap<EMAWrap>
   {
     return DefineClass(env, "EMA",
                        {InstanceMethod("update", &EMAWrap::Update),
+                        InstanceMethod("reset", &EMAWrap::Reset),
                         InstanceAccessor("value", &EMAWrap::Value, nullptr),
                         InstanceAccessor("ready", &EMAWrap::Ready, nullptr)});
   }
@@ -308,6 +396,12 @@ class EMAWrap : public Napi::ObjectWrap<EMAWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _val); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _count >= _period); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _count = 0;
+    _sum = 0;
+    _val = 0;
+  }
   size_t _period, _count = 0;
   double _mult, _sum = 0, _val = 0;
 };
@@ -320,6 +414,7 @@ class RSIWrap : public Napi::ObjectWrap<RSIWrap>
   {
     return DefineClass(env, "RSI",
                        {InstanceMethod("update", &RSIWrap::Update),
+                        InstanceMethod("reset", &RSIWrap::Reset),
                         InstanceAccessor("value", &RSIWrap::Value, nullptr),
                         InstanceAccessor("ready", &RSIWrap::Ready, nullptr)});
   }
@@ -355,6 +450,14 @@ class RSIWrap : public Napi::ObjectWrap<RSIWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _val); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _count > _period); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _count = 0;
+    _prev = 0;
+    _avgGain = 0;
+    _avgLoss = 0;
+    _val = 50;
+  }
   size_t _period, _count = 0;
   double _prev = 0, _avgGain = 0, _avgLoss = 0, _val = 50;
 };
@@ -367,6 +470,7 @@ class ATRWrap : public Napi::ObjectWrap<ATRWrap>
   {
     return DefineClass(env, "ATR",
                        {InstanceMethod("update", &ATRWrap::Update),
+                        InstanceMethod("reset", &ATRWrap::Reset),
                         InstanceAccessor("value", &ATRWrap::Value, nullptr),
                         InstanceAccessor("ready", &ATRWrap::Ready, nullptr)});
   }
@@ -395,6 +499,13 @@ class ATRWrap : public Napi::ObjectWrap<ATRWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _val); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _count >= _period); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _count = 0;
+    _prevC = 0;
+    _sum = 0;
+    _val = 0;
+  }
   size_t _period, _count = 0;
   double _prevC = 0, _sum = 0, _val = 0;
 };
@@ -407,6 +518,7 @@ class MACDWrap : public Napi::ObjectWrap<MACDWrap>
   {
     return DefineClass(env, "MACD",
                        {InstanceMethod("update", &MACDWrap::Update),
+                        InstanceMethod("reset", &MACDWrap::Reset),
                         InstanceAccessor("line", &MACDWrap::Line, nullptr),
                         InstanceAccessor("signal", &MACDWrap::Signal, nullptr),
                         InstanceAccessor("histogram", &MACDWrap::Histogram, nullptr),
@@ -457,6 +569,16 @@ class MACDWrap : public Napi::ObjectWrap<MACDWrap>
   Napi::Value Signal(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _sig); }
   Napi::Value Histogram(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _hist); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _rdy); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _fastEma = Ema(_fastEma.p);
+    _slowEma = Ema(_slowEma.p);
+    _sigEma = Ema(_sigEma.p);
+    _line = 0;
+    _sig = 0;
+    _hist = 0;
+    _rdy = false;
+  }
   Ema _fastEma, _slowEma, _sigEma;
   double _line = 0, _sig = 0, _hist = 0;
   bool _rdy = false;
@@ -470,6 +592,7 @@ class BollingerWrap : public Napi::ObjectWrap<BollingerWrap>
   {
     return DefineClass(env, "Bollinger",
                        {InstanceMethod("update", &BollingerWrap::Update),
+                        InstanceMethod("reset", &BollingerWrap::Reset),
                         InstanceAccessor("upper", &BollingerWrap::Upper, nullptr),
                         InstanceAccessor("middle", &BollingerWrap::Middle, nullptr),
                         InstanceAccessor("lower", &BollingerWrap::Lower, nullptr),
@@ -535,6 +658,14 @@ class BollingerWrap : public Napi::ObjectWrap<BollingerWrap>
   Napi::Value Middle(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _mid); }
   Napi::Value Lower(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _lower); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _sma.ready()); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _sma = Sma(_period);
+    _buf.clear();
+    _upper = 0;
+    _mid = 0;
+    _lower = 0;
+  }
   Sma _sma;
   size_t _period;
   double _mult, _upper = 0, _mid = 0, _lower = 0;
@@ -545,7 +676,7 @@ class BollingerWrap : public Napi::ObjectWrap<BollingerWrap>
 class RMAWrap : public Napi::ObjectWrap<RMAWrap>
 {
  public:
-  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "RMA", {InstanceMethod("update", &RMAWrap::Update), InstanceAccessor("value", &RMAWrap::Value, nullptr), InstanceAccessor("ready", &RMAWrap::Ready, nullptr)}); }
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "RMA", {InstanceMethod("update", &RMAWrap::Update), InstanceMethod("reset", &RMAWrap::Reset), InstanceAccessor("value", &RMAWrap::Value, nullptr), InstanceAccessor("ready", &RMAWrap::Ready, nullptr)}); }
   RMAWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<RMAWrap>(info), _p(info[0].As<Napi::Number>().Uint32Value()), _a(1.0 / _p) {}
 
  private:
@@ -566,6 +697,12 @@ class RMAWrap : public Napi::ObjectWrap<RMAWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _c >= _p); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _c = 0;
+    _s = 0;
+    _v = 0;
+  }
   size_t _p, _c = 0;
   double _a, _s = 0, _v = 0;
 };
@@ -574,7 +711,7 @@ class RMAWrap : public Napi::ObjectWrap<RMAWrap>
 class DEMAWrap : public Napi::ObjectWrap<DEMAWrap>
 {
  public:
-  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "DEMA", {InstanceMethod("update", &DEMAWrap::Update), InstanceAccessor("value", &DEMAWrap::Value, nullptr), InstanceAccessor("ready", &DEMAWrap::Ready, nullptr)}); }
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "DEMA", {InstanceMethod("update", &DEMAWrap::Update), InstanceMethod("reset", &DEMAWrap::Reset), InstanceAccessor("value", &DEMAWrap::Value, nullptr), InstanceAccessor("ready", &DEMAWrap::Ready, nullptr)}); }
   DEMAWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DEMAWrap>(info), _e1(info[0].As<Napi::Number>().Uint32Value()), _e2(info[0].As<Napi::Number>().Uint32Value()) {}
 
  private:
@@ -609,6 +746,12 @@ class DEMAWrap : public Napi::ObjectWrap<DEMAWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _e2.rdy()); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _e1 = E(_e1.p);
+    _e2 = E(_e2.p);
+    _v = 0;
+  }
   E _e1, _e2;
   double _v = 0;
 };
@@ -617,7 +760,7 @@ class DEMAWrap : public Napi::ObjectWrap<DEMAWrap>
 class TEMAWrap : public Napi::ObjectWrap<TEMAWrap>
 {
  public:
-  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "TEMA", {InstanceMethod("update", &TEMAWrap::Update), InstanceAccessor("value", &TEMAWrap::Value, nullptr), InstanceAccessor("ready", &TEMAWrap::Ready, nullptr)}); }
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "TEMA", {InstanceMethod("update", &TEMAWrap::Update), InstanceMethod("reset", &TEMAWrap::Reset), InstanceAccessor("value", &TEMAWrap::Value, nullptr), InstanceAccessor("ready", &TEMAWrap::Ready, nullptr)}); }
   TEMAWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<TEMAWrap>(info), _e1(info[0].As<Napi::Number>().Uint32Value()), _e2(info[0].As<Napi::Number>().Uint32Value()), _e3(info[0].As<Napi::Number>().Uint32Value()) {}
 
  private:
@@ -651,6 +794,13 @@ class TEMAWrap : public Napi::ObjectWrap<TEMAWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _e3.rdy()); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _e1 = E(_e1.p);
+    _e2 = E(_e2.p);
+    _e3 = E(_e3.p);
+    _v = 0;
+  }
   E _e1, _e2, _e3;
   double _v = 0;
 };
@@ -659,7 +809,7 @@ class TEMAWrap : public Napi::ObjectWrap<TEMAWrap>
 class KAMAWrap : public Napi::ObjectWrap<KAMAWrap>
 {
  public:
-  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "KAMA", {InstanceMethod("update", &KAMAWrap::Update), InstanceAccessor("value", &KAMAWrap::Value, nullptr), InstanceAccessor("ready", &KAMAWrap::Ready, nullptr)}); }
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "KAMA", {InstanceMethod("update", &KAMAWrap::Update), InstanceMethod("reset", &KAMAWrap::Reset), InstanceAccessor("value", &KAMAWrap::Value, nullptr), InstanceAccessor("ready", &KAMAWrap::Ready, nullptr)}); }
   KAMAWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<KAMAWrap>(info), _p(info[0].As<Napi::Number>().Uint32Value()), _fsc(2.0 / ((info.Length() > 1 ? info[1].As<Napi::Number>().Uint32Value() : 2) + 1)), _ssc(2.0 / ((info.Length() > 2 ? info[2].As<Napi::Number>().Uint32Value() : 30) + 1)) {}
 
  private:
@@ -689,6 +839,12 @@ class KAMAWrap : public Napi::ObjectWrap<KAMAWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _c > _p); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _c = 0;
+    _v = 0;
+    _buf.clear();
+  }
   size_t _p, _c = 0;
   double _fsc, _ssc, _v = 0;
   std::vector<double> _buf;
@@ -698,7 +854,7 @@ class KAMAWrap : public Napi::ObjectWrap<KAMAWrap>
 class SlopeWrap : public Napi::ObjectWrap<SlopeWrap>
 {
  public:
-  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "Slope", {InstanceMethod("update", &SlopeWrap::Update), InstanceAccessor("value", &SlopeWrap::Value, nullptr), InstanceAccessor("ready", &SlopeWrap::Ready, nullptr)}); }
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "Slope", {InstanceMethod("update", &SlopeWrap::Update), InstanceMethod("reset", &SlopeWrap::Reset), InstanceAccessor("value", &SlopeWrap::Value, nullptr), InstanceAccessor("ready", &SlopeWrap::Ready, nullptr)}); }
   SlopeWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<SlopeWrap>(info), _len(info[0].As<Napi::Number>().Uint32Value()) {}
 
  private:
@@ -718,6 +874,11 @@ class SlopeWrap : public Napi::ObjectWrap<SlopeWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _buf.size() > _len); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _v = 0;
+    _buf.clear();
+  }
   size_t _len;
   double _v = 0;
   std::vector<double> _buf;
@@ -727,7 +888,7 @@ class SlopeWrap : public Napi::ObjectWrap<SlopeWrap>
 class StochasticWrap : public Napi::ObjectWrap<StochasticWrap>
 {
  public:
-  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "Stochastic", {InstanceMethod("update", &StochasticWrap::Update), InstanceAccessor("k", &StochasticWrap::K, nullptr), InstanceAccessor("d", &StochasticWrap::D, nullptr), InstanceAccessor("value", &StochasticWrap::K, nullptr), InstanceAccessor("ready", &StochasticWrap::Ready, nullptr)}); }
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "Stochastic", {InstanceMethod("update", &StochasticWrap::Update), InstanceMethod("reset", &StochasticWrap::Reset), InstanceAccessor("k", &StochasticWrap::K, nullptr), InstanceAccessor("d", &StochasticWrap::D, nullptr), InstanceAccessor("value", &StochasticWrap::K, nullptr), InstanceAccessor("ready", &StochasticWrap::Ready, nullptr)}); }
   StochasticWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<StochasticWrap>(info), _kp(info[0].As<Napi::Number>().Uint32Value()), _dsma(info.Length() > 1 ? info[1].As<Napi::Number>().Uint32Value() : 3) {}
 
  private:
@@ -778,6 +939,14 @@ class StochasticWrap : public Napi::ObjectWrap<StochasticWrap>
   Napi::Value K(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _k); }
   Napi::Value D(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _d); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _h.size() >= _kp && _dsma.rdy()); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _h.clear();
+    _l.clear();
+    _dsma = Sma(_dsma.p);
+    _k = 0;
+    _d = 0;
+  }
   size_t _kp;
   Sma _dsma;
   std::vector<double> _h, _l;
@@ -788,7 +957,7 @@ class StochasticWrap : public Napi::ObjectWrap<StochasticWrap>
 class CCIWrap : public Napi::ObjectWrap<CCIWrap>
 {
  public:
-  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "CCI", {InstanceMethod("update", &CCIWrap::Update), InstanceAccessor("value", &CCIWrap::Value, nullptr), InstanceAccessor("ready", &CCIWrap::Ready, nullptr)}); }
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "CCI", {InstanceMethod("update", &CCIWrap::Update), InstanceMethod("reset", &CCIWrap::Reset), InstanceAccessor("value", &CCIWrap::Value, nullptr), InstanceAccessor("ready", &CCIWrap::Ready, nullptr)}); }
   CCIWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<CCIWrap>(info), _p(info[0].As<Napi::Number>().Uint32Value()) {}
 
  private:
@@ -821,6 +990,11 @@ class CCIWrap : public Napi::ObjectWrap<CCIWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _buf.size() >= _p); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _v = 0;
+    _buf.clear();
+  }
   size_t _p;
   double _v = 0;
   std::vector<double> _buf;
@@ -830,7 +1004,7 @@ class CCIWrap : public Napi::ObjectWrap<CCIWrap>
 class OBVWrap : public Napi::ObjectWrap<OBVWrap>
 {
  public:
-  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "OBV", {InstanceMethod("update", &OBVWrap::Update), InstanceAccessor("value", &OBVWrap::Value, nullptr), InstanceAccessor("ready", &OBVWrap::Ready, nullptr)}); }
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "OBV", {InstanceMethod("update", &OBVWrap::Update), InstanceMethod("reset", &OBVWrap::Reset), InstanceAccessor("value", &OBVWrap::Value, nullptr), InstanceAccessor("ready", &OBVWrap::Ready, nullptr)}); }
   OBVWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<OBVWrap>(info) {}
 
  private:
@@ -855,6 +1029,12 @@ class OBVWrap : public Napi::ObjectWrap<OBVWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _n > 0); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _n = 0;
+    _pc = 0;
+    _v = 0;
+  }
   size_t _n = 0;
   double _pc = 0, _v = 0;
 };
@@ -863,7 +1043,7 @@ class OBVWrap : public Napi::ObjectWrap<OBVWrap>
 class VWAPWrap : public Napi::ObjectWrap<VWAPWrap>
 {
  public:
-  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "VWAP", {InstanceMethod("update", &VWAPWrap::Update), InstanceAccessor("value", &VWAPWrap::Value, nullptr), InstanceAccessor("ready", &VWAPWrap::Ready, nullptr)}); }
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "VWAP", {InstanceMethod("update", &VWAPWrap::Update), InstanceMethod("reset", &VWAPWrap::Reset), InstanceAccessor("value", &VWAPWrap::Value, nullptr), InstanceAccessor("ready", &VWAPWrap::Ready, nullptr)}); }
   VWAPWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<VWAPWrap>(info), _w(info[0].As<Napi::Number>().Uint32Value()) {}
 
  private:
@@ -888,6 +1068,12 @@ class VWAPWrap : public Napi::ObjectWrap<VWAPWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _p.size() >= _w); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _v = 0;
+    _p.clear();
+    _vol.clear();
+  }
   size_t _w;
   double _v = 0;
   std::vector<double> _p, _vol;
@@ -897,7 +1083,7 @@ class VWAPWrap : public Napi::ObjectWrap<VWAPWrap>
 class CVDWrap : public Napi::ObjectWrap<CVDWrap>
 {
  public:
-  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "CVD", {InstanceMethod("update", &CVDWrap::Update), InstanceAccessor("value", &CVDWrap::Value, nullptr), InstanceAccessor("ready", &CVDWrap::Ready, nullptr)}); }
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "CVD", {InstanceMethod("update", &CVDWrap::Update), InstanceMethod("reset", &CVDWrap::Reset), InstanceAccessor("value", &CVDWrap::Value, nullptr), InstanceAccessor("ready", &CVDWrap::Ready, nullptr)}); }
   CVDWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<CVDWrap>(info) {}
 
  private:
@@ -911,8 +1097,406 @@ class CVDWrap : public Napi::ObjectWrap<CVDWrap>
   }
   Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
   Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _n > 0); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _n = 0;
+    _v = 0;
+  }
   size_t _n = 0;
   double _v = 0;
+};
+
+// Skewness streaming
+class SkewnessWrap : public Napi::ObjectWrap<SkewnessWrap>
+{
+ public:
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "Skewness", {InstanceMethod("update", &SkewnessWrap::Update), InstanceMethod("reset", &SkewnessWrap::Reset), InstanceAccessor("value", &SkewnessWrap::Value, nullptr), InstanceAccessor("ready", &SkewnessWrap::Ready, nullptr)}); }
+  SkewnessWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<SkewnessWrap>(info), _p(info[0].As<Napi::Number>().Uint32Value()) {}
+
+ private:
+  Napi::Value Update(const Napi::CallbackInfo& info)
+  {
+    double v = info[0].As<Napi::Number>().DoubleValue();
+    _buf.push_back(v);
+    if (_buf.size() > _p)
+    {
+      _buf.erase(_buf.begin());
+    }
+    if (_buf.size() >= _p)
+    {
+      double p = static_cast<double>(_p);
+      double mean = 0;
+      for (double x : _buf)
+      {
+        mean += x;
+      }
+      mean /= p;
+      double m2 = 0, m3 = 0;
+      for (double x : _buf)
+      {
+        double d = x - mean;
+        double d2 = d * d;
+        m2 += d2;
+        m3 += d2 * d;
+      }
+      double var = m2 / (p - 1.0);
+      if (var == 0.0)
+      {
+        return info.Env().Undefined();
+      }
+      double s = std::sqrt(var);
+      _v = (p / ((p - 1.0) * (p - 2.0))) * (m3 / (s * s * s));
+    }
+    return Napi::Number::New(info.Env(), _v);
+  }
+  Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
+  Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _buf.size() >= _p); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _v = 0;
+    _buf.clear();
+  }
+  size_t _p;
+  double _v = 0;
+  std::vector<double> _buf;
+};
+
+// Kurtosis streaming
+class KurtosisWrap : public Napi::ObjectWrap<KurtosisWrap>
+{
+ public:
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "Kurtosis", {InstanceMethod("update", &KurtosisWrap::Update), InstanceMethod("reset", &KurtosisWrap::Reset), InstanceAccessor("value", &KurtosisWrap::Value, nullptr), InstanceAccessor("ready", &KurtosisWrap::Ready, nullptr)}); }
+  KurtosisWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<KurtosisWrap>(info), _p(info[0].As<Napi::Number>().Uint32Value()) {}
+
+ private:
+  Napi::Value Update(const Napi::CallbackInfo& info)
+  {
+    double v = info[0].As<Napi::Number>().DoubleValue();
+    _buf.push_back(v);
+    if (_buf.size() > _p)
+    {
+      _buf.erase(_buf.begin());
+    }
+    if (_buf.size() >= _p)
+    {
+      double p = static_cast<double>(_p);
+      double mean = 0;
+      for (double x : _buf)
+      {
+        mean += x;
+      }
+      mean /= p;
+      double m2 = 0, m4 = 0;
+      for (double x : _buf)
+      {
+        double d = x - mean;
+        double d2 = d * d;
+        m2 += d2;
+        m4 += d2 * d2;
+      }
+      double var = m2 / (p - 1.0);
+      if (var == 0.0)
+      {
+        return info.Env().Undefined();
+      }
+      double s2 = var;
+      double t1 = (p * (p + 1.0)) / ((p - 1.0) * (p - 2.0) * (p - 3.0));
+      double t2 = m4 / (s2 * s2);
+      double t3 = (3.0 * (p - 1.0) * (p - 1.0)) / ((p - 2.0) * (p - 3.0));
+      _v = t1 * t2 - t3;
+    }
+    return Napi::Number::New(info.Env(), _v);
+  }
+  Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
+  Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _buf.size() >= _p); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _v = 0;
+    _buf.clear();
+  }
+  size_t _p;
+  double _v = 0;
+  std::vector<double> _buf;
+};
+
+// RollingZScore streaming
+class RollingZScoreWrap : public Napi::ObjectWrap<RollingZScoreWrap>
+{
+ public:
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "RollingZScore", {InstanceMethod("update", &RollingZScoreWrap::Update), InstanceMethod("reset", &RollingZScoreWrap::Reset), InstanceAccessor("value", &RollingZScoreWrap::Value, nullptr), InstanceAccessor("ready", &RollingZScoreWrap::Ready, nullptr)}); }
+  RollingZScoreWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<RollingZScoreWrap>(info), _p(info[0].As<Napi::Number>().Uint32Value()) {}
+
+ private:
+  Napi::Value Update(const Napi::CallbackInfo& info)
+  {
+    double v = info[0].As<Napi::Number>().DoubleValue();
+    _buf.push_back(v);
+    if (_buf.size() > _p)
+    {
+      _buf.erase(_buf.begin());
+    }
+    if (_buf.size() >= _p)
+    {
+      double p = static_cast<double>(_p);
+      double mean = 0;
+      for (double x : _buf)
+      {
+        mean += x;
+      }
+      mean /= p;
+      double sumSq = 0;
+      for (double x : _buf)
+      {
+        double d = x - mean;
+        sumSq += d * d;
+      }
+      double s = std::sqrt(sumSq / (p - 1.0));
+      if (s == 0.0)
+      {
+        return info.Env().Undefined();
+      }
+      _v = (v - mean) / s;
+    }
+    return Napi::Number::New(info.Env(), _v);
+  }
+  Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
+  Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _buf.size() >= _p); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _v = 0;
+    _buf.clear();
+  }
+  size_t _p;
+  double _v = 0;
+  std::vector<double> _buf;
+};
+
+// ShannonEntropy streaming
+class ShannonEntropyWrap : public Napi::ObjectWrap<ShannonEntropyWrap>
+{
+ public:
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "ShannonEntropy", {InstanceMethod("update", &ShannonEntropyWrap::Update), InstanceMethod("reset", &ShannonEntropyWrap::Reset), InstanceAccessor("value", &ShannonEntropyWrap::Value, nullptr), InstanceAccessor("ready", &ShannonEntropyWrap::Ready, nullptr)}); }
+  ShannonEntropyWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<ShannonEntropyWrap>(info), _p(info[0].As<Napi::Number>().Uint32Value()), _bins(info.Length() > 1 ? info[1].As<Napi::Number>().Uint32Value() : 10) {}
+
+ private:
+  Napi::Value Update(const Napi::CallbackInfo& info)
+  {
+    double v = info[0].As<Napi::Number>().DoubleValue();
+    _buf.push_back(v);
+    if (_buf.size() > _p)
+    {
+      _buf.erase(_buf.begin());
+    }
+    if (_buf.size() >= _p)
+    {
+      double lo = *std::min_element(_buf.begin(), _buf.end());
+      double hi = *std::max_element(_buf.begin(), _buf.end());
+      if (lo == hi)
+      {
+        _v = 0.0;
+        return Napi::Number::New(info.Env(), _v);
+      }
+      std::vector<size_t> counts(_bins, 0);
+      double range = hi - lo;
+      for (double x : _buf)
+      {
+        size_t bin = static_cast<size_t>(((x - lo) / range) * _bins);
+        if (bin >= _bins)
+        {
+          bin = _bins - 1;
+        }
+        counts[bin]++;
+      }
+      double ent = 0;
+      double denom = static_cast<double>(_p);
+      for (size_t b = 0; b < _bins; ++b)
+      {
+        if (counts[b] > 0)
+        {
+          double p = static_cast<double>(counts[b]) / denom;
+          ent -= p * std::log(p);
+        }
+      }
+      _v = ent / std::log(static_cast<double>(_bins));
+    }
+    return Napi::Number::New(info.Env(), _v);
+  }
+  Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
+  Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _buf.size() >= _p); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _v = 0;
+    _buf.clear();
+  }
+  size_t _p, _bins;
+  double _v = 0;
+  std::vector<double> _buf;
+};
+
+// ParkinsonVol streaming
+class ParkinsonVolWrap : public Napi::ObjectWrap<ParkinsonVolWrap>
+{
+ public:
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "ParkinsonVol", {InstanceMethod("update", &ParkinsonVolWrap::Update), InstanceMethod("reset", &ParkinsonVolWrap::Reset), InstanceAccessor("value", &ParkinsonVolWrap::Value, nullptr), InstanceAccessor("ready", &ParkinsonVolWrap::Ready, nullptr)}); }
+  ParkinsonVolWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<ParkinsonVolWrap>(info), _p(info[0].As<Napi::Number>().Uint32Value()) {}
+
+ private:
+  Napi::Value Update(const Napi::CallbackInfo& info)
+  {
+    double h = info[0].As<Napi::Number>().DoubleValue(), l = info[1].As<Napi::Number>().DoubleValue();
+    if (l <= 0.0 || h < l)
+    {
+      _hlsq.push_back(std::nan(""));
+    }
+    else
+    {
+      double lnhl = std::log(h / l);
+      _hlsq.push_back(lnhl * lnhl);
+    }
+    if (_hlsq.size() > _p)
+    {
+      _hlsq.erase(_hlsq.begin());
+    }
+    if (_hlsq.size() >= _p)
+    {
+      double sum = 0;
+      bool valid = true;
+      for (double x : _hlsq)
+      {
+        if (std::isnan(x))
+        {
+          valid = false;
+          break;
+        }
+        sum += x;
+      }
+      if (valid)
+      {
+        _v = std::sqrt(sum / static_cast<double>(_p) / (4.0 * std::log(2.0)));
+      }
+    }
+    return Napi::Number::New(info.Env(), _v);
+  }
+  Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
+  Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _hlsq.size() >= _p); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _v = 0;
+    _hlsq.clear();
+  }
+  size_t _p;
+  double _v = 0;
+  std::vector<double> _hlsq;
+};
+
+// RogersSatchellVol streaming
+class RogersSatchellVolWrap : public Napi::ObjectWrap<RogersSatchellVolWrap>
+{
+ public:
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "RogersSatchellVol", {InstanceMethod("update", &RogersSatchellVolWrap::Update), InstanceMethod("reset", &RogersSatchellVolWrap::Reset), InstanceAccessor("value", &RogersSatchellVolWrap::Value, nullptr), InstanceAccessor("ready", &RogersSatchellVolWrap::Ready, nullptr)}); }
+  RogersSatchellVolWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<RogersSatchellVolWrap>(info), _p(info[0].As<Napi::Number>().Uint32Value()) {}
+
+ private:
+  Napi::Value Update(const Napi::CallbackInfo& info)
+  {
+    double o = info[0].As<Napi::Number>().DoubleValue(), h = info[1].As<Napi::Number>().DoubleValue(), l = info[2].As<Napi::Number>().DoubleValue(), c = info[3].As<Napi::Number>().DoubleValue();
+    if (o <= 0.0 || c <= 0.0)
+    {
+      _rsq.push_back(std::nan(""));
+    }
+    else
+    {
+      double v = std::log(h / c) * std::log(h / o) + std::log(l / c) * std::log(l / o);
+      _rsq.push_back(v);
+    }
+    if (_rsq.size() > _p)
+    {
+      _rsq.erase(_rsq.begin());
+    }
+    if (_rsq.size() >= _p)
+    {
+      double sum = 0;
+      bool valid = true;
+      for (double x : _rsq)
+      {
+        if (std::isnan(x))
+        {
+          valid = false;
+          break;
+        }
+        sum += x;
+      }
+      if (valid)
+      {
+        double avg = sum / static_cast<double>(_p);
+        _v = avg >= 0.0 ? std::sqrt(avg) : 0.0;
+      }
+    }
+    return Napi::Number::New(info.Env(), _v);
+  }
+  Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
+  Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _rsq.size() >= _p); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _v = 0;
+    _rsq.clear();
+  }
+  size_t _p;
+  double _v = 0;
+  std::vector<double> _rsq;
+};
+
+// Correlation streaming
+class CorrelationWrap : public Napi::ObjectWrap<CorrelationWrap>
+{
+ public:
+  static Napi::Function Init(Napi::Env env) { return DefineClass(env, "Correlation", {InstanceMethod("update", &CorrelationWrap::Update), InstanceMethod("reset", &CorrelationWrap::Reset), InstanceAccessor("value", &CorrelationWrap::Value, nullptr), InstanceAccessor("ready", &CorrelationWrap::Ready, nullptr)}); }
+  CorrelationWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<CorrelationWrap>(info), _p(info[0].As<Napi::Number>().Uint32Value()) {}
+
+ private:
+  Napi::Value Update(const Napi::CallbackInfo& info)
+  {
+    double x = info[0].As<Napi::Number>().DoubleValue(), y = info[1].As<Napi::Number>().DoubleValue();
+    _xbuf.push_back(x);
+    _ybuf.push_back(y);
+    if (_xbuf.size() > _p)
+    {
+      _xbuf.erase(_xbuf.begin());
+      _ybuf.erase(_ybuf.begin());
+    }
+    if (_xbuf.size() >= _p)
+    {
+      double p = static_cast<double>(_p);
+      double sx = 0, sy = 0, sxy = 0, sx2 = 0, sy2 = 0;
+      for (size_t i = 0; i < _p; ++i)
+      {
+        sx += _xbuf[i];
+        sy += _ybuf[i];
+        sxy += _xbuf[i] * _ybuf[i];
+        sx2 += _xbuf[i] * _xbuf[i];
+        sy2 += _ybuf[i] * _ybuf[i];
+      }
+      double num = p * sxy - sx * sy;
+      double den = std::sqrt((p * sx2 - sx * sx) * (p * sy2 - sy * sy));
+      if (den == 0.0)
+      {
+        return info.Env().Undefined();
+      }
+      _v = num / den;
+    }
+    return Napi::Number::New(info.Env(), _v);
+  }
+  Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
+  Napi::Value Ready(const Napi::CallbackInfo& info) { return Napi::Boolean::New(info.Env(), _xbuf.size() >= _p); }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _v = 0;
+    _xbuf.clear();
+    _ybuf.clear();
+  }
+  size_t _p;
+  double _v = 0;
+  std::vector<double> _xbuf, _ybuf;
 };
 
 // ── Registration ────────────────────────────────────────────────────
@@ -938,6 +1522,13 @@ inline void registerIndicators(Napi::Env env, Napi::Object exports)
   exports.Set("obv", Napi::Function::New(env, batch_obv));
   exports.Set("vwap", Napi::Function::New(env, batch_vwap));
   exports.Set("cvd", Napi::Function::New(env, batch_cvd));
+  exports.Set("skewness", Napi::Function::New(env, batch_skewness));
+  exports.Set("kurtosis", Napi::Function::New(env, batch_kurtosis));
+  exports.Set("rolling_zscore", Napi::Function::New(env, batch_rolling_zscore));
+  exports.Set("shannon_entropy", Napi::Function::New(env, batch_shannon_entropy));
+  exports.Set("parkinson_vol", Napi::Function::New(env, batch_parkinson_vol));
+  exports.Set("rogers_satchell_vol", Napi::Function::New(env, batch_rogers_satchell_vol));
+  exports.Set("correlation", Napi::Function::New(env, batch_correlation));
 
   // Streaming
   exports.Set("SMA", SMAWrap::Init(env));
@@ -956,6 +1547,13 @@ inline void registerIndicators(Napi::Env env, Napi::Object exports)
   exports.Set("OBV", OBVWrap::Init(env));
   exports.Set("VWAP", VWAPWrap::Init(env));
   exports.Set("CVD", CVDWrap::Init(env));
+  exports.Set("Skewness", SkewnessWrap::Init(env));
+  exports.Set("Kurtosis", KurtosisWrap::Init(env));
+  exports.Set("RollingZScore", RollingZScoreWrap::Init(env));
+  exports.Set("ShannonEntropy", ShannonEntropyWrap::Init(env));
+  exports.Set("ParkinsonVol", ParkinsonVolWrap::Init(env));
+  exports.Set("RogersSatchellVol", RogersSatchellVolWrap::Init(env));
+  exports.Set("Correlation", CorrelationWrap::Init(env));
 }
 
 }  // namespace node_flox

--- a/python/indicator_bindings.h
+++ b/python/indicator_bindings.h
@@ -1,11 +1,11 @@
-// python/indicator_bindings.h
-
 #pragma once
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <algorithm>
+#include <cmath>
 #include <cstring>
 
 #include "flox/indicator/adx.h"
@@ -13,14 +13,21 @@
 #include "flox/indicator/bollinger.h"
 #include "flox/indicator/cci.h"
 #include "flox/indicator/chop.h"
+#include "flox/indicator/correlation.h"
 #include "flox/indicator/cvd.h"
 #include "flox/indicator/dema.h"
 #include "flox/indicator/ema.h"
 #include "flox/indicator/kama.h"
+#include "flox/indicator/kurtosis.h"
 #include "flox/indicator/macd.h"
 #include "flox/indicator/obv.h"
+#include "flox/indicator/parkinson_vol.h"
 #include "flox/indicator/rma.h"
+#include "flox/indicator/rogers_satchell_vol.h"
+#include "flox/indicator/rolling_zscore.h"
 #include "flox/indicator/rsi.h"
+#include "flox/indicator/shannon_entropy.h"
+#include "flox/indicator/skewness.h"
 #include "flox/indicator/slope.h"
 #include "flox/indicator/sma.h"
 #include "flox/indicator/stochastic.h"
@@ -59,15 +66,16 @@ py::array_t<double> computeSingle(const Indicator& ind, contiguous_double input)
   return result;
 }
 
-// =================================================================
-// Streaming indicator wrappers
-// =================================================================
+inline py::object optVal(double v, bool ready)
+{
+  return ready ? py::cast(v) : py::none();
+}
 
 class PySMA
 {
  public:
   PySMA(size_t period) : _period(period), _buffer(period, 0), _sum(0), _count(0), _index(0) {}
-  double update(double value)
+  py::object update(double value)
   {
     if (_count < _period)
     {
@@ -83,10 +91,19 @@ class PySMA
       _index = (_index + 1) % _period;
     }
     _value = _sum / _count;
-    return _value;
+    return optVal(_value, isReady());
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _count >= _period; }
+  void reset()
+  {
+    _sum = 0;
+    _count = 0;
+    _index = 0;
+    _value = 0;
+    std::fill(_buffer.begin(), _buffer.end(), 0);
+  }
+  PySMA fresh() const { return PySMA(_period); }
 
  private:
   size_t _period, _count, _index;
@@ -98,7 +115,7 @@ class PyEMA
 {
  public:
   PyEMA(size_t period) : _period(period), _mult(2.0 / (period + 1)) {}
-  double update(double value)
+  py::object update(double value)
   {
     if (_count < _period)
     {
@@ -110,10 +127,17 @@ class PyEMA
     {
       _value = (value - _value) * _mult + _value;
     }
-    return _value;
+    return optVal(_value, isReady());
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _count >= _period; }
+  void reset()
+  {
+    _count = 0;
+    _sum = 0;
+    _value = 0;
+  }
+  PyEMA fresh() const { return PyEMA(_period); }
 
  private:
   size_t _period, _count = 0;
@@ -124,7 +148,7 @@ class PyRMA
 {
  public:
   PyRMA(size_t period) : _period(period), _alpha(1.0 / period) {}
-  double update(double value)
+  py::object update(double value)
   {
     if (_count < _period)
     {
@@ -136,10 +160,17 @@ class PyRMA
     {
       _value = _alpha * value + (1 - _alpha) * _value;
     }
-    return _value;
+    return optVal(_value, isReady());
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _count >= _period; }
+  void reset()
+  {
+    _count = 0;
+    _sum = 0;
+    _value = 0;
+  }
+  PyRMA fresh() const { return PyRMA(_period); }
 
  private:
   size_t _period, _count = 0;
@@ -150,13 +181,13 @@ class PyRSI
 {
  public:
   PyRSI(size_t period) : _period(period) {}
-  double update(double value)
+  py::object update(double value)
   {
     if (_count == 0)
     {
       _prev = value;
       _count++;
-      return _value;
+      return py::none();
     }
     double change = value - _prev;
     _prev = value;
@@ -174,10 +205,19 @@ class PyRSI
       _avgLoss = (_avgLoss * (_period - 1) + loss) / _period;
     }
     _value = _avgLoss == 0 ? 100.0 : 100.0 - 100.0 / (1.0 + _avgGain / _avgLoss);
-    return _value;
+    return optVal(_value, isReady());
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _count > _period; }
+  void reset()
+  {
+    _count = 0;
+    _prev = 0;
+    _avgGain = 0;
+    _avgLoss = 0;
+    _value = 50;
+  }
+  PyRSI fresh() const { return PyRSI(_period); }
 
  private:
   size_t _period, _count = 0;
@@ -188,7 +228,7 @@ class PyATR
 {
  public:
   PyATR(size_t period) : _period(period) {}
-  double update(double high, double low, double close)
+  py::object update(double high, double low, double close)
   {
     double tr;
     if (_count == 0)
@@ -210,10 +250,18 @@ class PyATR
     {
       _value = (_value * (_period - 1) + tr) / _period;
     }
-    return _value;
+    return optVal(_value, isReady());
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _count >= _period; }
+  void reset()
+  {
+    _count = 0;
+    _prevClose = 0;
+    _sum = 0;
+    _value = 0;
+  }
+  PyATR fresh() const { return PyATR(_period); }
 
  private:
   size_t _period, _count = 0;
@@ -223,18 +271,28 @@ class PyATR
 class PyDEMA
 {
  public:
-  PyDEMA(size_t period) : _ema1(period), _ema2(period) {}
-  double update(double value)
+  PyDEMA(size_t period) : _period(period), _ema1(period), _ema2(period) {}
+  py::object update(double value)
   {
-    double e1 = _ema1.update(value);
-    double e2 = _ema2.update(e1);
+    _ema1.update(value);
+    double e1 = _ema1.isReady() ? py::cast<double>(_ema1.getValue()) : 0;
+    _ema2.update(e1);
+    double e2 = _ema2.isReady() ? py::cast<double>(_ema2.getValue()) : 0;
     _value = 2 * e1 - e2;
-    return _value;
+    return optVal(_value, isReady());
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _ema2.isReady(); }
+  void reset()
+  {
+    _ema1.reset();
+    _ema2.reset();
+    _value = 0;
+  }
+  PyDEMA fresh() const { return PyDEMA(_period); }
 
  private:
+  size_t _period;
   PyEMA _ema1, _ema2;
   double _value = 0;
 };
@@ -242,19 +300,31 @@ class PyDEMA
 class PyTEMA
 {
  public:
-  PyTEMA(size_t period) : _ema1(period), _ema2(period), _ema3(period) {}
-  double update(double value)
+  PyTEMA(size_t period) : _period(period), _ema1(period), _ema2(period), _ema3(period) {}
+  py::object update(double value)
   {
-    double e1 = _ema1.update(value);
-    double e2 = _ema2.update(e1);
-    double e3 = _ema3.update(e2);
+    _ema1.update(value);
+    double e1 = _ema1.isReady() ? py::cast<double>(_ema1.getValue()) : 0;
+    _ema2.update(e1);
+    double e2 = _ema2.isReady() ? py::cast<double>(_ema2.getValue()) : 0;
+    _ema3.update(e2);
+    double e3 = _ema3.isReady() ? py::cast<double>(_ema3.getValue()) : 0;
     _value = 3 * e1 - 3 * e2 + e3;
-    return _value;
+    return optVal(_value, isReady());
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _ema3.isReady(); }
+  void reset()
+  {
+    _ema1.reset();
+    _ema2.reset();
+    _ema3.reset();
+    _value = 0;
+  }
+  PyTEMA fresh() const { return PyTEMA(_period); }
 
  private:
+  size_t _period;
   PyEMA _ema1, _ema2, _ema3;
   double _value = 0;
 };
@@ -263,17 +333,17 @@ class PyKAMA
 {
  public:
   PyKAMA(size_t period, size_t fast = 2, size_t slow = 30)
-      : _period(period), _fastSc(2.0 / (fast + 1)), _slowSc(2.0 / (slow + 1))
+      : _period(period), _fast(fast), _slow(slow), _fastSc(2.0 / (fast + 1)), _slowSc(2.0 / (slow + 1))
   {
   }
-  double update(double value)
+  py::object update(double value)
   {
     _buffer.push_back(value);
     _count++;
     if (_count <= _period)
     {
       _value = value;
-      return _value;
+      return py::none();
     }
     if (_buffer.size() > _period + 1)
     {
@@ -289,13 +359,20 @@ class PyKAMA
     double sc = er * (_fastSc - _slowSc) + _slowSc;
     sc *= sc;
     _value += sc * (value - _value);
-    return _value;
+    return py::cast(_value);
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _count > _period; }
+  void reset()
+  {
+    _count = 0;
+    _value = 0;
+    _buffer.clear();
+  }
+  PyKAMA fresh() const { return PyKAMA(_period, _fast, _slow); }
 
  private:
-  size_t _period, _count = 0;
+  size_t _period, _fast, _slow, _count = 0;
   double _fastSc, _slowSc, _value = 0;
   std::vector<double> _buffer;
 };
@@ -304,7 +381,7 @@ class PySlope
 {
  public:
   PySlope(size_t length) : _length(length) {}
-  double update(double value)
+  py::object update(double value)
   {
     _buffer.push_back(value);
     if (_buffer.size() > _length + 1)
@@ -315,10 +392,16 @@ class PySlope
     {
       _value = (value - _buffer.front()) / _length;
     }
-    return _value;
+    return optVal(_value, isReady());
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _buffer.size() > _length; }
+  void reset()
+  {
+    _value = 0;
+    _buffer.clear();
+  }
+  PySlope fresh() const { return PySlope(_length); }
 
  private:
   size_t _length;
@@ -330,31 +413,46 @@ class PyMACD
 {
  public:
   PyMACD(size_t fast = 12, size_t slow = 26, size_t signal = 9)
-      : _fastEma(fast), _slowEma(slow), _signalEma(signal)
+      : _fast(fast), _slow(slow), _signal(signal), _fastEma(fast), _slowEma(slow), _signalEma(signal)
   {
   }
-  double update(double value)
+  py::object update(double value)
   {
-    double f = _fastEma.update(value);
-    double s = _slowEma.update(value);
+    _fastEma.update(value);
+    _slowEma.update(value);
+    double f = _fastEma.isReady() ? py::cast<double>(_fastEma.getValue()) : 0;
+    double s = _slowEma.isReady() ? py::cast<double>(_slowEma.getValue()) : 0;
     _line = f - s;
     if (_slowEma.isReady())
     {
-      _signal = _signalEma.update(_line);
+      _signalEma.update(_line);
       _ready = _signalEma.isReady();
+      _signalVal = _signalEma.isReady() ? py::cast<double>(_signalEma.getValue()) : 0;
     }
-    _histogram = _line - _signal;
-    return _line;
+    _histogram = _line - _signalVal;
+    return optVal(_line, _ready);
   }
-  double getLine() const { return _line; }
-  double getSignal() const { return _signal; }
-  double getHistogram() const { return _histogram; }
-  double getValue() const { return _line; }
+  py::object getLine() const { return optVal(_line, _ready); }
+  py::object getSignal() const { return optVal(_signalVal, _ready); }
+  py::object getHistogram() const { return optVal(_histogram, _ready); }
+  py::object getValue() const { return optVal(_line, _ready); }
   bool isReady() const { return _ready; }
+  void reset()
+  {
+    _fastEma.reset();
+    _slowEma.reset();
+    _signalEma.reset();
+    _line = 0;
+    _signalVal = 0;
+    _histogram = 0;
+    _ready = false;
+  }
+  PyMACD fresh() const { return PyMACD(_fast, _slow, _signal); }
 
  private:
+  size_t _fast, _slow, _signal;
   PyEMA _fastEma, _slowEma, _signalEma;
-  double _line = 0, _signal = 0, _histogram = 0;
+  double _line = 0, _signalVal = 0, _histogram = 0;
   bool _ready = false;
 };
 
@@ -365,9 +463,9 @@ class PyBollinger
       : _sma(period), _period(period), _multiplier(multiplier)
   {
   }
-  double update(double value)
+  py::object update(double value)
   {
-    _middle = _sma.update(value);
+    _sma.update(value);
     _buffer.push_back(value);
     if (_buffer.size() > _period)
     {
@@ -375,23 +473,33 @@ class PyBollinger
     }
     if (_sma.isReady())
     {
+      _middle = py::cast<double>(_sma.getValue());
       double sum = 0;
       for (double v : _buffer)
       {
         double d = v - _middle;
         sum += d * d;
       }
-      double std = std::sqrt(sum / _buffer.size());
-      _upper = _middle + _multiplier * std;
-      _lower = _middle - _multiplier * std;
+      double s = std::sqrt(sum / _buffer.size());
+      _upper = _middle + _multiplier * s;
+      _lower = _middle - _multiplier * s;
     }
-    return _middle;
+    return optVal(_middle, isReady());
   }
-  double getUpper() const { return _upper; }
-  double getMiddle() const { return _middle; }
-  double getLower() const { return _lower; }
-  double getValue() const { return _middle; }
+  py::object getUpper() const { return optVal(_upper, isReady()); }
+  py::object getMiddle() const { return optVal(_middle, isReady()); }
+  py::object getLower() const { return optVal(_lower, isReady()); }
+  py::object getValue() const { return optVal(_middle, isReady()); }
   bool isReady() const { return _sma.isReady(); }
+  void reset()
+  {
+    _sma.reset();
+    _buffer.clear();
+    _upper = 0;
+    _middle = 0;
+    _lower = 0;
+  }
+  PyBollinger fresh() const { return PyBollinger(_period, _multiplier); }
 
  private:
   PySMA _sma;
@@ -404,10 +512,10 @@ class PyStochastic
 {
  public:
   PyStochastic(size_t kPeriod = 14, size_t dPeriod = 3)
-      : _kPeriod(kPeriod), _dSma(dPeriod)
+      : _kPeriod(kPeriod), _dPeriod(dPeriod), _dSma(dPeriod)
   {
   }
-  double update(double high, double low, double close)
+  py::object update(double high, double low, double close)
   {
     _highs.push_back(high);
     _lows.push_back(low);
@@ -421,17 +529,27 @@ class PyStochastic
       double hh = *std::max_element(_highs.begin(), _highs.end());
       double ll = *std::min_element(_lows.begin(), _lows.end());
       _k = (hh != ll) ? 100.0 * (close - ll) / (hh - ll) : 0;
-      _d = _dSma.update(_k);
+      _dSma.update(_k);
+      _d = _dSma.isReady() ? py::cast<double>(_dSma.getValue()) : 0;
     }
-    return _k;
+    return optVal(_k, isReady());
   }
-  double getK() const { return _k; }
-  double getD() const { return _d; }
-  double getValue() const { return _k; }
+  py::object getK() const { return optVal(_k, isReady()); }
+  py::object getD() const { return optVal(_d, isReady()); }
+  py::object getValue() const { return optVal(_k, isReady()); }
   bool isReady() const { return _highs.size() >= _kPeriod && _dSma.isReady(); }
+  void reset()
+  {
+    _highs.clear();
+    _lows.clear();
+    _dSma.reset();
+    _k = 0;
+    _d = 0;
+  }
+  PyStochastic fresh() const { return PyStochastic(_kPeriod, _dPeriod); }
 
  private:
-  size_t _kPeriod;
+  size_t _kPeriod, _dPeriod;
   PySMA _dSma;
   std::vector<double> _highs, _lows;
   double _k = 0, _d = 0;
@@ -441,7 +559,7 @@ class PyCCI
 {
  public:
   PyCCI(size_t period = 20) : _period(period) {}
-  double update(double high, double low, double close)
+  py::object update(double high, double low, double close)
   {
     double tp = (high + low + close) / 3.0;
     _buffer.push_back(tp);
@@ -465,10 +583,16 @@ class PyCCI
       double meanDev = devSum / _buffer.size();
       _value = meanDev != 0 ? (tp - mean) / (0.015 * meanDev) : 0;
     }
-    return _value;
+    return optVal(_value, isReady());
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _buffer.size() >= _period; }
+  void reset()
+  {
+    _value = 0;
+    _buffer.clear();
+  }
+  PyCCI fresh() const { return PyCCI(_period); }
 
  private:
   size_t _period;
@@ -479,7 +603,7 @@ class PyCCI
 class PyOBV
 {
  public:
-  double update(double close, double volume)
+  py::object update(double close, double volume)
   {
     if (_count == 0)
     {
@@ -495,10 +619,17 @@ class PyOBV
     }
     _prevClose = close;
     _count++;
-    return _value;
+    return py::cast(_value);
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _count > 0; }
+  void reset()
+  {
+    _count = 0;
+    _prevClose = 0;
+    _value = 0;
+  }
+  PyOBV fresh() const { return PyOBV(); }
 
  private:
   size_t _count = 0;
@@ -509,7 +640,7 @@ class PyVWAP
 {
  public:
   PyVWAP(size_t window) : _window(window) {}
-  double update(double close, double volume)
+  py::object update(double close, double volume)
   {
     _prices.push_back(close);
     _volumes.push_back(volume);
@@ -525,10 +656,17 @@ class PyVWAP
       vSum += _volumes[i];
     }
     _value = vSum > 0 ? pvSum / vSum : 0;
-    return _value;
+    return optVal(_value, isReady());
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _prices.size() >= _window; }
+  void reset()
+  {
+    _value = 0;
+    _prices.clear();
+    _volumes.clear();
+  }
+  PyVWAP fresh() const { return PyVWAP(_window); }
 
  private:
   size_t _window;
@@ -539,20 +677,413 @@ class PyVWAP
 class PyCVD
 {
  public:
-  double update(double open, double high, double low, double close, double volume)
+  py::object update(double open, double high, double low, double close, double volume)
   {
     double range = high - low;
     double delta = range > 0 ? volume * (close - open) / range : 0;
     _value += delta;
     _count++;
-    return _value;
+    return py::cast(_value);
   }
-  double getValue() const { return _value; }
+  py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _count > 0; }
+  void reset()
+  {
+    _count = 0;
+    _value = 0;
+  }
+  PyCVD fresh() const { return PyCVD(); }
 
  private:
   size_t _count = 0;
   double _value = 0;
+};
+
+class PySkewness
+{
+ public:
+  PySkewness(size_t period) : _period(period) {}
+  py::object update(double value)
+  {
+    _buffer.push_back(value);
+    if (_buffer.size() > _period)
+    {
+      _buffer.erase(_buffer.begin());
+    }
+    if (_buffer.size() >= _period)
+    {
+      double p = static_cast<double>(_period);
+      double mean = 0;
+      for (double v : _buffer)
+      {
+        mean += v;
+      }
+      mean /= p;
+      double m2 = 0, m3 = 0;
+      for (double v : _buffer)
+      {
+        double d = v - mean;
+        double d2 = d * d;
+        m2 += d2;
+        m3 += d2 * d;
+      }
+      double var = m2 / (p - 1.0);
+      if (var == 0.0)
+      {
+        return py::none();
+      }
+      double s = std::sqrt(var);
+      _value = (p / ((p - 1.0) * (p - 2.0))) * (m3 / (s * s * s));
+      return py::cast(_value);
+    }
+    return py::none();
+  }
+  py::object getValue() const { return optVal(_value, isReady()); }
+  bool isReady() const { return _buffer.size() >= _period; }
+  void reset()
+  {
+    _value = 0;
+    _buffer.clear();
+  }
+  PySkewness fresh() const { return PySkewness(_period); }
+
+ private:
+  size_t _period;
+  double _value = 0;
+  std::vector<double> _buffer;
+};
+
+class PyKurtosis
+{
+ public:
+  PyKurtosis(size_t period) : _period(period) {}
+  py::object update(double value)
+  {
+    _buffer.push_back(value);
+    if (_buffer.size() > _period)
+    {
+      _buffer.erase(_buffer.begin());
+    }
+    if (_buffer.size() >= _period)
+    {
+      double p = static_cast<double>(_period);
+      double mean = 0;
+      for (double v : _buffer)
+      {
+        mean += v;
+      }
+      mean /= p;
+      double m2 = 0, m4 = 0;
+      for (double v : _buffer)
+      {
+        double d = v - mean;
+        double d2 = d * d;
+        m2 += d2;
+        m4 += d2 * d2;
+      }
+      double var = m2 / (p - 1.0);
+      if (var == 0.0)
+      {
+        return py::none();
+      }
+      double s2 = var;
+      double t1 = (p * (p + 1.0)) / ((p - 1.0) * (p - 2.0) * (p - 3.0));
+      double t2 = m4 / (s2 * s2);
+      double t3 = (3.0 * (p - 1.0) * (p - 1.0)) / ((p - 2.0) * (p - 3.0));
+      _value = t1 * t2 - t3;
+      return py::cast(_value);
+    }
+    return py::none();
+  }
+  py::object getValue() const { return optVal(_value, isReady()); }
+  bool isReady() const { return _buffer.size() >= _period; }
+  void reset()
+  {
+    _value = 0;
+    _buffer.clear();
+  }
+  PyKurtosis fresh() const { return PyKurtosis(_period); }
+
+ private:
+  size_t _period;
+  double _value = 0;
+  std::vector<double> _buffer;
+};
+
+class PyRollingZScore
+{
+ public:
+  PyRollingZScore(size_t period) : _period(period) {}
+  py::object update(double value)
+  {
+    _buffer.push_back(value);
+    if (_buffer.size() > _period)
+    {
+      _buffer.erase(_buffer.begin());
+    }
+    if (_buffer.size() >= _period)
+    {
+      double p = static_cast<double>(_period);
+      double mean = 0;
+      for (double v : _buffer)
+      {
+        mean += v;
+      }
+      mean /= p;
+      double sumSq = 0;
+      for (double v : _buffer)
+      {
+        double d = v - mean;
+        sumSq += d * d;
+      }
+      double s = std::sqrt(sumSq / (p - 1.0));
+      if (s == 0.0)
+      {
+        return py::none();
+      }
+      _value = (value - mean) / s;
+      return py::cast(_value);
+    }
+    return py::none();
+  }
+  py::object getValue() const { return optVal(_value, isReady()); }
+  bool isReady() const { return _buffer.size() >= _period; }
+  void reset()
+  {
+    _value = 0;
+    _buffer.clear();
+  }
+  PyRollingZScore fresh() const { return PyRollingZScore(_period); }
+
+ private:
+  size_t _period;
+  double _value = 0;
+  std::vector<double> _buffer;
+};
+
+class PyShannonEntropy
+{
+ public:
+  PyShannonEntropy(size_t period, size_t bins = 10) : _period(period), _bins(bins) {}
+  py::object update(double value)
+  {
+    _buffer.push_back(value);
+    if (_buffer.size() > _period)
+    {
+      _buffer.erase(_buffer.begin());
+    }
+    if (_buffer.size() >= _period)
+    {
+      double lo = *std::min_element(_buffer.begin(), _buffer.end());
+      double hi = *std::max_element(_buffer.begin(), _buffer.end());
+      if (lo == hi)
+      {
+        _value = 0.0;
+        return py::cast(_value);
+      }
+      std::vector<size_t> counts(_bins, 0);
+      double range = hi - lo;
+      for (double v : _buffer)
+      {
+        size_t bin = static_cast<size_t>(((v - lo) / range) * _bins);
+        if (bin >= _bins)
+        {
+          bin = _bins - 1;
+        }
+        counts[bin]++;
+      }
+      double ent = 0;
+      double denom = static_cast<double>(_period);
+      for (size_t b = 0; b < _bins; ++b)
+      {
+        if (counts[b] > 0)
+        {
+          double p = static_cast<double>(counts[b]) / denom;
+          ent -= p * std::log(p);
+        }
+      }
+      _value = ent / std::log(static_cast<double>(_bins));
+      return py::cast(_value);
+    }
+    return py::none();
+  }
+  py::object getValue() const { return optVal(_value, isReady()); }
+  bool isReady() const { return _buffer.size() >= _period; }
+  void reset()
+  {
+    _value = 0;
+    _buffer.clear();
+  }
+  PyShannonEntropy fresh() const { return PyShannonEntropy(_period, _bins); }
+
+ private:
+  size_t _period, _bins;
+  double _value = 0;
+  std::vector<double> _buffer;
+};
+
+class PyParkinsonVol
+{
+ public:
+  PyParkinsonVol(size_t period) : _period(period) {}
+  py::object update(double high, double low)
+  {
+    if (low <= 0.0 || high < low)
+    {
+      _hlsq.push_back(std::nan(""));
+    }
+    else
+    {
+      double lnhl = std::log(high / low);
+      _hlsq.push_back(lnhl * lnhl);
+    }
+    if (_hlsq.size() > _period)
+    {
+      _hlsq.erase(_hlsq.begin());
+    }
+    if (_hlsq.size() >= _period)
+    {
+      double sum = 0;
+      bool valid = true;
+      for (double v : _hlsq)
+      {
+        if (std::isnan(v))
+        {
+          valid = false;
+          break;
+        }
+        sum += v;
+      }
+      if (valid)
+      {
+        _value = std::sqrt(sum / static_cast<double>(_period) / (4.0 * std::log(2.0)));
+        return py::cast(_value);
+      }
+    }
+    return py::none();
+  }
+  py::object getValue() const { return optVal(_value, isReady()); }
+  bool isReady() const { return _hlsq.size() >= _period; }
+  void reset()
+  {
+    _value = 0;
+    _hlsq.clear();
+  }
+  PyParkinsonVol fresh() const { return PyParkinsonVol(_period); }
+
+ private:
+  size_t _period;
+  double _value = 0;
+  std::vector<double> _hlsq;
+};
+
+class PyRogersSatchellVol
+{
+ public:
+  PyRogersSatchellVol(size_t period) : _period(period) {}
+  py::object update(double open, double high, double low, double close)
+  {
+    if (open <= 0.0 || close <= 0.0)
+    {
+      _rsq.push_back(std::nan(""));
+    }
+    else
+    {
+      double v = std::log(high / close) * std::log(high / open) +
+                 std::log(low / close) * std::log(low / open);
+      _rsq.push_back(v);
+    }
+    if (_rsq.size() > _period)
+    {
+      _rsq.erase(_rsq.begin());
+    }
+    if (_rsq.size() >= _period)
+    {
+      double sum = 0;
+      bool valid = true;
+      for (double v : _rsq)
+      {
+        if (std::isnan(v))
+        {
+          valid = false;
+          break;
+        }
+        sum += v;
+      }
+      if (valid)
+      {
+        double avg = sum / static_cast<double>(_period);
+        _value = avg >= 0.0 ? std::sqrt(avg) : 0.0;
+        return py::cast(_value);
+      }
+    }
+    return py::none();
+  }
+  py::object getValue() const { return optVal(_value, isReady()); }
+  bool isReady() const { return _rsq.size() >= _period; }
+  void reset()
+  {
+    _value = 0;
+    _rsq.clear();
+  }
+  PyRogersSatchellVol fresh() const { return PyRogersSatchellVol(_period); }
+
+ private:
+  size_t _period;
+  double _value = 0;
+  std::vector<double> _rsq;
+};
+
+class PyCorrelation
+{
+ public:
+  PyCorrelation(size_t period) : _period(period) {}
+  py::object update(double x, double y)
+  {
+    _xbuf.push_back(x);
+    _ybuf.push_back(y);
+    if (_xbuf.size() > _period)
+    {
+      _xbuf.erase(_xbuf.begin());
+      _ybuf.erase(_ybuf.begin());
+    }
+    if (_xbuf.size() >= _period)
+    {
+      double p = static_cast<double>(_period);
+      double sx = 0, sy = 0, sxy = 0, sx2 = 0, sy2 = 0;
+      for (size_t i = 0; i < _period; ++i)
+      {
+        sx += _xbuf[i];
+        sy += _ybuf[i];
+        sxy += _xbuf[i] * _ybuf[i];
+        sx2 += _xbuf[i] * _xbuf[i];
+        sy2 += _ybuf[i] * _ybuf[i];
+      }
+      double num = p * sxy - sx * sy;
+      double den = std::sqrt((p * sx2 - sx * sx) * (p * sy2 - sy * sy));
+      if (den == 0.0)
+      {
+        return py::none();
+      }
+      _value = num / den;
+      return py::cast(_value);
+    }
+    return py::none();
+  }
+  py::object getValue() const { return optVal(_value, isReady()); }
+  bool isReady() const { return _xbuf.size() >= _period; }
+  void reset()
+  {
+    _value = 0;
+    _xbuf.clear();
+    _ybuf.clear();
+  }
+  PyCorrelation fresh() const { return PyCorrelation(_period); }
+
+ private:
+  size_t _period;
+  double _value = 0;
+  std::vector<double> _xbuf, _ybuf;
 };
 
 }  // namespace
@@ -720,7 +1251,6 @@ inline void bindIndicators(py::module_& m)
         std::memcpy(upper.mutable_data(), result.upper.data(), n * sizeof(double));
         std::memcpy(middle.mutable_data(), result.middle.data(), n * sizeof(double));
         std::memcpy(lower.mutable_data(), result.lower.data(), n * sizeof(double));
-
         py::dict d;
         d["upper"] = upper;
         d["middle"] = middle;
@@ -758,17 +1288,14 @@ inline void bindIndicators(py::module_& m)
         auto* sl = signal_long.data();
         auto* ss = signal_short.data();
         auto* lr = log_returns.data();
-
         std::vector<double> trades;
         double pnl = 0.0;
         int8_t prevPos = 0;
         bool inTrade = false;
-
         for (size_t i = 1; i < n; ++i)
         {
           int8_t pos = sl[i - 1] + ss[i - 1];
           double ret = static_cast<double>(pos) * lr[i];
-
           if (pos != prevPos)
           {
             if (inTrade)
@@ -788,7 +1315,6 @@ inline void bindIndicators(py::module_& m)
         {
           trades.push_back(pnl);
         }
-
         py::array_t<double> out(trades.size());
         std::memcpy(out.mutable_data(), trades.data(), trades.size() * sizeof(double));
         return out;
@@ -842,7 +1368,7 @@ inline void bindIndicators(py::module_& m)
   m.def(
       "rma", [](contiguous_double input, size_t period)
       { return computeSingle(flox::indicator::RMA(period), input); },
-      "Wilder's Moving Average (alpha=1/period)", py::arg("input"), py::arg("period"));
+      py::arg("input"), py::arg("period"));
 
   m.def(
       "dema", [](contiguous_double input, size_t period)
@@ -854,7 +1380,8 @@ inline void bindIndicators(py::module_& m)
         { py::gil_scoped_release r; result = flox::indicator::DEMA(period).compute(std::span<const double>(ptr, n)); }
         py::array_t<double> out(n);
         std::memcpy(out.mutable_data(), result.data(), n * sizeof(double));
-        return out; }, "Double EMA: 2*EMA - EMA(EMA)", py::arg("input"), py::arg("period"));
+        return out; },
+      py::arg("input"), py::arg("period"));
 
   m.def(
       "tema", [](contiguous_double input, size_t period)
@@ -866,7 +1393,8 @@ inline void bindIndicators(py::module_& m)
         { py::gil_scoped_release r; result = flox::indicator::TEMA(period).compute(std::span<const double>(ptr, n)); }
         py::array_t<double> out(n);
         std::memcpy(out.mutable_data(), result.data(), n * sizeof(double));
-        return out; }, "Triple EMA: 3*EMA - 3*EMA(EMA) + EMA(EMA(EMA))", py::arg("input"), py::arg("period"));
+        return out; },
+      py::arg("input"), py::arg("period"));
 
   m.def(
       "stochastic",
@@ -892,14 +1420,12 @@ inline void bindIndicators(py::module_& m)
         d["d"] = dout;
         return d;
       },
-      "Stochastic %K and %D",
       py::arg("high"), py::arg("low"), py::arg("close"),
       py::arg("k_period") = 14, py::arg("d_period") = 3);
 
   m.def(
       "cci",
-      [](contiguous_double high, contiguous_double low, contiguous_double close,
-         size_t period)
+      [](contiguous_double high, contiguous_double low, contiguous_double close, size_t period)
       {
         size_t n = high.request().shape[0];
         checkSameSize(n, low.request().shape[0], "arrays must have same size");
@@ -917,7 +1443,6 @@ inline void bindIndicators(py::module_& m)
         std::memcpy(out.mutable_data(), result.data(), n * sizeof(double));
         return out;
       },
-      "Commodity Channel Index",
       py::arg("high"), py::arg("low"), py::arg("close"), py::arg("period") = 20);
 
   m.def(
@@ -938,7 +1463,6 @@ inline void bindIndicators(py::module_& m)
         std::memcpy(out.mutable_data(), result.data(), n * sizeof(double));
         return out;
       },
-      "Rolling VWAP",
       py::arg("close"), py::arg("volume"), py::arg("window") = 96);
 
   m.def(
@@ -968,52 +1492,145 @@ inline void bindIndicators(py::module_& m)
         std::memcpy(out.mutable_data(), result.data(), n * sizeof(double));
         return out;
       },
-      "Cumulative Volume Delta",
       py::arg("open"), py::arg("high"), py::arg("low"), py::arg("close"), py::arg("volume"));
 
-  // =================================================================
-  // Streaming indicator classes
-  // =================================================================
+  m.def(
+      "skewness", [](contiguous_double input, size_t period)
+      { return computeSingle(flox::indicator::Skewness(period), input); },
+      py::arg("input"), py::arg("period"));
+
+  m.def(
+      "kurtosis", [](contiguous_double input, size_t period)
+      { return computeSingle(flox::indicator::Kurtosis(period), input); },
+      py::arg("input"), py::arg("period"));
+
+  m.def(
+      "rolling_zscore", [](contiguous_double input, size_t period)
+      { return computeSingle(flox::indicator::RollingZScore(period), input); },
+      py::arg("input"), py::arg("period"));
+
+  m.def(
+      "shannon_entropy", [](contiguous_double input, size_t period, size_t bins)
+      { return computeSingle(flox::indicator::ShannonEntropy(period, bins), input); },
+      py::arg("input"), py::arg("period"), py::arg("bins") = 10);
+
+  m.def(
+      "parkinson_vol",
+      [](contiguous_double high, contiguous_double low, size_t period) -> py::array_t<double>
+      {
+        size_t n = high.request().shape[0];
+        checkSameSize(n, low.request().shape[0], "high and low must have same size");
+        auto* h = high.data();
+        auto* l = low.data();
+        py::array_t<double> result(n);
+        auto* o = result.mutable_data();
+        {
+          py::gil_scoped_release release;
+          flox::indicator::ParkinsonVol(period).compute(
+              std::span<const double>(h, n), std::span<const double>(l, n), std::span<double>(o, n));
+        }
+        return result;
+      },
+      py::arg("high"), py::arg("low"), py::arg("period"));
+
+  m.def(
+      "rogers_satchell_vol",
+      [](contiguous_double open, contiguous_double high, contiguous_double low,
+         contiguous_double close, size_t period) -> py::array_t<double>
+      {
+        size_t n = open.request().shape[0];
+        checkSameSize(n, high.request().shape[0], "arrays must have same size");
+        checkSameSize(n, low.request().shape[0], "arrays must have same size");
+        checkSameSize(n, close.request().shape[0], "arrays must have same size");
+        auto* o = open.data();
+        auto* h = high.data();
+        auto* l = low.data();
+        auto* c = close.data();
+        py::array_t<double> result(n);
+        auto* out = result.mutable_data();
+        {
+          py::gil_scoped_release release;
+          flox::indicator::RogersSatchellVol(period).compute(
+              std::span<const double>(o, n), std::span<const double>(h, n),
+              std::span<const double>(l, n), std::span<const double>(c, n),
+              std::span<double>(out, n));
+        }
+        return result;
+      },
+      py::arg("open"), py::arg("high"), py::arg("low"), py::arg("close"), py::arg("period"));
+
+  m.def(
+      "correlation",
+      [](contiguous_double x, contiguous_double y, size_t period) -> py::array_t<double>
+      {
+        size_t n = x.request().shape[0];
+        checkSameSize(n, y.request().shape[0], "x and y must have same size");
+        auto* xp = x.data();
+        auto* yp = y.data();
+        py::array_t<double> result(n);
+        auto* o = result.mutable_data();
+        {
+          py::gil_scoped_release release;
+          flox::indicator::Correlation(period).compute(
+              std::span<const double>(xp, n), std::span<const double>(yp, n), std::span<double>(o, n));
+        }
+        return result;
+      },
+      py::arg("x"), py::arg("y"), py::arg("period"));
 
   py::class_<PySMA>(m, "SMA")
       .def(py::init<size_t>(), py::arg("period"))
       .def("update", &PySMA::update, py::arg("value"))
+      .def("reset", &PySMA::reset)
+      .def("fresh", &PySMA::fresh)
       .def_property_readonly("value", &PySMA::getValue)
       .def_property_readonly("ready", &PySMA::isReady);
 
   py::class_<PyEMA>(m, "EMA")
       .def(py::init<size_t>(), py::arg("period"))
       .def("update", &PyEMA::update, py::arg("value"))
+      .def("reset", &PyEMA::reset)
+      .def("fresh", &PyEMA::fresh)
       .def_property_readonly("value", &PyEMA::getValue)
       .def_property_readonly("ready", &PyEMA::isReady);
 
   py::class_<PyRMA>(m, "RMA")
       .def(py::init<size_t>(), py::arg("period"))
       .def("update", &PyRMA::update, py::arg("value"))
+      .def("reset", &PyRMA::reset)
+      .def("fresh", &PyRMA::fresh)
       .def_property_readonly("value", &PyRMA::getValue)
       .def_property_readonly("ready", &PyRMA::isReady);
 
   py::class_<PyRSI>(m, "RSI")
       .def(py::init<size_t>(), py::arg("period"))
       .def("update", &PyRSI::update, py::arg("value"))
+      .def("reset", &PyRSI::reset)
+      .def("fresh", &PyRSI::fresh)
       .def_property_readonly("value", &PyRSI::getValue)
       .def_property_readonly("ready", &PyRSI::isReady);
 
   py::class_<PyATR>(m, "ATR")
       .def(py::init<size_t>(), py::arg("period"))
       .def("update", &PyATR::update, py::arg("high"), py::arg("low"), py::arg("close"))
+      .def("reset", &PyATR::reset)
+      .def("fresh", &PyATR::fresh)
       .def_property_readonly("value", &PyATR::getValue)
       .def_property_readonly("ready", &PyATR::isReady);
 
   py::class_<PyDEMA>(m, "DEMA")
       .def(py::init<size_t>(), py::arg("period"))
       .def("update", &PyDEMA::update, py::arg("value"))
+      .def("reset", &PyDEMA::reset)
+      .def("fresh", &PyDEMA::fresh)
       .def_property_readonly("value", &PyDEMA::getValue)
       .def_property_readonly("ready", &PyDEMA::isReady);
 
   py::class_<PyTEMA>(m, "TEMA")
       .def(py::init<size_t>(), py::arg("period"))
       .def("update", &PyTEMA::update, py::arg("value"))
+      .def("reset", &PyTEMA::reset)
+      .def("fresh", &PyTEMA::fresh)
       .def_property_readonly("value", &PyTEMA::getValue)
       .def_property_readonly("ready", &PyTEMA::isReady);
 
@@ -1021,12 +1638,16 @@ inline void bindIndicators(py::module_& m)
       .def(py::init<size_t, size_t, size_t>(), py::arg("period"), py::arg("fast") = 2,
            py::arg("slow") = 30)
       .def("update", &PyKAMA::update, py::arg("value"))
+      .def("reset", &PyKAMA::reset)
+      .def("fresh", &PyKAMA::fresh)
       .def_property_readonly("value", &PyKAMA::getValue)
       .def_property_readonly("ready", &PyKAMA::isReady);
 
   py::class_<PySlope>(m, "Slope")
       .def(py::init<size_t>(), py::arg("length"))
       .def("update", &PySlope::update, py::arg("value"))
+      .def("reset", &PySlope::reset)
+      .def("fresh", &PySlope::fresh)
       .def_property_readonly("value", &PySlope::getValue)
       .def_property_readonly("ready", &PySlope::isReady);
 
@@ -1034,6 +1655,8 @@ inline void bindIndicators(py::module_& m)
       .def(py::init<size_t, size_t, size_t>(), py::arg("fast") = 12, py::arg("slow") = 26,
            py::arg("signal") = 9)
       .def("update", &PyMACD::update, py::arg("value"))
+      .def("reset", &PyMACD::reset)
+      .def("fresh", &PyMACD::fresh)
       .def_property_readonly("line", &PyMACD::getLine)
       .def_property_readonly("signal", &PyMACD::getSignal)
       .def_property_readonly("histogram", &PyMACD::getHistogram)
@@ -1043,6 +1666,8 @@ inline void bindIndicators(py::module_& m)
   py::class_<PyBollinger>(m, "Bollinger")
       .def(py::init<size_t, double>(), py::arg("period") = 20, py::arg("multiplier") = 2.0)
       .def("update", &PyBollinger::update, py::arg("value"))
+      .def("reset", &PyBollinger::reset)
+      .def("fresh", &PyBollinger::fresh)
       .def_property_readonly("upper", &PyBollinger::getUpper)
       .def_property_readonly("middle", &PyBollinger::getMiddle)
       .def_property_readonly("lower", &PyBollinger::getLower)
@@ -1052,6 +1677,8 @@ inline void bindIndicators(py::module_& m)
   py::class_<PyStochastic>(m, "Stochastic")
       .def(py::init<size_t, size_t>(), py::arg("k_period") = 14, py::arg("d_period") = 3)
       .def("update", &PyStochastic::update, py::arg("high"), py::arg("low"), py::arg("close"))
+      .def("reset", &PyStochastic::reset)
+      .def("fresh", &PyStochastic::fresh)
       .def_property_readonly("k", &PyStochastic::getK)
       .def_property_readonly("d", &PyStochastic::getD)
       .def_property_readonly("value", &PyStochastic::getValue)
@@ -1060,18 +1687,24 @@ inline void bindIndicators(py::module_& m)
   py::class_<PyCCI>(m, "CCI")
       .def(py::init<size_t>(), py::arg("period") = 20)
       .def("update", &PyCCI::update, py::arg("high"), py::arg("low"), py::arg("close"))
+      .def("reset", &PyCCI::reset)
+      .def("fresh", &PyCCI::fresh)
       .def_property_readonly("value", &PyCCI::getValue)
       .def_property_readonly("ready", &PyCCI::isReady);
 
   py::class_<PyOBV>(m, "OBV")
       .def(py::init<>())
       .def("update", &PyOBV::update, py::arg("close"), py::arg("volume"))
+      .def("reset", &PyOBV::reset)
+      .def("fresh", &PyOBV::fresh)
       .def_property_readonly("value", &PyOBV::getValue)
       .def_property_readonly("ready", &PyOBV::isReady);
 
   py::class_<PyVWAP>(m, "VWAP")
       .def(py::init<size_t>(), py::arg("window"))
       .def("update", &PyVWAP::update, py::arg("close"), py::arg("volume"))
+      .def("reset", &PyVWAP::reset)
+      .def("fresh", &PyVWAP::fresh)
       .def_property_readonly("value", &PyVWAP::getValue)
       .def_property_readonly("ready", &PyVWAP::isReady);
 
@@ -1079,6 +1712,65 @@ inline void bindIndicators(py::module_& m)
       .def(py::init<>())
       .def("update", &PyCVD::update, py::arg("open"), py::arg("high"), py::arg("low"),
            py::arg("close"), py::arg("volume"))
+      .def("reset", &PyCVD::reset)
+      .def("fresh", &PyCVD::fresh)
       .def_property_readonly("value", &PyCVD::getValue)
       .def_property_readonly("ready", &PyCVD::isReady);
+
+  py::class_<PySkewness>(m, "Skewness")
+      .def(py::init<size_t>(), py::arg("period"))
+      .def("update", &PySkewness::update, py::arg("value"))
+      .def("reset", &PySkewness::reset)
+      .def("fresh", &PySkewness::fresh)
+      .def_property_readonly("value", &PySkewness::getValue)
+      .def_property_readonly("ready", &PySkewness::isReady);
+
+  py::class_<PyKurtosis>(m, "Kurtosis")
+      .def(py::init<size_t>(), py::arg("period"))
+      .def("update", &PyKurtosis::update, py::arg("value"))
+      .def("reset", &PyKurtosis::reset)
+      .def("fresh", &PyKurtosis::fresh)
+      .def_property_readonly("value", &PyKurtosis::getValue)
+      .def_property_readonly("ready", &PyKurtosis::isReady);
+
+  py::class_<PyRollingZScore>(m, "RollingZScore")
+      .def(py::init<size_t>(), py::arg("period"))
+      .def("update", &PyRollingZScore::update, py::arg("value"))
+      .def("reset", &PyRollingZScore::reset)
+      .def("fresh", &PyRollingZScore::fresh)
+      .def_property_readonly("value", &PyRollingZScore::getValue)
+      .def_property_readonly("ready", &PyRollingZScore::isReady);
+
+  py::class_<PyShannonEntropy>(m, "ShannonEntropy")
+      .def(py::init<size_t, size_t>(), py::arg("period"), py::arg("bins") = 10)
+      .def("update", &PyShannonEntropy::update, py::arg("value"))
+      .def("reset", &PyShannonEntropy::reset)
+      .def("fresh", &PyShannonEntropy::fresh)
+      .def_property_readonly("value", &PyShannonEntropy::getValue)
+      .def_property_readonly("ready", &PyShannonEntropy::isReady);
+
+  py::class_<PyParkinsonVol>(m, "ParkinsonVol")
+      .def(py::init<size_t>(), py::arg("period"))
+      .def("update", &PyParkinsonVol::update, py::arg("high"), py::arg("low"))
+      .def("reset", &PyParkinsonVol::reset)
+      .def("fresh", &PyParkinsonVol::fresh)
+      .def_property_readonly("value", &PyParkinsonVol::getValue)
+      .def_property_readonly("ready", &PyParkinsonVol::isReady);
+
+  py::class_<PyRogersSatchellVol>(m, "RogersSatchellVol")
+      .def(py::init<size_t>(), py::arg("period"))
+      .def("update", &PyRogersSatchellVol::update, py::arg("open"), py::arg("high"),
+           py::arg("low"), py::arg("close"))
+      .def("reset", &PyRogersSatchellVol::reset)
+      .def("fresh", &PyRogersSatchellVol::fresh)
+      .def_property_readonly("value", &PyRogersSatchellVol::getValue)
+      .def_property_readonly("ready", &PyRogersSatchellVol::isReady);
+
+  py::class_<PyCorrelation>(m, "Correlation")
+      .def(py::init<size_t>(), py::arg("period"))
+      .def("update", &PyCorrelation::update, py::arg("x"), py::arg("y"))
+      .def("reset", &PyCorrelation::reset)
+      .def("fresh", &PyCorrelation::fresh)
+      .def_property_readonly("value", &PyCorrelation::getValue)
+      .def_property_readonly("ready", &PyCorrelation::isReady);
 }

--- a/quickjs/flox/indicators.js
+++ b/quickjs/flox/indicators.js
@@ -27,6 +27,7 @@ class SMA {
     }
     get value() { return this._value; }
     get ready() { return this._count >= this._period; }
+    reset() { this._buffer = new Array(this._period); this._sum = 0; this._count = 0; this._index = 0; this._value = 0; }
     static compute(data, period) { return __flox_indicator_sma(data, period); }
 }
 
@@ -50,6 +51,7 @@ class EMA {
     }
     get value() { return this._value; }
     get ready() { return this._count >= this._period; }
+    reset() { this._value = 0; this._count = 0; this._sum = 0; }
     static compute(data, period) { return __flox_indicator_ema(data, period); }
 }
 
@@ -73,6 +75,7 @@ class RMA {
     }
     get value() { return this._value; }
     get ready() { return this._count >= this._period; }
+    reset() { this._value = 0; this._count = 0; this._sum = 0; }
     static compute(data, period) { return __flox_indicator_rma(data, period); }
 }
 
@@ -90,6 +93,7 @@ class DEMA {
     }
     get value() { return this._value; }
     get ready() { return this._ema2.ready; }
+    reset() { this._ema1.reset(); this._ema2.reset(); this._value = 0; }
     static compute(data, period) { return __flox_indicator_dema(data, period); }
 }
 
@@ -109,6 +113,7 @@ class TEMA {
     }
     get value() { return this._value; }
     get ready() { return this._ema3.ready; }
+    reset() { this._ema1.reset(); this._ema2.reset(); this._ema3.reset(); this._value = 0; }
     static compute(data, period) { return __flox_indicator_tema(data, period); }
 }
 
@@ -142,6 +147,7 @@ class KAMA {
     }
     get value() { return this._value; }
     get ready() { return this._count > this._period; }
+    reset() { this._buffer = []; this._value = 0; this._count = 0; }
     static compute(data, period, fast, slow) {
         return __flox_indicator_kama(data, period, fast || 2, slow || 30);
     }
@@ -187,6 +193,7 @@ class RSI {
     }
     get value() { return this._value; }
     get ready() { return this._count > this._period; }
+    reset() { this._count = 0; this._prevValue = 0; this._avgGain = 0; this._avgLoss = 0; this._value = 50; }
     static compute(data, period) { return __flox_indicator_rsi(data, period); }
 }
 
@@ -222,6 +229,7 @@ class Stochastic {
     get d() { return this._d; }
     get value() { return this._k; }
     get ready() { return this._highs.length >= this._kPeriod && this._dSma.ready; }
+    reset() { this._highs = []; this._lows = []; this._dSma = new SMA(this._dPeriod); this._k = 0; this._d = 0; }
     static compute(high, low, close, kPeriod, dPeriod) {
         return __flox_indicator_stochastic(high, low, close, kPeriod || 14, dPeriod || 3);
     }
@@ -249,6 +257,7 @@ class CCI {
     }
     get value() { return this._value; }
     get ready() { return this._buffer.length >= this._period; }
+    reset() { this._buffer = []; this._value = 0; }
     static compute(high, low, close, period) {
         return __flox_indicator_cci(high, low, close, period || 20);
     }
@@ -289,6 +298,7 @@ class CHOP {
     }
     get value() { return this._value; }
     get ready() { return this._atrSum.length >= this._period; }
+    reset() { this._atr1 = new ATR(1); this._atrSum = []; this._highs = []; this._lows = []; this._value = 0; }
     static compute(high, low, close, period) {
         return __flox_indicator_chop(high, low, close, period);
     }
@@ -325,6 +335,7 @@ class ATR {
     }
     get value() { return this._value; }
     get ready() { return this._count >= this._period; }
+    reset() { this._count = 0; this._prevClose = 0; this._value = 0; this._sum = 0; }
     static compute(high, low, close, period) {
         return __flox_indicator_atr(high, low, close, period);
     }
@@ -390,6 +401,7 @@ class ADX {
     get minusDi() { return this._minusDi; }
     get value() { return this._adx; }
     get ready() { return this._count > 2 * this._period; }
+    reset() { this._count = 0; this._prevHigh = 0; this._prevLow = 0; this._prevClose = 0; this._smoothPlusDm = 0; this._smoothMinusDm = 0; this._smoothTr = 0; this._adxSum = 0; this._adxCount = 0; this._adx = 0; this._plusDi = 0; this._minusDi = 0; }
     static compute(high, low, close, period) {
         return __flox_indicator_adx(high, low, close, period);
     }
@@ -411,6 +423,7 @@ class Slope {
     }
     get value() { return this._value; }
     get ready() { return this._buffer.length > this._length; }
+    reset() { this._buffer = []; this._value = 0; }
     static compute(data, length) { return __flox_indicator_slope(data, length); }
 }
 
@@ -440,6 +453,7 @@ class MACD {
     get histogram() { return this._histogram; }
     get value() { return this._line; }
     get ready() { return this._ready; }
+    reset() { this._fastEma.reset(); this._slowEma.reset(); this._signalEma.reset(); this._line = 0; this._signal = 0; this._histogram = 0; this._ready = false; }
     static compute(data, fast, slow, signal) {
         return __flox_indicator_macd(data, fast || 12, slow || 26, signal || 9);
     }
@@ -476,6 +490,7 @@ class Bollinger {
     get lower() { return this._lower; }
     get value() { return this._middle; }
     get ready() { return this._sma.ready; }
+    reset() { this._sma = new SMA(this._period); this._buffer = []; this._upper = 0; this._middle = 0; this._lower = 0; }
     static compute(data, period, multiplier) {
         return __flox_indicator_bollinger(data, period || 20, multiplier || 2.0);
     }
@@ -505,6 +520,7 @@ class OBV {
     }
     get value() { return this._value; }
     get ready() { return this._count > 0; }
+    reset() { this._value = 0; this._prevClose = 0; this._count = 0; }
     static compute(close, volume) { return __flox_indicator_obv(close, volume); }
 }
 
@@ -532,6 +548,7 @@ class VWAP {
     }
     get value() { return this._value; }
     get ready() { return this._prices.length >= this._window; }
+    reset() { this._prices = []; this._volumes = []; this._value = 0; }
     static compute(close, volume, window) {
         return __flox_indicator_vwap(close, volume, window);
     }
@@ -551,7 +568,216 @@ class CVD {
     }
     get value() { return this._value; }
     get ready() { return this._count > 0; }
+    reset() { this._value = 0; this._count = 0; }
     static compute(open, high, low, close, volume) {
         return __flox_indicator_cvd(open, high, low, close, volume);
     }
+}
+
+// ============================================================
+// Statistical
+// ============================================================
+
+class Skewness {
+    constructor(period) {
+        this._period = period;
+        this._buffer = [];
+        this._value = NaN;
+    }
+    update(value) {
+        this._buffer.push(value);
+        if (this._buffer.length > this._period) this._buffer.shift();
+        if (this._buffer.length < this._period) return this._value;
+        var n = this._buffer.length;
+        var sum = 0;
+        for (var i = 0; i < n; i++) sum += this._buffer[i];
+        var mean = sum / n;
+        var s2 = 0;
+        for (var i = 0; i < n; i++) { var d = this._buffer[i] - mean; s2 += d * d; }
+        var s = Math.sqrt(s2 / (n - 1));
+        if (s === 0) { this._value = NaN; return this._value; }
+        var m3 = 0;
+        for (var i = 0; i < n; i++) { var d = (this._buffer[i] - mean) / s; m3 += d * d * d; }
+        this._value = (n / ((n - 1) * (n - 2))) * m3;
+        return this._value;
+    }
+    get value() { return this._value; }
+    get ready() { return this._buffer.length >= this._period; }
+    reset() { this._buffer = []; this._value = NaN; }
+    static compute(data, period) { return __flox_indicator_skewness(data, period); }
+}
+
+class Kurtosis {
+    constructor(period) {
+        this._period = period;
+        this._buffer = [];
+        this._value = NaN;
+    }
+    update(value) {
+        this._buffer.push(value);
+        if (this._buffer.length > this._period) this._buffer.shift();
+        if (this._buffer.length < this._period) return this._value;
+        var n = this._buffer.length;
+        var sum = 0;
+        for (var i = 0; i < n; i++) sum += this._buffer[i];
+        var mean = sum / n;
+        var s2 = 0;
+        for (var i = 0; i < n; i++) { var d = this._buffer[i] - mean; s2 += d * d; }
+        var s = Math.sqrt(s2 / (n - 1));
+        if (s === 0) { this._value = NaN; return this._value; }
+        var m4 = 0;
+        for (var i = 0; i < n; i++) { var d = (this._buffer[i] - mean) / s; m4 += d * d * d * d; }
+        this._value = (n * (n + 1)) / ((n - 1) * (n - 2) * (n - 3)) * m4 - 3 * (n - 1) * (n - 1) / ((n - 2) * (n - 3));
+        return this._value;
+    }
+    get value() { return this._value; }
+    get ready() { return this._buffer.length >= this._period; }
+    reset() { this._buffer = []; this._value = NaN; }
+    static compute(data, period) { return __flox_indicator_kurtosis(data, period); }
+}
+
+class RollingZScore {
+    constructor(period) {
+        this._period = period;
+        this._buffer = [];
+        this._value = NaN;
+    }
+    update(value) {
+        this._buffer.push(value);
+        if (this._buffer.length > this._period) this._buffer.shift();
+        if (this._buffer.length < this._period) return this._value;
+        var n = this._buffer.length;
+        var sum = 0;
+        for (var i = 0; i < n; i++) sum += this._buffer[i];
+        var mean = sum / n;
+        var s2 = 0;
+        for (var i = 0; i < n; i++) { var d = this._buffer[i] - mean; s2 += d * d; }
+        var s = Math.sqrt(s2 / n);
+        this._value = s === 0 ? NaN : (value - mean) / s;
+        return this._value;
+    }
+    get value() { return this._value; }
+    get ready() { return this._buffer.length >= this._period; }
+    reset() { this._buffer = []; this._value = NaN; }
+    static compute(data, period) { return __flox_indicator_rolling_zscore(data, period); }
+}
+
+class ShannonEntropy {
+    constructor(period, bins) {
+        this._period = period;
+        this._bins = bins || 10;
+        this._buffer = [];
+        this._value = NaN;
+    }
+    update(value) {
+        this._buffer.push(value);
+        if (this._buffer.length > this._period) this._buffer.shift();
+        if (this._buffer.length < this._period) return this._value;
+        var n = this._buffer.length;
+        var min = Infinity, max = -Infinity;
+        for (var i = 0; i < n; i++) {
+            if (this._buffer[i] < min) min = this._buffer[i];
+            if (this._buffer[i] > max) max = this._buffer[i];
+        }
+        if (max === min) { this._value = 0; return this._value; }
+        var counts = new Array(this._bins);
+        for (var i = 0; i < this._bins; i++) counts[i] = 0;
+        var range = max - min;
+        for (var i = 0; i < n; i++) {
+            var bin = Math.floor((this._buffer[i] - min) / range * this._bins);
+            if (bin >= this._bins) bin = this._bins - 1;
+            counts[bin]++;
+        }
+        var entropy = 0;
+        var lnBins = Math.log(this._bins);
+        for (var i = 0; i < this._bins; i++) {
+            if (counts[i] > 0) {
+                var p = counts[i] / n;
+                entropy -= p * Math.log(p);
+            }
+        }
+        this._value = lnBins > 0 ? entropy / lnBins : 0;
+        return this._value;
+    }
+    get value() { return this._value; }
+    get ready() { return this._buffer.length >= this._period; }
+    reset() { this._buffer = []; this._value = NaN; }
+    static compute(data, period, bins) { return __flox_indicator_shannon_entropy(data, period, bins || 10); }
+}
+
+class ParkinsonVol {
+    constructor(period) {
+        this._period = period;
+        this._buffer = [];
+        this._value = NaN;
+    }
+    update(high, low) {
+        var hl = Math.log(high / low);
+        this._buffer.push(hl * hl);
+        if (this._buffer.length > this._period) this._buffer.shift();
+        if (this._buffer.length < this._period) return this._value;
+        var sum = 0;
+        for (var i = 0; i < this._buffer.length; i++) sum += this._buffer[i];
+        this._value = Math.sqrt(sum / this._buffer.length / (4 * Math.LN2));
+        return this._value;
+    }
+    get value() { return this._value; }
+    get ready() { return this._buffer.length >= this._period; }
+    reset() { this._buffer = []; this._value = NaN; }
+    static compute(high, low, period) { return __flox_indicator_parkinson_vol(high, low, period); }
+}
+
+class RogersSatchellVol {
+    constructor(period) {
+        this._period = period;
+        this._buffer = [];
+        this._value = NaN;
+    }
+    update(open, high, low, close) {
+        var rs = Math.log(high / close) * Math.log(high / open) + Math.log(low / close) * Math.log(low / open);
+        this._buffer.push(rs);
+        if (this._buffer.length > this._period) this._buffer.shift();
+        if (this._buffer.length < this._period) return this._value;
+        var sum = 0;
+        for (var i = 0; i < this._buffer.length; i++) sum += this._buffer[i];
+        this._value = Math.sqrt(sum / this._buffer.length);
+        return this._value;
+    }
+    get value() { return this._value; }
+    get ready() { return this._buffer.length >= this._period; }
+    reset() { this._buffer = []; this._value = NaN; }
+    static compute(open, high, low, close, period) { return __flox_indicator_rogers_satchell_vol(open, high, low, close, period); }
+}
+
+class Correlation {
+    constructor(period) {
+        this._period = period;
+        this._xs = [];
+        this._ys = [];
+        this._value = NaN;
+    }
+    update(x, y) {
+        this._xs.push(x);
+        this._ys.push(y);
+        if (this._xs.length > this._period) { this._xs.shift(); this._ys.shift(); }
+        if (this._xs.length < this._period) return this._value;
+        var n = this._xs.length;
+        var sx = 0, sy = 0;
+        for (var i = 0; i < n; i++) { sx += this._xs[i]; sy += this._ys[i]; }
+        var mx = sx / n, my = sy / n;
+        var sxy = 0, sxx = 0, syy = 0;
+        for (var i = 0; i < n; i++) {
+            var dx = this._xs[i] - mx, dy = this._ys[i] - my;
+            sxy += dx * dy;
+            sxx += dx * dx;
+            syy += dy * dy;
+        }
+        var denom = Math.sqrt(sxx * syy);
+        this._value = denom === 0 ? NaN : sxy / denom;
+        return this._value;
+    }
+    get value() { return this._value; }
+    get ready() { return this._xs.length >= this._period; }
+    reset() { this._xs = []; this._ys = []; this._value = NaN; }
+    static compute(x, y, period) { return __flox_indicator_correlation(x, y, period); }
 }

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -30,14 +30,21 @@
 #include "flox/indicator/bollinger.h"
 #include "flox/indicator/cci.h"
 #include "flox/indicator/chop.h"
+#include "flox/indicator/correlation.h"
 #include "flox/indicator/cvd.h"
 #include "flox/indicator/dema.h"
 #include "flox/indicator/ema.h"
 #include "flox/indicator/kama.h"
+#include "flox/indicator/kurtosis.h"
 #include "flox/indicator/macd.h"
 #include "flox/indicator/obv.h"
+#include "flox/indicator/parkinson_vol.h"
 #include "flox/indicator/rma.h"
+#include "flox/indicator/rogers_satchell_vol.h"
+#include "flox/indicator/rolling_zscore.h"
 #include "flox/indicator/rsi.h"
+#include "flox/indicator/shannon_entropy.h"
+#include "flox/indicator/skewness.h"
 #include "flox/indicator/slope.h"
 #include "flox/indicator/sma.h"
 #include "flox/indicator/stochastic.h"
@@ -518,6 +525,57 @@ void flox_indicator_cvd(const double* open, const double* high, const double* lo
       std::span<const double>(low, len), std::span<const double>(close, len),
       std::span<const double>(volume, len));
   std::copy(result.begin(), result.end(), output);
+}
+
+void flox_indicator_skewness(const double* input, size_t len, size_t period, double* output)
+{
+  indicator::Skewness ind(period);
+  ind.compute(std::span<const double>(input, len), std::span<double>(output, len));
+}
+
+void flox_indicator_kurtosis(const double* input, size_t len, size_t period, double* output)
+{
+  indicator::Kurtosis ind(period);
+  ind.compute(std::span<const double>(input, len), std::span<double>(output, len));
+}
+
+void flox_indicator_parkinson_vol(const double* high, const double* low, size_t len, size_t period,
+                                  double* output)
+{
+  indicator::ParkinsonVol ind(period);
+  ind.compute(std::span<const double>(high, len), std::span<const double>(low, len),
+              std::span<double>(output, len));
+}
+
+void flox_indicator_rogers_satchell_vol(const double* open, const double* high, const double* low,
+                                        const double* close, size_t len, size_t period,
+                                        double* output)
+{
+  indicator::RogersSatchellVol ind(period);
+  ind.compute(std::span<const double>(open, len), std::span<const double>(high, len),
+              std::span<const double>(low, len), std::span<const double>(close, len),
+              std::span<double>(output, len));
+}
+
+void flox_indicator_rolling_zscore(const double* input, size_t len, size_t period, double* output)
+{
+  indicator::RollingZScore ind(period);
+  ind.compute(std::span<const double>(input, len), std::span<double>(output, len));
+}
+
+void flox_indicator_shannon_entropy(const double* input, size_t len, size_t period, size_t bins,
+                                    double* output)
+{
+  indicator::ShannonEntropy ind(period, bins);
+  ind.compute(std::span<const double>(input, len), std::span<double>(output, len));
+}
+
+void flox_indicator_correlation(const double* x, const double* y, size_t len, size_t period,
+                                double* output)
+{
+  indicator::Correlation ind(period);
+  ind.compute(std::span<const double>(x, len), std::span<const double>(y, len),
+              std::span<double>(output, len));
 }
 
 // ============================================================

--- a/src/quickjs/js_bindings.cpp
+++ b/src/quickjs/js_bindings.cpp
@@ -530,6 +530,80 @@ static JSValue js_indicator_cvd(JSContext* ctx, JSValueConst, int, JSValueConst*
   return jsArrayFromDoubles(ctx, output);
 }
 
+static JSValue js_indicator_skewness(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto data = jsArrayToDoubles(ctx, argv[0]);
+  uint32_t period = toUint32(ctx, argv[1]);
+  std::vector<double> output(data.size());
+  flox_indicator_skewness(data.data(), data.size(), period, output.data());
+  return jsArrayFromDoubles(ctx, output);
+}
+
+static JSValue js_indicator_kurtosis(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto data = jsArrayToDoubles(ctx, argv[0]);
+  uint32_t period = toUint32(ctx, argv[1]);
+  std::vector<double> output(data.size());
+  flox_indicator_kurtosis(data.data(), data.size(), period, output.data());
+  return jsArrayFromDoubles(ctx, output);
+}
+
+static JSValue js_indicator_rolling_zscore(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto data = jsArrayToDoubles(ctx, argv[0]);
+  uint32_t period = toUint32(ctx, argv[1]);
+  std::vector<double> output(data.size());
+  flox_indicator_rolling_zscore(data.data(), data.size(), period, output.data());
+  return jsArrayFromDoubles(ctx, output);
+}
+
+static JSValue js_indicator_shannon_entropy(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto data = jsArrayToDoubles(ctx, argv[0]);
+  uint32_t period = toUint32(ctx, argv[1]);
+  uint32_t bins = toUint32(ctx, argv[2]);
+  std::vector<double> output(data.size());
+  flox_indicator_shannon_entropy(data.data(), data.size(), period, bins, output.data());
+  return jsArrayFromDoubles(ctx, output);
+}
+
+static JSValue js_indicator_parkinson_vol(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto high = jsArrayToDoubles(ctx, argv[0]);
+  auto low = jsArrayToDoubles(ctx, argv[1]);
+  uint32_t period = toUint32(ctx, argv[2]);
+  size_t len = high.size();
+  std::vector<double> output(len);
+  flox_indicator_parkinson_vol(high.data(), low.data(), len, period, output.data());
+  return jsArrayFromDoubles(ctx, output);
+}
+
+static JSValue js_indicator_rogers_satchell_vol(JSContext* ctx, JSValueConst, int,
+                                                JSValueConst* argv)
+{
+  auto open = jsArrayToDoubles(ctx, argv[0]);
+  auto high = jsArrayToDoubles(ctx, argv[1]);
+  auto low = jsArrayToDoubles(ctx, argv[2]);
+  auto close = jsArrayToDoubles(ctx, argv[3]);
+  uint32_t period = toUint32(ctx, argv[4]);
+  size_t len = open.size();
+  std::vector<double> output(len);
+  flox_indicator_rogers_satchell_vol(open.data(), high.data(), low.data(), close.data(), len,
+                                     period, output.data());
+  return jsArrayFromDoubles(ctx, output);
+}
+
+static JSValue js_indicator_correlation(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto x = jsArrayToDoubles(ctx, argv[0]);
+  auto y = jsArrayToDoubles(ctx, argv[1]);
+  uint32_t period = toUint32(ctx, argv[2]);
+  size_t len = x.size();
+  std::vector<double> output(len);
+  flox_indicator_correlation(x.data(), y.data(), len, period, output.data());
+  return jsArrayFromDoubles(ctx, output);
+}
+
 // ============================================================
 // Order book bindings
 // ============================================================
@@ -2014,6 +2088,13 @@ void registerFloxBindings(JSContext* ctx)
   addGlobalFunc(ctx, "__flox_indicator_obv", js_indicator_obv, 2);
   addGlobalFunc(ctx, "__flox_indicator_vwap", js_indicator_vwap, 3);
   addGlobalFunc(ctx, "__flox_indicator_cvd", js_indicator_cvd, 5);
+  addGlobalFunc(ctx, "__flox_indicator_skewness", js_indicator_skewness, 2);
+  addGlobalFunc(ctx, "__flox_indicator_kurtosis", js_indicator_kurtosis, 2);
+  addGlobalFunc(ctx, "__flox_indicator_rolling_zscore", js_indicator_rolling_zscore, 2);
+  addGlobalFunc(ctx, "__flox_indicator_shannon_entropy", js_indicator_shannon_entropy, 3);
+  addGlobalFunc(ctx, "__flox_indicator_parkinson_vol", js_indicator_parkinson_vol, 3);
+  addGlobalFunc(ctx, "__flox_indicator_rogers_satchell_vol", js_indicator_rogers_satchell_vol, 5);
+  addGlobalFunc(ctx, "__flox_indicator_correlation", js_indicator_correlation, 3);
 
   // Order book
   addGlobalFunc(ctx, "__flox_book_create", js_book_create, 1);

--- a/tests/test_indicators.cpp
+++ b/tests/test_indicators.cpp
@@ -4,15 +4,22 @@
 #include "flox/indicator/bollinger.h"
 #include "flox/indicator/cci.h"
 #include "flox/indicator/chop.h"
+#include "flox/indicator/correlation.h"
 #include "flox/indicator/cvd.h"
 #include "flox/indicator/dema.h"
 #include "flox/indicator/ema.h"
 #include "flox/indicator/indicator_pipeline.h"
 #include "flox/indicator/kama.h"
+#include "flox/indicator/kurtosis.h"
 #include "flox/indicator/macd.h"
 #include "flox/indicator/obv.h"
+#include "flox/indicator/parkinson_vol.h"
 #include "flox/indicator/rma.h"
+#include "flox/indicator/rogers_satchell_vol.h"
+#include "flox/indicator/rolling_zscore.h"
 #include "flox/indicator/rsi.h"
+#include "flox/indicator/shannon_entropy.h"
+#include "flox/indicator/skewness.h"
 #include "flox/indicator/slope.h"
 #include "flox/indicator/sma.h"
 #include "flox/indicator/stochastic.h"
@@ -740,4 +747,431 @@ TEST(IndicatorGraph, CacheInvalidation)
   g.setBars(0, bars);
   auto& r2 = g.require(0, "ema3");
   EXPECT_NE(r2[9], first);
+}
+
+// Skewness
+
+TEST(Skewness, BasicComputation)
+{
+  Skewness skew(5);
+  std::vector<double> input = {1, 2, 3, 4, 10};
+  auto result = skew.compute(input);
+  ASSERT_EQ(result.size(), 5u);
+  for (int i = 0; i < 4; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_FALSE(std::isnan(result[4]));
+  EXPECT_GT(result[4], 0.0);
+}
+
+TEST(Skewness, SymmetricDistribution)
+{
+  Skewness skew(5);
+  std::vector<double> input = {1, 2, 3, 4, 5};
+  auto result = skew.compute(input);
+  EXPECT_NEAR(result[4], 0.0, 1e-10);
+}
+
+TEST(Skewness, ZeroStd)
+{
+  Skewness skew(3);
+  std::vector<double> input = {5, 5, 5};
+  auto result = skew.compute(input);
+  EXPECT_TRUE(std::isnan(result[2]));
+}
+
+TEST(Skewness, EmptyInput)
+{
+  Skewness skew(3);
+  auto result = skew.compute(std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(Skewness, WriteToBuffer)
+{
+  Skewness skew(5);
+  auto p = prices();
+  std::vector<double> buf(p.size());
+  skew.compute(p, buf);
+  auto alloced = skew.compute(p);
+  for (size_t i = 0; i < p.size(); ++i)
+  {
+    if (std::isnan(alloced[i]))
+    {
+      EXPECT_TRUE(std::isnan(buf[i]));
+    }
+    else
+    {
+      EXPECT_DOUBLE_EQ(buf[i], alloced[i]);
+    }
+  }
+}
+
+// Kurtosis
+
+TEST(Kurtosis, BasicComputation)
+{
+  Kurtosis kurt(5);
+  std::vector<double> input = {1, 2, 3, 4, 100};
+  auto result = kurt.compute(input);
+  ASSERT_EQ(result.size(), 5u);
+  for (int i = 0; i < 4; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_FALSE(std::isnan(result[4]));
+  EXPECT_GT(result[4], 0.0);
+}
+
+TEST(Kurtosis, ZeroStd)
+{
+  Kurtosis kurt(4);
+  std::vector<double> input = {5, 5, 5, 5};
+  auto result = kurt.compute(input);
+  EXPECT_TRUE(std::isnan(result[3]));
+}
+
+TEST(Kurtosis, EmptyInput)
+{
+  Kurtosis kurt(4);
+  auto result = kurt.compute(std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(Kurtosis, WriteToBuffer)
+{
+  Kurtosis kurt(5);
+  auto p = prices();
+  std::vector<double> buf(p.size());
+  kurt.compute(p, buf);
+  auto alloced = kurt.compute(p);
+  for (size_t i = 0; i < p.size(); ++i)
+  {
+    if (std::isnan(alloced[i]))
+    {
+      EXPECT_TRUE(std::isnan(buf[i]));
+    }
+    else
+    {
+      EXPECT_DOUBLE_EQ(buf[i], alloced[i]);
+    }
+  }
+}
+
+// RollingZScore
+
+TEST(RollingZScore, BasicComputation)
+{
+  RollingZScore zscore(5);
+  std::vector<double> input = {10, 10, 10, 10, 10};
+  auto result = zscore.compute(input);
+  for (int i = 0; i < 4; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_TRUE(std::isnan(result[4]));
+}
+
+TEST(RollingZScore, MeanIsZero)
+{
+  RollingZScore zscore(3);
+  std::vector<double> input = {1, 2, 3, 2, 1};
+  auto result = zscore.compute(input);
+  EXPECT_FALSE(std::isnan(result[2]));
+}
+
+TEST(RollingZScore, EmptyInput)
+{
+  RollingZScore zscore(3);
+  auto result = zscore.compute(std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(RollingZScore, WriteToBuffer)
+{
+  RollingZScore zscore(5);
+  auto p = prices();
+  std::vector<double> buf(p.size());
+  zscore.compute(p, buf);
+  auto alloced = zscore.compute(p);
+  for (size_t i = 0; i < p.size(); ++i)
+  {
+    if (std::isnan(alloced[i]))
+    {
+      EXPECT_TRUE(std::isnan(buf[i]));
+    }
+    else
+    {
+      EXPECT_DOUBLE_EQ(buf[i], alloced[i]);
+    }
+  }
+}
+
+// ShannonEntropy
+
+TEST(ShannonEntropy, ZeroEntropy)
+{
+  ShannonEntropy ent(5, 10);
+  std::vector<double> input = {5, 5, 5, 5, 5};
+  auto result = ent.compute(input);
+  EXPECT_DOUBLE_EQ(result[4], 0.0);
+}
+
+TEST(ShannonEntropy, MaxEntropy)
+{
+  ShannonEntropy ent(10, 10);
+  std::vector<double> input = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  auto result = ent.compute(input);
+  EXPECT_GT(result[9], 0.8);
+  EXPECT_LE(result[9], 1.0);
+}
+
+TEST(ShannonEntropy, EmptyInput)
+{
+  ShannonEntropy ent(5);
+  auto result = ent.compute(std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(ShannonEntropy, WarmupPeriod)
+{
+  ShannonEntropy ent(5, 10);
+  auto result = ent.compute(prices());
+  for (int i = 0; i < 4; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_FALSE(std::isnan(result[4]));
+}
+
+// ParkinsonVol
+
+TEST(ParkinsonVol, BasicComputation)
+{
+  std::vector<double> h = {48.70, 48.72, 48.90, 48.87, 48.82, 49.05, 49.20, 49.35, 49.92, 50.19};
+  std::vector<double> l = {47.79, 48.14, 48.39, 48.37, 48.24, 48.64, 48.94, 48.86, 49.50, 49.87};
+
+  ParkinsonVol pv(5);
+  auto result = pv.compute(h, l);
+  ASSERT_EQ(result.size(), 10u);
+  for (int i = 0; i < 4; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_FALSE(std::isnan(result[4]));
+  EXPECT_GT(result[4], 0.0);
+}
+
+TEST(ParkinsonVol, EqualHighLow)
+{
+  std::vector<double> h = {10, 10, 10, 10, 10};
+  std::vector<double> l = {10, 10, 10, 10, 10};
+  ParkinsonVol pv(5);
+  auto result = pv.compute(h, l);
+  EXPECT_DOUBLE_EQ(result[4], 0.0);
+}
+
+TEST(ParkinsonVol, EmptyInput)
+{
+  ParkinsonVol pv(5);
+  auto result = pv.compute(std::span<const double>{}, std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(ParkinsonVol, BarOverload)
+{
+  std::vector<Bar> bars(10);
+  for (size_t i = 0; i < 10; ++i)
+  {
+    bars[i].high = Price::fromDouble(101.0 + i);
+    bars[i].low = Price::fromDouble(99.0 + i);
+  }
+  ParkinsonVol pv(5);
+  auto fromBars = pv.compute(std::span<const Bar>(bars));
+
+  std::vector<double> h(10), l(10);
+  for (size_t i = 0; i < 10; ++i)
+  {
+    h[i] = bars[i].high.toDouble();
+    l[i] = bars[i].low.toDouble();
+  }
+  auto fromSpans = pv.compute(h, l);
+
+  for (size_t i = 0; i < 10; ++i)
+  {
+    if (std::isnan(fromBars[i]))
+    {
+      EXPECT_TRUE(std::isnan(fromSpans[i]));
+    }
+    else
+    {
+      EXPECT_NEAR(fromBars[i], fromSpans[i], 1e-10);
+    }
+  }
+}
+
+// RogersSatchellVol
+
+TEST(RogersSatchellVol, BasicComputation)
+{
+  std::vector<double> o = {100, 101, 102, 103, 104};
+  std::vector<double> h = {102, 103, 104, 105, 106};
+  std::vector<double> l = {98, 99, 100, 101, 102};
+  std::vector<double> c = {101, 102, 103, 104, 105};
+
+  RogersSatchellVol rsv(3);
+  auto result = rsv.compute(o, h, l, c);
+  ASSERT_EQ(result.size(), 5u);
+  for (int i = 0; i < 2; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_FALSE(std::isnan(result[2]));
+  EXPECT_GT(result[2], 0.0);
+}
+
+TEST(RogersSatchellVol, FlatBars)
+{
+  std::vector<double> v = {100, 100, 100, 100, 100};
+  RogersSatchellVol rsv(3);
+  auto result = rsv.compute(v, v, v, v);
+  EXPECT_DOUBLE_EQ(result[2], 0.0);
+}
+
+TEST(RogersSatchellVol, EmptyInput)
+{
+  RogersSatchellVol rsv(3);
+  auto result = rsv.compute(std::span<const double>{}, std::span<const double>{},
+                            std::span<const double>{}, std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(RogersSatchellVol, BarOverload)
+{
+  std::vector<Bar> bars(10);
+  for (size_t i = 0; i < 10; ++i)
+  {
+    bars[i].open = Price::fromDouble(100.0 + i);
+    bars[i].high = Price::fromDouble(102.0 + i);
+    bars[i].low = Price::fromDouble(98.0 + i);
+    bars[i].close = Price::fromDouble(101.0 + i);
+  }
+  RogersSatchellVol rsv(5);
+  auto fromBars = rsv.compute(std::span<const Bar>(bars));
+
+  std::vector<double> o(10), h(10), l(10), c(10);
+  for (size_t i = 0; i < 10; ++i)
+  {
+    o[i] = bars[i].open.toDouble();
+    h[i] = bars[i].high.toDouble();
+    l[i] = bars[i].low.toDouble();
+    c[i] = bars[i].close.toDouble();
+  }
+  auto fromSpans = rsv.compute(o, h, l, c);
+
+  for (size_t i = 0; i < 10; ++i)
+  {
+    if (std::isnan(fromBars[i]))
+    {
+      EXPECT_TRUE(std::isnan(fromSpans[i]));
+    }
+    else
+    {
+      EXPECT_NEAR(fromBars[i], fromSpans[i], 1e-10);
+    }
+  }
+}
+
+// Correlation
+
+TEST(Correlation, PerfectPositive)
+{
+  Correlation corr(5);
+  std::vector<double> x = {1, 2, 3, 4, 5};
+  std::vector<double> y = {2, 4, 6, 8, 10};
+  auto result = corr.compute(x, y);
+  EXPECT_NEAR(result[4], 1.0, 1e-10);
+}
+
+TEST(Correlation, PerfectNegative)
+{
+  Correlation corr(5);
+  std::vector<double> x = {1, 2, 3, 4, 5};
+  std::vector<double> y = {10, 8, 6, 4, 2};
+  auto result = corr.compute(x, y);
+  EXPECT_NEAR(result[4], -1.0, 1e-10);
+}
+
+TEST(Correlation, ConstantSeries)
+{
+  Correlation corr(5);
+  std::vector<double> x = {1, 2, 3, 4, 5};
+  std::vector<double> y = {5, 5, 5, 5, 5};
+  auto result = corr.compute(x, y);
+  EXPECT_TRUE(std::isnan(result[4]));
+}
+
+TEST(Correlation, WarmupPeriod)
+{
+  Correlation corr(5);
+  auto p = prices();
+  std::vector<double> p2(p.rbegin(), p.rend());
+  auto result = corr.compute(p, p2);
+  for (int i = 0; i < 4; ++i)
+  {
+    EXPECT_TRUE(std::isnan(result[i]));
+  }
+  EXPECT_FALSE(std::isnan(result[4]));
+}
+
+TEST(Correlation, EmptyInput)
+{
+  Correlation corr(3);
+  auto result = corr.compute(std::span<const double>{}, std::span<const double>{});
+  EXPECT_TRUE(result.empty());
+}
+
+// Contract tests: warmup NaN for all single-input indicators
+
+TEST(Contract, WarmupAllSingleIndicators)
+{
+  auto p = prices();
+  auto check = [&](const std::string& name, const std::vector<double>& result, size_t warmup)
+  {
+    for (size_t i = 0; i < warmup && i < result.size(); ++i)
+    {
+      EXPECT_TRUE(std::isnan(result[i])) << name << " should be NaN at index " << i;
+    }
+    if (result.size() > warmup)
+    {
+      EXPECT_FALSE(std::isnan(result[warmup])) << name << " should be valid at index " << warmup;
+    }
+  };
+
+  check("SMA(5)", SMA(5).compute(p), 4);
+  check("EMA(5)", EMA(5).compute(p), 4);
+  check("RMA(5)", RMA(5).compute(p), 4);
+  check("RSI(5)", RSI(5).compute(p), 5);
+  check("Slope(3)", Slope(3).compute(p), 3);
+  check("KAMA(5)", KAMA(5).compute(p), 5);
+  check("Skewness(5)", Skewness(5).compute(p), 4);
+  check("Kurtosis(5)", Kurtosis(5).compute(p), 4);
+  check("RollingZScore(5)", RollingZScore(5).compute(p), 4);
+  check("ShannonEntropy(5)", ShannonEntropy(5).compute(p), 4);
+}
+
+TEST(Contract, EmptyAllSingleIndicators)
+{
+  std::span<const double> empty{};
+  EXPECT_TRUE(SMA(5).compute(empty).empty());
+  EXPECT_TRUE(EMA(5).compute(empty).empty());
+  EXPECT_TRUE(RMA(5).compute(empty).empty());
+  EXPECT_TRUE(RSI(5).compute(empty).empty());
+  EXPECT_TRUE(Slope(3).compute(empty).empty());
+  EXPECT_TRUE(KAMA(5).compute(empty).empty());
+  EXPECT_TRUE(Skewness(5).compute(empty).empty());
+  EXPECT_TRUE(Kurtosis(5).compute(empty).empty());
+  EXPECT_TRUE(RollingZScore(5).compute(empty).empty());
+  EXPECT_TRUE(ShannonEntropy(5).compute(empty).empty());
 }


### PR DESCRIPTION
New indicators: Skewness, Kurtosis, RollingZScore, ShannonEntropy, ParkinsonVol, RogersSatchellVol, Correlation.

Streaming API: reset() and fresh() on all Python streaming classes; reset() on Node.js, QuickJS, Codon. Python update() and .value now return None during warmup instead of NaN-derived values.

Docs: landing page rewrite, Python/Node.js quickstart pages, indicators explanation page, reference pages reformatted.