### PR TITLE
feat(target): add forward-looking labels distinct from indicators

### DIFF
--- a/codon/CMakeLists.txt
+++ b/codon/CMakeLists.txt
@@ -38,3 +38,6 @@ add_codon_executable(codon_backtest_from_csv
 
 add_codon_executable(codon_full_backtest
   ${CMAKE_SOURCE_DIR}/docs/examples/codon_full_backtest.codon)
+
+add_codon_executable(codon_targets_smoke
+  ${CMAKE_CURRENT_SOURCE_DIR}/examples/targets_smoke.codon)

--- a/codon/examples/targets_smoke.codon
+++ b/codon/examples/targets_smoke.codon
@@ -1,0 +1,16 @@
+# Smoke test: targets module compiles + computes against the C API.
+
+from flox.targets import future_return, future_ctc_volatility, future_linear_slope
+
+close = [100.0, 101.0, 99.0, 105.0, 110.0]
+fr = future_return(close, 2)
+print("future_return[0] =", fr[0])
+print("future_return[2] =", fr[2])
+
+const_close = [100.0] * 20
+vol = future_ctc_volatility(const_close, 5)
+print("future_ctc_volatility const[0] =", vol[0])
+
+linear = [100.0 + 0.5 * float(i) for i in range(20)]
+sl = future_linear_slope(linear, 4)
+print("future_linear_slope linear[0] =", sl[0])

--- a/codon/flox/__init__.codon
+++ b/codon/flox/__init__.codon
@@ -5,6 +5,7 @@
 #   from flox.strategy import Strategy
 #   from flox.types import Price, Quantity
 #   from flox.indicators import ema, sma
+#   from flox.targets import future_return  # research-only labels
 
 from flox.types import *
 from flox.context import *

--- a/codon/flox/targets.codon
+++ b/codon/flox/targets.codon
@@ -1,0 +1,30 @@
+# flox/targets.codon -- Forward-looking labels (research-only).
+#
+# Targets are batch-only and live in their own module so look-ahead is
+# visible at the call site. Feeding them into a live update loop is a
+# look-ahead-bias bug.
+
+from C import flox_target_future_return(Ptr[f64], int, int, Ptr[f64])
+from C import flox_target_future_ctc_volatility(Ptr[f64], int, int, Ptr[f64])
+from C import flox_target_future_linear_slope(Ptr[f64], int, int, Ptr[f64])
+
+
+def future_return(close: List[float], horizon: int) -> List[float]:
+    n = len(close)
+    out = [0.0] * n
+    flox_target_future_return(close.arr.ptr, n, horizon, out.arr.ptr)
+    return out
+
+
+def future_ctc_volatility(close: List[float], horizon: int) -> List[float]:
+    n = len(close)
+    out = [0.0] * n
+    flox_target_future_ctc_volatility(close.arr.ptr, n, horizon, out.arr.ptr)
+    return out
+
+
+def future_linear_slope(close: List[float], horizon: int) -> List[float]:
+    n = len(close)
+    out = [0.0] * n
+    flox_target_future_linear_slope(close.arr.ptr, n, horizon, out.arr.ptr)
+    return out

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -238,6 +238,20 @@ extern "C"
                                   double* output);
 
   // ============================================================
+  // Targets (forward-looking labels, batch only)
+  //
+  // Targets read into the future relative to t. They are intentionally
+  // separate from indicators: feeding them into a live update loop is a
+  // look-ahead-bias bug.
+  // ============================================================
+
+  void flox_target_future_return(const double* close, size_t len, size_t horizon, double* output);
+  void flox_target_future_ctc_volatility(const double* close, size_t len, size_t horizon,
+                                         double* output);
+  void flox_target_future_linear_slope(const double* close, size_t len, size_t horizon,
+                                       double* output);
+
+  // ============================================================
   // Order book
   // ============================================================
 

