### PR TITLE
fix(python): handle non-contiguous arrays in raw→double converters

### DIFF
--- a/python/replay_bindings.h
+++ b/python/replay_bindings.h
@@ -419,17 +419,25 @@ inline void bindReplay(py::module_& m)
   m.attr("QUANTITY_SCALE") = py::int_(flox::Quantity::Scale);
   m.attr("VOLUME_SCALE") = py::int_(flox::Volume::Scale);
 
-  // Vectorized raw → double converters. Operate on numpy int64 arrays of any shape.
-  auto rawToDouble = [](py::array_t<int64_t> raw, int64_t scale) -> py::array_t<double>
+  // Vectorized raw → double converters. Operate on numpy int64 arrays of any
+  // shape, including non-contiguous views (e.g. `bars["close_raw"]` taken from
+  // a structured array). Output is always a fresh contiguous array of the same
+  // shape as the input.
+  auto rawToDouble = [](py::array raw, int64_t scale) -> py::array_t<double>
   {
-    auto buf = raw.request();
-    py::array_t<double> out(buf.shape, buf.strides);
-    auto out_buf = out.request();
-    const int64_t* in_ptr = static_cast<const int64_t*>(buf.ptr);
-    double* out_ptr = static_cast<double*>(out_buf.ptr);
+    // Force int64 dtype + contiguous layout. If the caller passed a strided
+    // view (e.g. a structured-array field), this materialises a contiguous
+    // copy; if it was already contiguous int64, no copy.
+    py::array_t<int64_t, py::array::c_style | py::array::forcecast> in(raw);
+    const int64_t* in_ptr = in.data();
+
+    std::vector<py::ssize_t> shape(in.shape(), in.shape() + in.ndim());
+    py::array_t<double> out(shape);
+    double* out_ptr = out.mutable_data();
+
     const double inv_scale = 1.0 / static_cast<double>(scale);
-    const size_t n = static_cast<size_t>(buf.size);
-    for (size_t i = 0; i < n; ++i)
+    const py::ssize_t n = in.size();
+    for (py::ssize_t i = 0; i < n; ++i)
     {
       out_ptr[i] = static_cast<double>(in_ptr[i]) * inv_scale;
     }

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -45,6 +45,59 @@ check(flox.QUEUE_NONE == 0, "QUEUE_NONE == 0")
 check(flox.QUEUE_TOB == 1, "QUEUE_TOB == 1")
 check(flox.QUEUE_FULL == 2, "QUEUE_FULL == 2")
 
+check(flox.PRICE_SCALE == 100_000_000, "PRICE_SCALE == 1e8")
+check(flox.QUANTITY_SCALE == 100_000_000, "QUANTITY_SCALE == 1e8")
+check(flox.VOLUME_SCALE == 100_000_000, "VOLUME_SCALE == 1e8")
+
+# ── Raw-to-double converters ─────────────────────────────────────────
+
+print("=== Raw-to-double converters ===")
+
+# Contiguous int64 input
+contig = np.array([100_00000000, 200_00000000, 300_00000000], dtype=np.int64)
+out = flox.prices_to_double(contig)
+check(np.allclose(out, [100.0, 200.0, 300.0]), "prices_to_double on contiguous 1D")
+check(out.dtype == np.float64, "prices_to_double returns float64")
+
+# Non-contiguous slice (every-other element)
+strided_src = np.array([1, 999, 2, 999, 3, 999], dtype=np.int64) * 100_000_000
+strided = strided_src[::2]
+check(not strided.flags["C_CONTIGUOUS"], "test setup: strided view is non-contiguous")
+out = flox.prices_to_double(strided)
+check(np.allclose(out, [1.0, 2.0, 3.0]),
+      "prices_to_double on non-contiguous strided view (every-other element)")
+
+# Field of a structured array — the canonical buggy case
+bar_dtype = np.dtype([
+    ("start_time_ns", "<i8"),
+    ("end_time_ns", "<i8"),
+    ("open_raw", "<i8"),
+    ("high_raw", "<i8"),
+    ("low_raw", "<i8"),
+    ("close_raw", "<i8"),
+    ("volume_raw", "<i8"),
+    ("buy_volume_raw", "<i8"),
+    ("trade_count", "<i8"),
+])
+bars = np.zeros(5, dtype=bar_dtype)
+bars["close_raw"] = np.array([100_00000000, 101_00000000, 102_00000000,
+                              103_00000000, 104_00000000], dtype=np.int64)
+# Set other fields to garbage to ensure we don't accidentally read them
+bars["open_raw"] = 999_00000000
+bars["volume_raw"] = 7777_00000000
+out = flox.prices_to_double(bars["close_raw"])
+check(np.allclose(out, [100.0, 101.0, 102.0, 103.0, 104.0]),
+      "prices_to_double on structured-array field view (close_raw)")
+
+out_v = flox.volumes_to_double(bars["volume_raw"])
+check(np.allclose(out_v, [7777.0] * 5), "volumes_to_double on structured-array field view")
+
+# 2D input — shape preserved
+two_d = np.arange(6, dtype=np.int64).reshape(2, 3) * 100_000_000
+out2 = flox.quantities_to_double(two_d)
+check(out2.shape == (2, 3), "quantities_to_double preserves 2D shape")
+check(np.allclose(out2, [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]), "quantities_to_double 2D values")
+
 # ── Streaming indicators ──────────────────────────────────────────────
 
 print("=== Streaming indicators ===")


### PR DESCRIPTION
Fixes #112.

## Problem

`prices_to_double`, `quantities_to_double` and `volumes_to_double` (added in #027ce9a) iterate the input pointer linearly:

```cpp
const int64_t* in_ptr = static_cast<const int64_t*>(buf.ptr);
for (size_t i = 0; i < n; ++i)
    out_ptr[i] = static_cast<double>(in_ptr[i]) * inv_scale;
```

When the input is a non-contiguous view — most importantly, a field of a structured array such as `bars["close_raw"]`, where consecutive int64s are 72 bytes apart instead of 8 — `in_ptr[i]` reads at the wrong offsets. On a real BTCUSDT tick-bar array this yields:

- ~66% zeros (memory between fields / padding)
- 423 anomalous values up to ~1.7×10^10 (reads landing on `volume_raw`, `start_time_ns`, etc.)

A second bug compounds it: `py::array_t<double> out(buf.shape, buf.strides)` reuses the input's strides for the output, so even a correctly-read contiguous input can produce a mis-laid-out result.

## Fix

Force the input to int64 + C-contiguous via `py::array::c_style | py::array::forcecast` (no copy when already laid out that way). Allocate a fresh contiguous output of the same shape. Iterate by index over a contiguous buffer.

```cpp
auto rawToDouble = [](py::array raw, int64_t scale) -> py::array_t<double>
{
  py::array_t<int64_t, py::array::c_style | py::array::forcecast> in(raw);
  const int64_t* in_ptr = in.data();

  std::vector<py::ssize_t> shape(in.shape(), in.shape() + in.ndim());
  py::array_t<double> out(shape);
  double* out_ptr = out.mutable_data();

  const double inv_scale = 1.0 / static_cast<double>(scale);
  const py::ssize_t n = in.size();
  for (py::ssize_t i = 0; i < n; ++i)
    out_ptr[i] = static_cast<double>(in_ptr[i]) * inv_scale;
  return out;
};
```

## Tests

`python/tests/test_bindings.py` gets a new section covering:

- Contiguous 1D input (regression check)
- Every-other-element strided view
- Structured-array field views — `bars["close_raw"]`, `bars["volume_raw"]` — the canonical failure mode
- 2D shape preservation

All 58 binding tests pass on macOS arm64 + Python 3.12.

## Impact

Any client code using the helpers on a structured-array field (the documented use case for raw→float conversion of `DataReader.read_trades()` output and `aggregate_*` output) was getting silently wrong numbers. Worth a patch release.