### PR TITLE
ci: dedicated Release workflow + fix publish job skip on tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
 
     - name: Install Codon
       run: |
-        curl -fsSL https://exaloop.io/install.sh | bash
+        mkdir -p ~/.codon && cd ~/.codon
+        curl -fsSL https://github.com/exaloop/codon/releases/latest/download/codon-linux-x86_64.tar.gz \
+          | tar zxf - --strip-components=1
         echo "$HOME/.codon/bin" >> $GITHUB_PATH
 
     - name: Build and Install GoogleTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,11 @@ jobs:
       run: python3 -m pip install --break-system-packages pybind11 numpy
 
     - name: Install Codon
+      env:
+        CODON_VERSION: v0.19.6
       run: |
         mkdir -p ~/.codon && cd ~/.codon
-        curl -fsSL https://github.com/exaloop/codon/releases/latest/download/codon-linux-x86_64.tar.gz \
+        curl -fsSL "https://github.com/exaloop/codon/releases/download/${CODON_VERSION}/codon-linux-x86_64.tar.gz" \
           | tar zxf - --strip-components=1
         echo "$HOME/.codon/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -5,10 +5,6 @@ on:
     tags: ["v*"]
   workflow_dispatch:
     inputs:
-      version:
-        description: "Package version (e.g. 0.2.0)"
-        type: string
-        required: true
       publish_npm:
         description: "Publish to npm"
         type: boolean
@@ -51,18 +47,6 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Set version
-        shell: bash
-        run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
-          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            exit 0
-          fi
-          ./scripts/set-version.sh "${VERSION}"
-
       - name: Install dependencies
         working-directory: node
         run: npm install
@@ -95,7 +79,10 @@ jobs:
   publish:
     needs: [build]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish_npm == 'true'
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish_npm == 'true')
     steps:
       - uses: actions/checkout@v4
 
@@ -103,17 +90,6 @@ jobs:
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Set version
-        run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
-          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            exit 0
-          fi
-          ./scripts/set-version.sh "${VERSION}"
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -5,10 +5,6 @@ on:
     tags: ["v*"]
   workflow_dispatch:
     inputs:
-      version:
-        description: "Package version (e.g. 0.2.0)"
-        type: string
-        required: true
       publish_pypi:
         description: "Publish to PyPI (prod)"
         type: boolean
@@ -35,22 +31,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Set version
-        shell: bash
-        run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
-          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            exit 0
-          fi
-          ./scripts/set-version.sh "${VERSION}"
 
       - uses: actions/setup-python@v5
         with:
@@ -82,19 +62,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-      - name: Set version
-        run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
-          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            exit 0
-          fi
-          ./scripts/set-version.sh "${VERSION}"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -108,6 +75,10 @@ jobs:
   publish-testpypi:
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
+    if: |
+      always() &&
+      needs.build-wheels.result == 'success' &&
+      needs.build-sdist.result == 'success'
     permissions:
       id-token: write
     steps:
@@ -123,7 +94,11 @@ jobs:
   publish-pypi:
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish_pypi == 'true'
+    if: |
+      always() &&
+      needs.build-wheels.result == 'success' &&
+      needs.build-sdist.result == 'success' &&
+      (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish_pypi == 'true')
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.5.6)"
+        type: string
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Restrict manual trigger
+        if: github.actor != 'eeiaao'
+        run: |
+          echo "::error::Only eeiaao can trigger this workflow."
+          exit 1
+
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::version '${{ inputs.version }}' does not look like SemVer"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Bump version in source
+        run: ./scripts/set-version.sh "${{ inputs.version }}"
+
+      - name: Commit, tag, and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add CMakeLists.txt python/pyproject.toml node/package.json
+          if git diff --cached --quiet; then
+            echo "::warning::No version changes to commit (already at ${{ inputs.version }}?)"
+          else
+            git commit -m "release: v${{ inputs.version }}"
+            git push origin main
+          fi
+
+          if git rev-parse "v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::tag v${{ inputs.version }} already exists"
+            exit 1
+          fi
+          git tag "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"


### PR DESCRIPTION
## Problems

**1. Source version stays stale across releases.** The build/publish workflows ran `scripts/set-version.sh` inline on every checkout, which produced correct artefacts but never wrote the bump back. Tag `v0.5.5` points at a commit whose `CMakeLists.txt`, `python/pyproject.toml` and `node/package.json` all read `0.5.3`. Anyone doing `git checkout v0.5.5 && pip install -e python/` gets the wrong version.

**2. On `v0.5.5` tag push, every publish job was SKIPPED.** The `check-actor` job is gated to `workflow_dispatch` only, so on tag push it's skipped. `build-wheels` / `build-sdist` / `build` (node) override that with `if: always() && (needs.check-actor.result == 'success' || skipped)`. The publish jobs only had `if: startsWith(github.ref, 'refs/tags/v')` — without `always()` — so the transitive-skip from `check-actor` cascades through `needs: [build-wheels, build-sdist]` and skips the publish jobs regardless of the `if`. PyPI and npm only got `0.5.5` because subsequent manual `workflow_dispatch` runs were fired by hand.

GH Actions logs from the v0.5.5 tag push:
```
Build Python wheels (push, v0.5.5):
  ✓ build-wheels (3 OS)
  ✓ build-sdist
  ⏭ check-actor       (expected — workflow_dispatch only)
  ⏭ publish-testpypi  ← bug
  ⏭ publish-pypi      ← bug
```

## Fix

### New `release.yml`

`workflow_dispatch` with a `version` input, restricted to `eeiaao`. Steps:

1. Validate version against SemVer regex
2. Checkout `main`
3. Run `scripts/set-version.sh ${version}`
4. Commit `release: vX.Y.Z` on `main`, push
5. Create tag `vX.Y.Z` on the bump commit, push

After step 5, the existing `push: tags` workflows fire on a tag that points at a commit whose source already matches. GitHub Releases UI is used afterwards to attach notes to the existing tag — no longer creating the tag itself.

### `python-wheels.yml` / `node-publish.yml`

- Drop the in-flight `set-version.sh` step and the `version` `workflow_dispatch` input — source is now authoritative.
- Replace the broken `if: startsWith(github.ref, 'refs/tags/v') || ...` on publish jobs with the standard `always() && needs.*.result == 'success' && (...)` pattern so the transitive-skip from `check-actor` doesn't cascade.

## Release flow after this

- **New release:** Actions tab → `Release` → Run workflow → fill `version` → click. The bump commit + tag land on `main`, build & publish workflows fire on the tag, artefacts hit PyPI and npm.
- **Optional:** open GitHub Releases UI on the freshly-created tag to add release notes.
- **Manual republish (rare):** existing `python-wheels.yml` / `node-publish.yml` `workflow_dispatch` paths still work; `publish_pypi` / `publish_npm` toggles preserved.