--- a/include/flox/target/future_ctc_volatility.h
+++ b/include/flox/target/future_ctc_volatility.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+#include "flox/target/target.h"
+
+namespace flox::target
+{
+
+// FutureCTCVolatility(horizon): close-to-close realised volatility over
+// [t, t + horizon]. Computed as the sample standard deviation of the
+// `horizon` close-to-close log returns r_i = ln(close[t+i+1] / close[t+i])
+// for i in [0, horizon). Uses the `(n-1)` denominator (sample stddev).
+//
+// horizon must be >= 2 (need at least two log-returns for sample stddev).
+//
+// Tail (n - horizon, ..., n - 1) is NaN.
+class FutureCTCVolatility
+{
+ public:
+  static constexpr bool is_target = true;
+
+  explicit FutureCTCVolatility(size_t horizon) noexcept : _horizon(horizon)
+  {
+    assert(horizon >= 2);
+  }
+
+  std::vector<double> compute(std::span<const double> close) const
+  {
+    std::vector<double> out(close.size(), std::nan(""));
+    if (!close.empty())
+    {
+      compute(close, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> close, std::span<double> output) const
+  {
+    const size_t n = close.size();
+    assert(output.size() >= n);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n <= _horizon)
+    {
+      return;
+    }
+
+    const double denom = static_cast<double>(_horizon - 1);
+
+    for (size_t t = 0; t + _horizon < n; ++t)
+    {
+      double sum = 0.0;
+      double sumSq = 0.0;
+      bool valid = true;
+
+      for (size_t i = 0; i < _horizon; ++i)
+      {
+        double a = close[t + i];
+        double b = close[t + i + 1];
+        if (std::isnan(a) || std::isnan(b) || a <= 0.0 || b <= 0.0)
+        {
+          valid = false;
+          break;
+        }
+        double r = std::log(b / a);
+        sum += r;
+        sumSq += r * r;
+      }
+
+      if (!valid)
+      {
+        continue;
+      }
+
+      double mean = sum / static_cast<double>(_horizon);
+      double var = (sumSq - static_cast<double>(_horizon) * mean * mean) / denom;
+      if (var < 0.0)
+      {
+        var = 0.0;
+      }
+      output[t] = std::sqrt(var);
+    }
+  }
+
+  size_t horizon() const noexcept { return _horizon; }
+
+ private:
+  size_t _horizon;
+};
+
+static_assert(BatchTarget<FutureCTCVolatility>);
+
+}  // namespace flox::target

--- a/include/flox/target/future_linear_slope.h
+++ b/include/flox/target/future_linear_slope.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+#include "flox/target/target.h"
+
+namespace flox::target
+{
+
+// FutureLinearSlope(horizon): OLS slope of close over the points
+// (i, close[t + i]) for i in [0, horizon]. Uses (horizon + 1) points.
+// Returns NaN where the future window is unavailable.
+//
+// horizon must be >= 1 (need at least two points for a slope).
+//
+// Closed form for x = 0..horizon:
+//   slope = (n * sum(x*y) - sum(x) * sum(y)) / (n * sum(x*x) - sum(x)^2)
+class FutureLinearSlope
+{
+ public:
+  static constexpr bool is_target = true;
+
+  explicit FutureLinearSlope(size_t horizon) noexcept : _horizon(horizon)
+  {
+    assert(horizon >= 1);
+  }
+
+  std::vector<double> compute(std::span<const double> close) const
+  {
+    std::vector<double> out(close.size(), std::nan(""));
+    if (!close.empty())
+    {
+      compute(close, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> close, std::span<double> output) const
+  {
+    const size_t n = close.size();
+    assert(output.size() >= n);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n <= _horizon)
+    {
+      return;
+    }
+
+    const size_t points = _horizon + 1;
+    const double np = static_cast<double>(points);
+    // sum(x), sum(x*x) for x = 0..horizon are constants.
+    const double sumX = static_cast<double>(_horizon) * np / 2.0;
+    const double sumX2 = static_cast<double>(_horizon) * np * (2.0 * _horizon + 1.0) / 6.0;
+    const double denom = np * sumX2 - sumX * sumX;
+    if (denom == 0.0)
+    {
+      return;
+    }
+
+    for (size_t t = 0; t + _horizon < n; ++t)
+    {
+      double sumY = 0.0;
+      double sumXY = 0.0;
+      bool valid = true;
+
+      for (size_t i = 0; i < points; ++i)
+      {
+        double y = close[t + i];
+        if (std::isnan(y))
+        {
+          valid = false;
+          break;
+        }
+        sumY += y;
+        sumXY += static_cast<double>(i) * y;
+      }
+
+      if (!valid)
+      {
+        continue;
+      }
+
+      output[t] = (np * sumXY - sumX * sumY) / denom;
+    }
+  }
+
+  size_t horizon() const noexcept { return _horizon; }
+
+ private:
+  size_t _horizon;
+};
+
+static_assert(BatchTarget<FutureLinearSlope>);
+
+}  // namespace flox::target

--- a/include/flox/target/future_return.h
+++ b/include/flox/target/future_return.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+#include "flox/target/target.h"
+
+namespace flox::target
+{
+
+// FutureReturn(horizon): out[t] = close[t + horizon] / close[t] - 1.
+// Tail (n - horizon, ..., n - 1) is NaN.
+class FutureReturn
+{
+ public:
+  static constexpr bool is_target = true;
+
+  explicit FutureReturn(size_t horizon) noexcept : _horizon(horizon) { assert(horizon >= 1); }
+
+  std::vector<double> compute(std::span<const double> close) const
+  {
+    std::vector<double> out(close.size(), std::nan(""));
+    if (!close.empty())
+    {
+      compute(close, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> close, std::span<double> output) const
+  {
+    const size_t n = close.size();
+    assert(output.size() >= n);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    if (n <= _horizon)
+    {
+      return;
+    }
+
+    for (size_t t = 0; t + _horizon < n; ++t)
+    {
+      double base = close[t];
+      double fwd = close[t + _horizon];
+      if (std::isnan(base) || std::isnan(fwd) || base == 0.0)
+      {
+        continue;
+      }
+      output[t] = fwd / base - 1.0;
+    }
+  }
+
+  size_t horizon() const noexcept { return _horizon; }
+
+ private:
+  size_t _horizon;
+};
+
+static_assert(BatchTarget<FutureReturn>);
+
+}  // namespace flox::target

--- a/include/flox/target/target.h
+++ b/include/flox/target/target.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <concepts>
+#include <span>
+#include <vector>
+
+// Targets are forward-looking labels (e.g. future return, future volatility).
+// They are batch-only and intentionally have no streaming `update()` overload —
+// feeding them into a live update loop is a look-ahead-bias bug.
+//
+// Targets live in `flox::target`, distinct from `flox::indicator`, so the
+// lookahead is visible at the call site. The `BatchTarget` concept below is
+// the type-level guard: anything that looks like a streaming indicator does
+// not satisfy it.
+
+namespace flox::target
+{
+
+template <typename T>
+concept BatchTarget = requires(const T& t, std::span<const double> input) {
+  { t.compute(input) } -> std::same_as<std::vector<double>>;
+  { t.horizon() } noexcept -> std::convertible_to<size_t>;
+  { T::is_target } -> std::convertible_to<bool>;
+} && (T::is_target == true);
+
+}  // namespace flox::target

--- a/node/src/flox_node.cpp
+++ b/node/src/flox_node.cpp
@@ -12,6 +12,7 @@
 #include "profiles.h"
 #include "stats.h"
 #include "strategy.h"
+#include "targets.h"
 
 Napi::Object Init(Napi::Env env, Napi::Object exports)
 {
@@ -25,6 +26,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports)
   node_flox::registerAggregators(env, exports);
   node_flox::registerDataOps(env, exports);
   node_flox::registerStrategy(env, exports);
+  node_flox::registerTargets(env, exports);
   return exports;
 }
 

--- a/node/src/targets.h
+++ b/node/src/targets.h
@@ -1,0 +1,69 @@
+// node/src/targets.h -- forward-looking labels (research-only).
+//
+// Targets are intentionally batch-only and live under the `flox.targets.*`
+// namespace so look-ahead is visible at the call site.
+
+#pragma once
+#include <napi.h>
+
+#include <cstring>
+#include <span>
+#include <vector>
+
+#include "flox/target/future_ctc_volatility.h"
+#include "flox/target/future_linear_slope.h"
+#include "flox/target/future_return.h"
+
+namespace node_flox
+{
+
+namespace
+{
+
+inline Napi::Float64Array vecToFloat64Array(Napi::Env env, const std::vector<double>& v)
+{
+  auto a = Napi::Float64Array::New(env, v.size());
+  std::memcpy(a.Data(), v.data(), v.size() * sizeof(double));
+  return a;
+}
+
+template <typename Target>
+Napi::Value computeTarget(const Napi::CallbackInfo& info, Target t)
+{
+  auto in = info[0].As<Napi::Float64Array>();
+  size_t n = in.ElementLength();
+  std::vector<double> out(n);
+  t.compute(std::span<const double>(in.Data(), n), std::span<double>(out.data(), n));
+  return vecToFloat64Array(info.Env(), out);
+}
+
+inline Napi::Value batch_future_return(const Napi::CallbackInfo& info)
+{
+  size_t h = info[1].As<Napi::Number>().Uint32Value();
+  return computeTarget(info, flox::target::FutureReturn(h));
+}
+
+inline Napi::Value batch_future_ctc_volatility(const Napi::CallbackInfo& info)
+{
+  size_t h = info[1].As<Napi::Number>().Uint32Value();
+  return computeTarget(info, flox::target::FutureCTCVolatility(h));
+}
+
+inline Napi::Value batch_future_linear_slope(const Napi::CallbackInfo& info)
+{
+  size_t h = info[1].As<Napi::Number>().Uint32Value();
+  return computeTarget(info, flox::target::FutureLinearSlope(h));
+}
+
+}  // namespace
+
+inline void registerTargets(Napi::Env env, Napi::Object exports)
+{
+  auto targets = Napi::Object::New(env);
+  targets.Set("future_return", Napi::Function::New(env, batch_future_return));
+  targets.Set("future_ctc_volatility", Napi::Function::New(env, batch_future_ctc_volatility));
+  targets.Set("future_linear_slope", Napi::Function::New(env, batch_future_linear_slope));
+  exports.Set("targets", targets);
+}
+
+}  // namespace node_flox

--- a/node/test/test_bindings.js
+++ b/node/test/test_bindings.js
@@ -77,6 +77,27 @@ const bEma = flox.ema(prices, 3);
 check(bEma.length === prices.length, 'batch ema length matches input');
 check(bEma[6] > bEma[2], 'batch ema increases for ascending input');
 
+// ── Targets (forward-looking labels) ──────────────────────────────────
+
+console.log('=== Targets ===');
+
+const tClose = new Float64Array([100.0, 101.0, 99.0, 105.0, 110.0]);
+const fr = flox.targets.future_return(tClose, 2);
+check(approx(fr[0], 99.0 / 100.0 - 1.0), 'targets.future_return[0]');
+check(approx(fr[2], 110.0 / 99.0 - 1.0), 'targets.future_return[2]');
+check(Number.isNaN(fr[3]) && Number.isNaN(fr[4]), 'targets.future_return tail NaN');
+
+const constClose = new Float64Array(20).fill(100.0);
+const vol = flox.targets.future_ctc_volatility(constClose, 5);
+check(approx(vol[0], 0.0), 'targets.future_ctc_volatility const-series == 0');
+check(Number.isNaN(vol[19]), 'targets.future_ctc_volatility tail NaN');
+
+const linear = new Float64Array(20);
+for (let i = 0; i < 20; ++i) linear[i] = 100.0 + 0.5 * i;
+const sl = flox.targets.future_linear_slope(linear, 4);
+check(approx(sl[0], 0.5), 'targets.future_linear_slope linear-series == 0.5');
+check(Number.isNaN(sl[19]), 'targets.future_linear_slope tail NaN');
+
 // ── PositionTracker ───────────────────────────────────────────────────
 
 console.log('=== PositionTracker ===');

--- a/python/flox_py.cpp
+++ b/python/flox_py.cpp
@@ -19,6 +19,7 @@
 #include "replay_bindings.h"
 #include "segment_ops_bindings.h"
 #include "strategy_bindings.h"
+#include "target_bindings.h"
 
 #include <algorithm>
 #include <atomic>
@@ -722,6 +723,7 @@ PYBIND11_MODULE(flox_py, m)
   bindOptimizer(m);
   bindCompositeBook(m);
   bindStrategy(m);
+  bindTargets(m);
 
   // Slippage model constants
   m.attr("SLIPPAGE_NONE") = 0;

--- a/python/target_bindings.h
+++ b/python/target_bindings.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <cstring>
+
+#include "flox/target/future_ctc_volatility.h"
+#include "flox/target/future_linear_slope.h"
+#include "flox/target/future_return.h"
+
+namespace py = pybind11;
+
+namespace
+{
+
+using contiguous_double_target =
+    py::array_t<double, py::array::c_style | py::array::forcecast>;
+
+template <typename Target>
+py::array_t<double> computeTarget(const Target& t, contiguous_double_target input)
+{
+  auto buf = input.request();
+  size_t n = buf.shape[0];
+  auto* ptr = static_cast<const double*>(buf.ptr);
+  py::array_t<double> result(n);
+  auto* out = result.mutable_data();
+  {
+    py::gil_scoped_release release;
+    t.compute(std::span<const double>(ptr, n), std::span<double>(out, n));
+  }
+  return result;
+}
+
+}  // namespace
+
+inline void bindTargets(py::module_& parent)
+{
+  auto m = parent.def_submodule(
+      "targets",
+      "Forward-looking labels (research-only). Distinct from indicators: feeding "
+      "these into a live update loop is a look-ahead-bias bug.");
+
+  m.def(
+      "future_return",
+      [](contiguous_double_target close, size_t horizon)
+      { return computeTarget(flox::target::FutureReturn(horizon), close); },
+      py::arg("close"), py::arg("horizon"));
+
+  m.def(
+      "future_ctc_volatility",
+      [](contiguous_double_target close, size_t horizon)
+      { return computeTarget(flox::target::FutureCTCVolatility(horizon), close); },
+      py::arg("close"), py::arg("horizon"));
+
+  m.def(
+      "future_linear_slope",
+      [](contiguous_double_target close, size_t horizon)
+      { return computeTarget(flox::target::FutureLinearSlope(horizon), close); },
+      py::arg("close"), py::arg("horizon"));
+}

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -149,6 +149,26 @@ out_ema = flox.ema(prices, 3)
 check(len(out_ema) == len(prices), "batch ema length matches input")
 check(out_ema[6] > out_ema[2], "batch ema is increasing for ascending input")
 
+# ── Targets (forward-looking labels) ──────────────────────────────────
+
+print("=== Targets ===")
+
+close = np.array([100.0, 101.0, 99.0, 105.0, 110.0])
+fr = flox.targets.future_return(close, 2)
+check(approx(fr[0], 99.0 / 100.0 - 1.0), "future_return[0] == c[2]/c[0]-1")
+check(approx(fr[2], 110.0 / 99.0 - 1.0), "future_return[2] == c[4]/c[2]-1")
+check(math.isnan(fr[3]) and math.isnan(fr[4]), "future_return tail is NaN")
+
+const_close = np.full(20, 100.0)
+vol = flox.targets.future_ctc_volatility(const_close, 5)
+check(approx(vol[0], 0.0), "future_ctc_volatility on const series == 0")
+check(math.isnan(vol[19]), "future_ctc_volatility tail is NaN")
+
+linear = np.array([100.0 + 0.5 * i for i in range(20)])
+sl = flox.targets.future_linear_slope(linear, 4)
+check(approx(sl[0], 0.5), "future_linear_slope on linear series == 0.5")
+check(math.isnan(sl[19]), "future_linear_slope tail is NaN")
+
 # ── PositionTracker ───────────────────────────────────────────────────
 
 print("=== PositionTracker ===")

--- a/quickjs/flox/targets.js
+++ b/quickjs/flox/targets.js
@@ -1,0 +1,17 @@
+// Targets — forward-looking labels (research-only).
+//
+// Targets read into the future relative to t. They live under `flox.targets.*`
+// and are intentionally batch-only: feeding them into a live update loop is
+// a look-ahead-bias bug.
+
+var __floxTargets = {
+    future_return: function(close, horizon) {
+        return __flox_target_future_return(close, horizon);
+    },
+    future_ctc_volatility: function(close, horizon) {
+        return __flox_target_future_ctc_volatility(close, horizon);
+    },
+    future_linear_slope: function(close, horizon) {
+        return __flox_target_future_linear_slope(close, horizon);
+    }
+};

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -49,6 +49,9 @@
 #include "flox/indicator/sma.h"
 #include "flox/indicator/stochastic.h"
 #include "flox/indicator/vwap.h"
+#include "flox/target/future_ctc_volatility.h"
+#include "flox/target/future_linear_slope.h"
+#include "flox/target/future_return.h"
 
 #include "flox/aggregator/custom/footprint_bar.h"
 #include "flox/aggregator/custom/market_profile.h"
@@ -576,6 +579,30 @@ void flox_indicator_correlation(const double* x, const double* y, size_t len, si
   indicator::Correlation ind(period);
   ind.compute(std::span<const double>(x, len), std::span<const double>(y, len),
               std::span<double>(output, len));
+}
+
+// ============================================================
+// Targets
+// ============================================================
+
+void flox_target_future_return(const double* close, size_t len, size_t horizon, double* output)
+{
+  target::FutureReturn t(horizon);
+  t.compute(std::span<const double>(close, len), std::span<double>(output, len));
+}
+
+void flox_target_future_ctc_volatility(const double* close, size_t len, size_t horizon,
+                                       double* output)
+{
+  target::FutureCTCVolatility t(horizon);
+  t.compute(std::span<const double>(close, len), std::span<double>(output, len));
+}
+
+void flox_target_future_linear_slope(const double* close, size_t len, size_t horizon,
+                                     double* output)
+{
+  target::FutureLinearSlope t(horizon);
+  t.compute(std::span<const double>(close, len), std::span<double>(output, len));
 }
 
 // ============================================================

--- a/src/quickjs/CMakeLists.txt
+++ b/src/quickjs/CMakeLists.txt
@@ -47,9 +47,20 @@ add_custom_command(
   COMMENT "Embedding indicators.js"
 )
 
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/js_stdlib_targets.inc
+  COMMAND ${CMAKE_COMMAND}
+    -DIN_FILE=${JS_STDLIB_DIR}/targets.js
+    -DOUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/js_stdlib_targets.inc
+    -P ${GEN_INC_SCRIPT}
+  DEPENDS ${JS_STDLIB_DIR}/targets.js ${GEN_INC_SCRIPT}
+  COMMENT "Embedding targets.js"
+)
+
 add_custom_target(js_stdlib_gen DEPENDS
   ${CMAKE_CURRENT_BINARY_DIR}/js_stdlib_strategy.inc
   ${CMAKE_CURRENT_BINARY_DIR}/js_stdlib_indicators.inc
+  ${CMAKE_CURRENT_BINARY_DIR}/js_stdlib_targets.inc
 )
 
 # flox_quickjs static library

--- a/src/quickjs/js_bindings.cpp
+++ b/src/quickjs/js_bindings.cpp
@@ -605,6 +605,42 @@ static JSValue js_indicator_correlation(JSContext* ctx, JSValueConst, int, JSVal
 }
 
 // ============================================================
+// Targets (forward-looking labels, batch only)
+// ============================================================
+
+static JSValue js_target_future_return(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto close = jsArrayToDoubles(ctx, argv[0]);
+  uint32_t horizon = toUint32(ctx, argv[1]);
+  size_t len = close.size();
+  std::vector<double> output(len);
+  flox_target_future_return(close.data(), len, horizon, output.data());
+  return jsArrayFromDoubles(ctx, output);
+}
+
+static JSValue js_target_future_ctc_volatility(JSContext* ctx, JSValueConst, int,
+                                               JSValueConst* argv)
+{
+  auto close = jsArrayToDoubles(ctx, argv[0]);
+  uint32_t horizon = toUint32(ctx, argv[1]);
+  size_t len = close.size();
+  std::vector<double> output(len);
+  flox_target_future_ctc_volatility(close.data(), len, horizon, output.data());
+  return jsArrayFromDoubles(ctx, output);
+}
+
+static JSValue js_target_future_linear_slope(JSContext* ctx, JSValueConst, int,
+                                             JSValueConst* argv)
+{
+  auto close = jsArrayToDoubles(ctx, argv[0]);
+  uint32_t horizon = toUint32(ctx, argv[1]);
+  size_t len = close.size();
+  std::vector<double> output(len);
+  flox_target_future_linear_slope(close.data(), len, horizon, output.data());
+  return jsArrayFromDoubles(ctx, output);
+}
+
+// ============================================================
 // Order book bindings
 // ============================================================
 
@@ -2095,6 +2131,11 @@ void registerFloxBindings(JSContext* ctx)
   addGlobalFunc(ctx, "__flox_indicator_parkinson_vol", js_indicator_parkinson_vol, 3);
   addGlobalFunc(ctx, "__flox_indicator_rogers_satchell_vol", js_indicator_rogers_satchell_vol, 5);
   addGlobalFunc(ctx, "__flox_indicator_correlation", js_indicator_correlation, 3);
+
+  // Targets (forward-looking labels)
+  addGlobalFunc(ctx, "__flox_target_future_return", js_target_future_return, 2);
+  addGlobalFunc(ctx, "__flox_target_future_ctc_volatility", js_target_future_ctc_volatility, 2);
+  addGlobalFunc(ctx, "__flox_target_future_linear_slope", js_target_future_linear_slope, 2);
 
   // Order book
   addGlobalFunc(ctx, "__flox_book_create", js_book_create, 1);

--- a/src/quickjs/js_strategy.cpp
+++ b/src/quickjs/js_strategy.cpp
@@ -13,6 +13,10 @@ static const char* const INDICATORS_JS =
 #include "js_stdlib_indicators.inc"
     ;
 
+static const char* const TARGETS_JS =
+#include "js_stdlib_targets.inc"
+    ;
+
 namespace flox
 {
 
@@ -57,6 +61,10 @@ void FloxJsStrategy::loadStdlib()
   if (!_engine.eval(STRATEGY_JS, "flox/strategy.js"))
   {
     throw std::runtime_error("Failed to load strategy.js: " + _engine.getErrorMessage());
+  }
+  if (!_engine.eval(TARGETS_JS, "flox/targets.js"))
+  {
+    throw std::runtime_error("Failed to load targets.js: " + _engine.getErrorMessage());
   }
 
   // Create flox global object with register() and batch indicators
@@ -461,7 +469,10 @@ void FloxJsStrategy::loadStdlib()
         return __flox_seg_extract_time(inputPath, outputPath, fromNs || 0, toNs || 0);
       },
 
-      loadCsv: function(path) { return __flox_load_csv(path); }
+      loadCsv: function(path) { return __flox_load_csv(path); },
+
+      // Forward-looking labels (research-only). See flox/targets.js.
+      targets: __floxTargets
     };
   )";
   if (!_engine.eval(registerCode, "<flox_register>"))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ if(FLOX_ENABLE_BACKTEST)
 endif()
 
 add_flox_test(test_indicators)
+add_flox_test(test_targets)
 
 if(FLOX_ENABLE_CAPI)
   add_flox_test(test_capi_registry)

--- a/tests/test_quickjs.cpp
+++ b/tests/test_quickjs.cpp
@@ -107,6 +107,47 @@ int TempJsFile::counter_ = 0;
 // Integration tests — full strategy lifecycle
 // ============================================================
 
+TEST(JsIntegrationTest, TargetsBindings)
+{
+  TempJsFile script(R"(
+    var fr = flox.targets.future_return([100.0, 101.0, 99.0, 105.0, 110.0], 2);
+    var fr0 = fr[0];
+    var fr2 = fr[2];
+    var fr_tail_nan = isNaN(fr[3]) && isNaN(fr[4]);
+
+    var constClose = [];
+    for (var i = 0; i < 20; i++) constClose.push(100.0);
+    var vol = flox.targets.future_ctc_volatility(constClose, 5);
+    var vol0 = vol[0];
+
+    var lin = [];
+    for (var i = 0; i < 20; i++) lin.push(100.0 + 0.5 * i);
+    var sl = flox.targets.future_linear_slope(lin, 4);
+    var sl0 = sl[0];
+  )");
+
+  SymbolRegistry registry;
+  FloxJsStrategy jsStrat(script.path(), registry);
+
+  auto getNum = [&](const char* name)
+  {
+    JSValue v = jsStrat.engine().getGlobalProperty(name);
+    double d = 0;
+    JS_ToFloat64(jsStrat.engine().context(), &d, v);
+    JS_FreeValue(jsStrat.engine().context(), v);
+    return d;
+  };
+
+  EXPECT_NEAR(getNum("fr0"), 99.0 / 100.0 - 1.0, 1e-12);
+  EXPECT_NEAR(getNum("fr2"), 110.0 / 99.0 - 1.0, 1e-12);
+  EXPECT_NEAR(getNum("vol0"), 0.0, 1e-12);
+  EXPECT_NEAR(getNum("sl0"), 0.5, 1e-12);
+
+  JSValue tail = jsStrat.engine().getGlobalProperty("fr_tail_nan");
+  EXPECT_TRUE(JS_ToBool(jsStrat.engine().context(), tail));
+  JS_FreeValue(jsStrat.engine().context(), tail);
+}
+
 TEST(JsIntegrationTest, LoadStrategyAndResolveSymbols)
 {
   TempJsFile script(R"(

--- a/tests/test_targets.cpp
+++ b/tests/test_targets.cpp
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "flox/target/future_ctc_volatility.h"
+#include "flox/target/future_linear_slope.h"
+#include "flox/target/future_return.h"
+
+using namespace flox::target;
+
+static std::vector<double> linearSeries(size_t n, double base, double step)
+{
+  std::vector<double> out(n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    out[i] = base + step * static_cast<double>(i);
+  }
+  return out;
+}
+
+// ── FutureReturn ─────────────────────────────────────────────────────
+
+TEST(FutureReturn, BasicForwardRatio)
+{
+  std::vector<double> close = {100.0, 101.0, 99.0, 105.0, 110.0};
+  FutureReturn fr(2);
+  auto out = fr.compute(close);
+
+  ASSERT_EQ(out.size(), close.size());
+  EXPECT_NEAR(out[0], 99.0 / 100.0 - 1.0, 1e-12);
+  EXPECT_NEAR(out[1], 105.0 / 101.0 - 1.0, 1e-12);
+  EXPECT_NEAR(out[2], 110.0 / 99.0 - 1.0, 1e-12);
+  EXPECT_TRUE(std::isnan(out[3]));
+  EXPECT_TRUE(std::isnan(out[4]));
+}
+
+TEST(FutureReturn, TooShortAllNan)
+{
+  std::vector<double> close = {1.0, 2.0};
+  FutureReturn fr(5);
+  auto out = fr.compute(close);
+  for (double v : out)
+  {
+    EXPECT_TRUE(std::isnan(v));
+  }
+}
+
+TEST(FutureReturn, ZeroBaseGivesNan)
+{
+  std::vector<double> close = {0.0, 1.0, 2.0, 3.0};
+  FutureReturn fr(1);
+  auto out = fr.compute(close);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_NEAR(out[1], 1.0, 1e-12);
+  EXPECT_NEAR(out[2], 0.5, 1e-12);
+  EXPECT_TRUE(std::isnan(out[3]));
+}
+
+// ── FutureCTCVolatility ──────────────────────────────────────────────
+
+TEST(FutureCTCVolatility, ConstantSeriesIsZero)
+{
+  std::vector<double> close(20, 100.0);
+  FutureCTCVolatility v(5);
+  auto out = v.compute(close);
+  for (size_t i = 0; i + 5 < close.size(); ++i)
+  {
+    EXPECT_NEAR(out[i], 0.0, 1e-12);
+  }
+  for (size_t i = close.size() - 5; i < close.size(); ++i)
+  {
+    EXPECT_TRUE(std::isnan(out[i]));
+  }
+}
+
+TEST(FutureCTCVolatility, MatchesSampleStdOfLogReturns)
+{
+  std::vector<double> close = {100.0, 102.0, 101.0, 105.0, 103.0, 108.0};
+  FutureCTCVolatility v(3);
+  auto out = v.compute(close);
+
+  // out[0] uses returns over [c0..c3]: ln(102/100), ln(101/102), ln(105/101)
+  std::vector<double> r = {std::log(102.0 / 100.0), std::log(101.0 / 102.0),
+                           std::log(105.0 / 101.0)};
+  double m = (r[0] + r[1] + r[2]) / 3.0;
+  double s = 0.0;
+  for (double x : r)
+  {
+    s += (x - m) * (x - m);
+  }
+  double expected = std::sqrt(s / 2.0);
+  EXPECT_NEAR(out[0], expected, 1e-12);
+
+  EXPECT_TRUE(std::isnan(out[3]));
+  EXPECT_TRUE(std::isnan(out[4]));
+  EXPECT_TRUE(std::isnan(out[5]));
+}
+
+TEST(FutureCTCVolatility, NonPositivePriceGivesNan)
+{
+  std::vector<double> close = {100.0, 0.0, 101.0, 102.0, 103.0};
+  FutureCTCVolatility v(2);
+  auto out = v.compute(close);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_TRUE(std::isnan(out[1]));
+  EXPECT_FALSE(std::isnan(out[2]));
+}
+
+// ── FutureLinearSlope ────────────────────────────────────────────────
+
+TEST(FutureLinearSlope, ExactSlopeOnLinearSeries)
+{
+  auto close = linearSeries(20, 100.0, 0.5);
+  FutureLinearSlope s(4);
+  auto out = s.compute(close);
+
+  for (size_t t = 0; t + 4 < close.size(); ++t)
+  {
+    EXPECT_NEAR(out[t], 0.5, 1e-12) << "t=" << t;
+  }
+  for (size_t t = close.size() - 4; t < close.size(); ++t)
+  {
+    EXPECT_TRUE(std::isnan(out[t]));
+  }
+}
+
+TEST(FutureLinearSlope, NegativeSlope)
+{
+  auto close = linearSeries(10, 100.0, -2.5);
+  FutureLinearSlope s(3);
+  auto out = s.compute(close);
+  for (size_t t = 0; t + 3 < close.size(); ++t)
+  {
+    EXPECT_NEAR(out[t], -2.5, 1e-12);
+  }
+}
+
+TEST(FutureLinearSlope, MatchesClosedFormOLS)
+{
+  // y = 0.7 * x + 5 plus a bump
+  std::vector<double> close = {5.0, 6.0, 7.5, 7.0, 8.5, 9.0, 10.5};
+  FutureLinearSlope s(4);
+  auto out = s.compute(close);
+
+  // For t = 0, fit y over x = 0..4 to {5.0, 6.0, 7.5, 7.0, 8.5}.
+  // closed-form OLS slope:
+  // sumX = 10, sumX2 = 30, n = 5, denom = 5*30 - 10*10 = 50
+  // sumY = 34.0, sumXY = 0*5 + 1*6 + 2*7.5 + 3*7 + 4*8.5 = 0+6+15+21+34 = 76
+  // slope = (5*76 - 10*34) / 50 = (380 - 340) / 50 = 0.8
+  EXPECT_NEAR(out[0], 0.8, 1e-12);
+}
+
+TEST(FutureLinearSlope, HorizonOneIsForwardDifference)
+{
+  std::vector<double> close = {100.0, 101.5, 99.0, 105.0};
+  FutureLinearSlope s(1);
+  auto out = s.compute(close);
+  EXPECT_NEAR(out[0], 1.5, 1e-12);
+  EXPECT_NEAR(out[1], -2.5, 1e-12);
+  EXPECT_NEAR(out[2], 6.0, 1e-12);
+  EXPECT_TRUE(std::isnan(out[3]));
+}


### PR DESCRIPTION
## Summary

Closes #110.

Introduces a `flox::target` namespace, distinct from `flox::indicator`, for forward-looking labels. Targets read into the future relative to `t` and are research-only — feeding them into a live `update()` loop is a look-ahead-bias bug. Keeping them in their own namespace makes that lookahead visible at the call site.

Three labels:

- `FutureReturn(horizon)` — `close[t+h] / close[t] - 1`
- `FutureCTCVolatility(horizon)` — sample stddev of close-to-close log returns over `[t, t+h]`
- `FutureLinearSlope(horizon)` — OLS slope of close over `[t, t+h]` (uses `h+1` points)

Type-level guard: a `BatchTarget` concept that requires a `is_target = true` marker. Anything that satisfies the streaming-indicator interface won't satisfy `BatchTarget`, and vice versa.

## Bindings

Exposed under a clearly separate namespace on every surface so the look-ahead is visible at the call site:

- **C API** — `flox_target_future_return / _ctc_volatility / _linear_slope`
- **Python** — `flox.targets.future_return(close, horizon)` etc.
- **Node** — `flox.targets.future_return(close, horizon)` etc.
- **Codon** — `from flox.targets import future_return, future_ctc_volatility, future_linear_slope`
- **QuickJS** — `flox.targets.future_return(close, horizon)` etc., loaded from `quickjs/flox/targets.js`

## Test plan

- [x] C++ unit: `tests/test_targets.cpp` covers basic forward ratio, NaN tail, OLS slope on linear/non-linear series, sample-stddev formula, edge cases (zero base, non-positive prices, too-short input)
- [x] Python smoke: `python/tests/test_bindings.py` — 7 new asserts
- [x] Node smoke: `node/test/test_bindings.js` — 7 new asserts
- [x] QuickJS integration: `JsIntegrationTest.TargetsBindings` exercises `flox.targets.*` end-to-end
- [x] Codon: `codon_targets_smoke` example compiles via the C API
- [x] Full ctest: 45/45 passed
- [x] `clang-format` clean