### PR TITLE
feat(indicator): ADF stationarity test

### DIFF
--- a/codon/CMakeLists.txt
+++ b/codon/CMakeLists.txt
@@ -41,3 +41,6 @@ add_codon_executable(codon_full_backtest
 
 add_codon_executable(codon_targets_smoke
   ${CMAKE_CURRENT_SOURCE_DIR}/examples/targets_smoke.codon)
+
+add_codon_executable(codon_adf_smoke
+  ${CMAKE_CURRENT_SOURCE_DIR}/examples/adf_smoke.codon)

--- a/codon/examples/adf_smoke.codon
+++ b/codon/examples/adf_smoke.codon
@@ -1,0 +1,12 @@
+# Smoke test: ADF compiles + computes against the C API.
+
+from flox.indicators import adf
+
+# Random walk-ish series — won't reject the unit-root null.
+walk = [0.0, 0.3, -0.2, 0.5, 0.1, 0.7, 0.4, 0.9, 0.6, 1.1,
+        0.8, 1.3, 1.0, 1.5, 1.2, 1.7, 1.4, 1.9, 1.6, 2.1]
+
+r = adf(walk, 2, "c")
+print("test_stat =", r.test_stat)
+print("p_value   =", r.p_value)
+print("used_lag  =", r.used_lag)

--- a/codon/flox/indicators.codon
+++ b/codon/flox/indicators.codon
@@ -33,6 +33,8 @@ from C import flox_indicator_shannon_entropy(Ptr[f64], int, int, int, Ptr[f64])
 from C import flox_indicator_parkinson_vol(Ptr[f64], Ptr[f64], int, int, Ptr[f64])
 from C import flox_indicator_rogers_satchell_vol(Ptr[f64], Ptr[f64], Ptr[f64], Ptr[f64], int, int, Ptr[f64])
 from C import flox_indicator_correlation(Ptr[f64], Ptr[f64], int, int, Ptr[f64])
+from C import flox_indicator_adf(Ptr[f64], int, int, cobj,
+                                  Ptr[f64], Ptr[f64], Ptr[int])
 
 
 # ======================================================================
@@ -337,6 +339,27 @@ class StochasticResult:
     def __init__(self, k: List[float], d: List[float]):
         self.k = k
         self.d = d
+
+
+class AdfResult:
+    test_stat: float
+    p_value: float
+    used_lag: int
+
+    def __init__(self, test_stat: float, p_value: float, used_lag: int):
+        self.test_stat = test_stat
+        self.p_value = p_value
+        self.used_lag = used_lag
+
+
+def adf(data: List[float], max_lag: int = 4, regression: str = "c") -> AdfResult:
+    n = len(data)
+    test_stat = [0.0]
+    p_value = [0.0]
+    used_lag = [0]
+    flox_indicator_adf(data.arr.ptr, n, max_lag, regression.c_str(),
+                       test_stat.arr.ptr, p_value.arr.ptr, used_lag.arr.ptr)
+    return AdfResult(test_stat[0], p_value[0], used_lag[0])
 
 
 def macd(data: List[float], fast: int = 12, slow: int = 26,

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -237,6 +237,11 @@ extern "C"
   void flox_indicator_correlation(const double* x, const double* y, size_t len, size_t period,
                                   double* output);
 
+  // Augmented Dickey-Fuller test. `regression` accepts: "n", "c", "ct".
+  // Writes the t-statistic, approximate p-value, and AIC-selected lag.
+  void flox_indicator_adf(const double* input, size_t len, size_t max_lag, const char* regression,
+                          double* test_stat_out, double* p_value_out, size_t* used_lag_out);
+
   // ============================================================
   // Targets (forward-looking labels, batch only)
   //

--- a/include/flox/indicator/adf.h
+++ b/include/flox/indicator/adf.h
@@ -1,0 +1,394 @@
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace flox::indicator
+{
+
+// Augmented Dickey-Fuller (ADF) stationarity test.
+//
+//   adf(x, max_lag, regression="c")
+//
+// Tests the null H0: y has a unit root (non-stationary) against the
+// alternative H1: y is (trend-)stationary.
+//
+// Regression modes:
+//   "n"  — no constant, no trend
+//   "c"  — constant (drift)
+//   "ct" — constant + linear trend
+//
+// Returns: { test_stat, p_value, used_lag }.
+//   test_stat = β / SE(β) for the coefficient on y[t-1] in the regression
+//      Δy[t] = α + δ*t + β*y[t-1] + Σ γ_i * Δy[t-i] + ε
+//   used_lag = lag chosen via AIC over [0 .. max_lag]
+//   p_value  = approximate, via MacKinnon (1996) asymptotic critical values.
+//              For more precision, compare test_stat to the published critical
+//              values directly.
+//
+// Inherently batch over a window — no streaming variant.
+
+enum class AdfRegression : uint8_t
+{
+  None = 0,          // "n"
+  Constant = 1,      // "c"
+  ConstantTrend = 2  // "ct"
+};
+
+inline AdfRegression parseAdfRegression(const std::string& s)
+{
+  if (s == "n")
+  {
+    return AdfRegression::None;
+  }
+  if (s == "c")
+  {
+    return AdfRegression::Constant;
+  }
+  if (s == "ct")
+  {
+    return AdfRegression::ConstantTrend;
+  }
+  throw std::invalid_argument("adf: regression must be one of: \"n\", \"c\", \"ct\"");
+}
+
+struct AdfResult
+{
+  double test_stat;
+  double p_value;
+  size_t used_lag;
+};
+
+namespace detail
+{
+
+// OLS via normal equations: solve (X^T X) β = X^T y, return β plus the
+// residual sum-of-squares and the diagonal of (X^T X)^{-1} for SE estimates.
+//
+// Uses Gauss-Jordan elimination on the augmented (X^T X | I | X^T y) matrix.
+struct OlsFit
+{
+  std::vector<double> beta;     // size k
+  std::vector<double> covDiag;  // diag of (X^T X)^{-1}
+  double rss;                   // residual sum of squares
+  size_t n;                     // sample size
+  size_t k;                     // number of regressors
+};
+
+inline OlsFit olsFit(const std::vector<double>& X, size_t n, size_t k,
+                     const std::vector<double>& y)
+{
+  // X is row-major n x k. y is size n.
+  std::vector<double> XtX(k * k, 0.0);
+  std::vector<double> Xty(k, 0.0);
+
+  for (size_t i = 0; i < n; ++i)
+  {
+    for (size_t a = 0; a < k; ++a)
+    {
+      double xa = X[i * k + a];
+      Xty[a] += xa * y[i];
+      for (size_t b = 0; b < k; ++b)
+      {
+        XtX[a * k + b] += xa * X[i * k + b];
+      }
+    }
+  }
+
+  // Augment [XtX | I] and run Gauss-Jordan to invert.
+  std::vector<double> aug(k * (2 * k), 0.0);
+  for (size_t i = 0; i < k; ++i)
+  {
+    for (size_t j = 0; j < k; ++j)
+    {
+      aug[i * (2 * k) + j] = XtX[i * k + j];
+    }
+    aug[i * (2 * k) + k + i] = 1.0;
+  }
+
+  for (size_t col = 0; col < k; ++col)
+  {
+    // Partial pivoting
+    size_t pivot = col;
+    double best = std::abs(aug[col * (2 * k) + col]);
+    for (size_t r = col + 1; r < k; ++r)
+    {
+      double v = std::abs(aug[r * (2 * k) + col]);
+      if (v > best)
+      {
+        best = v;
+        pivot = r;
+      }
+    }
+    if (best < 1e-14)
+    {
+      throw std::runtime_error("adf: singular regression matrix");
+    }
+    if (pivot != col)
+    {
+      for (size_t j = 0; j < 2 * k; ++j)
+      {
+        std::swap(aug[col * (2 * k) + j], aug[pivot * (2 * k) + j]);
+      }
+    }
+
+    double piv = aug[col * (2 * k) + col];
+    for (size_t j = 0; j < 2 * k; ++j)
+    {
+      aug[col * (2 * k) + j] /= piv;
+    }
+    for (size_t r = 0; r < k; ++r)
+    {
+      if (r == col)
+      {
+        continue;
+      }
+      double factor = aug[r * (2 * k) + col];
+      if (factor == 0.0)
+      {
+        continue;
+      }
+      for (size_t j = 0; j < 2 * k; ++j)
+      {
+        aug[r * (2 * k) + j] -= factor * aug[col * (2 * k) + j];
+      }
+    }
+  }
+
+  // β = (XtX)^{-1} * Xty
+  std::vector<double> beta(k, 0.0);
+  for (size_t i = 0; i < k; ++i)
+  {
+    double s = 0.0;
+    for (size_t j = 0; j < k; ++j)
+    {
+      s += aug[i * (2 * k) + k + j] * Xty[j];
+    }
+    beta[i] = s;
+  }
+
+  std::vector<double> covDiag(k, 0.0);
+  for (size_t i = 0; i < k; ++i)
+  {
+    covDiag[i] = aug[i * (2 * k) + k + i];
+  }
+
+  // RSS
+  double rss = 0.0;
+  for (size_t i = 0; i < n; ++i)
+  {
+    double pred = 0.0;
+    for (size_t a = 0; a < k; ++a)
+    {
+      pred += X[i * k + a] * beta[a];
+    }
+    double r = y[i] - pred;
+    rss += r * r;
+  }
+
+  return OlsFit{std::move(beta), std::move(covDiag), rss, n, k};
+}
+
+// Build the ADF regression for a given lag.
+// Returns true if regression succeeded; fit is populated.
+inline bool buildAdfRegression(std::span<const double> x, size_t lag, AdfRegression reg,
+                               OlsFit& outFit, size_t& outBetaIdx)
+{
+  const size_t T = x.size();
+  // We need x[t-1] and x[t-1-lag], so the first usable t is lag+1.
+  // Effective sample size n = T - lag - 1.
+  if (T <= lag + 1)
+  {
+    return false;
+  }
+  const size_t start = lag + 1;
+  const size_t n = T - start;
+
+  // Number of regressors:
+  //   1 for y[t-1]
+  // + lag terms for Δy[t-1] .. Δy[t-lag]
+  // + intercept and/or trend
+  size_t k = 1 + lag;
+  if (reg == AdfRegression::Constant)
+  {
+    k += 1;
+  }
+  else if (reg == AdfRegression::ConstantTrend)
+  {
+    k += 2;
+  }
+
+  if (n <= k)
+  {
+    return false;
+  }
+
+  std::vector<double> X(n * k, 0.0);
+  std::vector<double> y(n, 0.0);
+
+  for (size_t i = 0; i < n; ++i)
+  {
+    size_t t = start + i;
+    y[i] = x[t] - x[t - 1];
+
+    size_t col = 0;
+    if (reg == AdfRegression::Constant || reg == AdfRegression::ConstantTrend)
+    {
+      X[i * k + col++] = 1.0;
+    }
+    if (reg == AdfRegression::ConstantTrend)
+    {
+      // Trend term — start at 1 to mirror conventional formulations.
+      X[i * k + col++] = static_cast<double>(i + 1);
+    }
+    outBetaIdx = col;
+    X[i * k + col++] = x[t - 1];
+
+    for (size_t L = 1; L <= lag; ++L)
+    {
+      X[i * k + col++] = x[t - L] - x[t - L - 1];
+    }
+  }
+
+  outFit = olsFit(X, n, k, y);
+  return true;
+}
+
+// MacKinnon (1996) asymptotic critical values for ADF test.
+// Rows: regression type. Columns: probability levels in `adfPLevels`.
+inline const std::vector<double>& adfPLevels()
+{
+  static const std::vector<double> v = {0.01, 0.025, 0.05, 0.10, 0.50, 0.90, 0.95, 0.975, 0.99};
+  return v;
+}
+
+inline const std::vector<double>& adfCritValues(AdfRegression reg)
+{
+  // Asymptotic critical values from MacKinnon (1996).
+  // Index aligned with adfPLevels().
+  static const std::vector<double> none = {-2.566, -2.260, -1.941, -1.617, -0.443,
+                                           0.911, 1.282, 1.645, 2.054};
+  static const std::vector<double> constant = {-3.430, -3.119, -2.861, -2.567, -1.617,
+                                               -0.260, 0.058, 0.330, 0.601};
+  static const std::vector<double> ct = {-3.958, -3.658, -3.410, -3.121, -2.181,
+                                         -0.861, -0.571, -0.314, -0.040};
+
+  switch (reg)
+  {
+    case AdfRegression::None:
+      return none;
+    case AdfRegression::Constant:
+      return constant;
+    case AdfRegression::ConstantTrend:
+      return ct;
+  }
+  return constant;
+}
+
+// Map test statistic to p-value via piecewise-linear interpolation against
+// MacKinnon's asymptotic critical-value table. Monotonic in the statistic.
+inline double adfPValue(double tau, AdfRegression reg)
+{
+  const auto& probs = adfPLevels();
+  const auto& crits = adfCritValues(reg);
+  assert(probs.size() == crits.size());
+
+  if (tau <= crits.front())
+  {
+    return probs.front();
+  }
+  if (tau >= crits.back())
+  {
+    return probs.back();
+  }
+
+  for (size_t i = 1; i < crits.size(); ++i)
+  {
+    if (tau <= crits[i])
+    {
+      double w = (tau - crits[i - 1]) / (crits[i] - crits[i - 1]);
+      return probs[i - 1] + w * (probs[i] - probs[i - 1]);
+    }
+  }
+  return probs.back();
+}
+
+}  // namespace detail
+
+inline AdfResult adf(std::span<const double> x, size_t max_lag,
+                     AdfRegression reg = AdfRegression::Constant)
+{
+  if (x.size() < 4)
+  {
+    throw std::invalid_argument("adf: input too short (need at least 4 observations)");
+  }
+  for (double v : x)
+  {
+    if (std::isnan(v))
+    {
+      throw std::invalid_argument("adf: input contains NaN");
+    }
+  }
+
+  // AIC-based lag selection over [0 .. max_lag]. Pick the lag minimising AIC.
+  size_t bestLag = 0;
+  double bestAic = std::numeric_limits<double>::infinity();
+  detail::OlsFit bestFit;
+  size_t bestBetaIdx = 0;
+  bool found = false;
+
+  for (size_t lag = 0; lag <= max_lag; ++lag)
+  {
+    detail::OlsFit fit;
+    size_t betaIdx = 0;
+    if (!detail::buildAdfRegression(x, lag, reg, fit, betaIdx))
+    {
+      break;
+    }
+    // AIC = n * ln(rss/n) + 2*k.
+    if (fit.rss <= 0.0)
+    {
+      continue;
+    }
+    double aic = static_cast<double>(fit.n) * std::log(fit.rss / static_cast<double>(fit.n)) +
+                 2.0 * static_cast<double>(fit.k);
+    if (aic < bestAic)
+    {
+      bestAic = aic;
+      bestLag = lag;
+      bestFit = std::move(fit);
+      bestBetaIdx = betaIdx;
+      found = true;
+    }
+  }
+
+  if (!found)
+  {
+    throw std::invalid_argument("adf: input too short for the requested max_lag and regression");
+  }
+
+  // t-statistic for the y[t-1] coefficient.
+  double beta = bestFit.beta[bestBetaIdx];
+  double sigma2 = bestFit.rss / static_cast<double>(bestFit.n - bestFit.k);
+  if (sigma2 <= 0.0 || bestFit.covDiag[bestBetaIdx] <= 0.0)
+  {
+    throw std::runtime_error("adf: degenerate regression");
+  }
+  double se = std::sqrt(sigma2 * bestFit.covDiag[bestBetaIdx]);
+  double tau = beta / se;
+
+  return AdfResult{tau, detail::adfPValue(tau, reg), bestLag};
+}
+
+inline AdfResult adf(std::span<const double> x, size_t max_lag, const std::string& regression)
+{
+  return adf(x, max_lag, parseAdfRegression(regression));
+}
+
+}  // namespace flox::indicator

--- a/node/src/indicators.h
+++ b/node/src/indicators.h
@@ -21,6 +21,7 @@
 #include "flox/indicator/stochastic.h"
 #include "flox/indicator/vwap.h"
 
+#include "flox/indicator/adf.h"
 #include "flox/indicator/correlation.h"
 #include "flox/indicator/kurtosis.h"
 #include "flox/indicator/parkinson_vol.h"
@@ -285,6 +286,21 @@ inline Napi::Value batch_correlation(const Napi::CallbackInfo& info)
   std::vector<double> out(n);
   flox::indicator::Correlation(p).compute({x.Data(), n}, {y.Data(), n}, {out.data(), n});
   return vec2arr(info.Env(), out);
+}
+
+inline Napi::Value batch_adf(const Napi::CallbackInfo& info)
+{
+  auto in = info[0].As<Napi::Float64Array>();
+  size_t n = in.ElementLength();
+  size_t maxLag = info[1].As<Napi::Number>().Uint32Value();
+  std::string regression = info[2].As<Napi::String>().Utf8Value();
+  flox::indicator::AdfResult r =
+      flox::indicator::adf(std::span<const double>(in.Data(), n), maxLag, regression);
+  auto o = Napi::Object::New(info.Env());
+  o.Set("test_stat", Napi::Number::New(info.Env(), r.test_stat));
+  o.Set("p_value", Napi::Number::New(info.Env(), r.p_value));
+  o.Set("used_lag", Napi::Number::New(info.Env(), static_cast<double>(r.used_lag)));
+  return o;
 }
 
 // ── Streaming indicator classes ─────────────────────────────────────
@@ -1529,6 +1545,7 @@ inline void registerIndicators(Napi::Env env, Napi::Object exports)
   exports.Set("parkinson_vol", Napi::Function::New(env, batch_parkinson_vol));
   exports.Set("rogers_satchell_vol", Napi::Function::New(env, batch_rogers_satchell_vol));
   exports.Set("correlation", Napi::Function::New(env, batch_correlation));
+  exports.Set("adf", Napi::Function::New(env, batch_adf));
 
   // Streaming
   exports.Set("SMA", SMAWrap::Init(env));

--- a/node/test/test_bindings.js
+++ b/node/test/test_bindings.js
@@ -98,6 +98,39 @@ const sl = flox.targets.future_linear_slope(linear, 4);
 check(approx(sl[0], 0.5), 'targets.future_linear_slope linear-series == 0.5');
 check(Number.isNaN(sl[19]), 'targets.future_linear_slope tail NaN');
 
+// ── ADF stationarity test ─────────────────────────────────────────────
+
+console.log('=== ADF ===');
+
+function gaussian(seed) {
+  // simple deterministic Box-Muller
+  let s = seed;
+  return function() {
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    const u1 = ((s + 1) / 0x80000000);
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    const u2 = ((s + 1) / 0x80000000);
+    return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+  };
+}
+
+const N = 500;
+const gen = gaussian(42);
+const walk = new Float64Array(N);
+walk[0] = 0;
+for (let i = 1; i < N; ++i) walk[i] = walk[i - 1] + gen();
+
+const r = flox.adf(walk, 4, 'c');
+check(r.used_lag <= 4, 'adf used_lag <= max_lag');
+check(r.p_value > 0.05, 'adf does not reject H0 for random walk');
+
+const gen2 = gaussian(7);
+const noise = new Float64Array(N);
+for (let i = 0; i < N; ++i) noise[i] = gen2() * 0.5;
+const r2 = flox.adf(noise, 4, 'c');
+check(r2.test_stat < r.test_stat, 'stationary series produces lower test_stat');
+check(r2.p_value < 0.05, 'adf rejects H0 for white noise');
+
 // ── PositionTracker ───────────────────────────────────────────────────
 
 console.log('=== PositionTracker ===');

--- a/python/indicator_bindings.h
+++ b/python/indicator_bindings.h
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstring>
 
+#include "flox/indicator/adf.h"
 #include "flox/indicator/adx.h"
 #include "flox/indicator/atr.h"
 #include "flox/indicator/bollinger.h"
@@ -1558,6 +1559,26 @@ inline void bindIndicators(py::module_& m)
         return result;
       },
       py::arg("open"), py::arg("high"), py::arg("low"), py::arg("close"), py::arg("period"));
+
+  m.def(
+      "adf",
+      [](contiguous_double input, size_t max_lag, const std::string& regression) -> py::dict
+      {
+        auto buf = input.request();
+        size_t n = buf.shape[0];
+        const auto* p = static_cast<const double*>(buf.ptr);
+        flox::indicator::AdfResult r;
+        {
+          py::gil_scoped_release release;
+          r = flox::indicator::adf(std::span<const double>(p, n), max_lag, regression);
+        }
+        py::dict d;
+        d["test_stat"] = r.test_stat;
+        d["p_value"] = r.p_value;
+        d["used_lag"] = r.used_lag;
+        return d;
+      },
+      py::arg("input"), py::arg("max_lag") = 4, py::arg("regression") = "c");
 
   m.def(
       "correlation",

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -169,6 +169,21 @@ sl = flox.targets.future_linear_slope(linear, 4)
 check(approx(sl[0], 0.5), "future_linear_slope on linear series == 0.5")
 check(math.isnan(sl[19]), "future_linear_slope tail is NaN")
 
+# ── ADF stationarity test ────────────────────────────────────────────
+
+print("=== ADF ===")
+
+rng = np.random.default_rng(42)
+walk = np.cumsum(rng.standard_normal(500))
+res = flox.adf(walk, max_lag=4, regression="c")
+check(res["used_lag"] <= 4, "adf reports used_lag")
+check(res["p_value"] > 0.05, "adf does not reject unit root for random walk")
+
+stationary = rng.standard_normal(500) * 0.5
+res2 = flox.adf(stationary, max_lag=4, regression="c")
+check(res2["test_stat"] < res["test_stat"], "stationary series produces lower test_stat")
+check(res2["p_value"] < 0.05, "adf rejects unit root for white noise")
+
 # ── PositionTracker ───────────────────────────────────────────────────
 
 print("=== PositionTracker ===")

--- a/quickjs/flox/indicators.js
+++ b/quickjs/flox/indicators.js
@@ -781,3 +781,13 @@ class Correlation {
     reset() { this._xs = []; this._ys = []; this._value = NaN; }
     static compute(x, y, period) { return __flox_indicator_correlation(x, y, period); }
 }
+
+// ============================================================
+// Stationarity tests
+// ============================================================
+
+// Augmented Dickey-Fuller test. Returns { test_stat, p_value, used_lag }.
+function adf(data, max_lag, regression) {
+    return __flox_indicator_adf(data, max_lag === undefined ? 4 : max_lag,
+                                regression === undefined ? "c" : regression);
+}

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -25,6 +25,7 @@
 #include "flox/replay/abstract_event_reader.h"
 #include "flox/replay/binary_format_v1.h"
 
+#include "flox/indicator/adf.h"
 #include "flox/indicator/adx.h"
 #include "flox/indicator/atr.h"
 #include "flox/indicator/bollinger.h"
@@ -579,6 +580,25 @@ void flox_indicator_correlation(const double* x, const double* y, size_t len, si
   indicator::Correlation ind(period);
   ind.compute(std::span<const double>(x, len), std::span<const double>(y, len),
               std::span<double>(output, len));
+}
+
+void flox_indicator_adf(const double* input, size_t len, size_t max_lag, const char* regression,
+                        double* test_stat_out, double* p_value_out, size_t* used_lag_out)
+{
+  std::string reg = regression ? regression : "c";
+  auto r = indicator::adf(std::span<const double>(input, len), max_lag, reg);
+  if (test_stat_out)
+  {
+    *test_stat_out = r.test_stat;
+  }
+  if (p_value_out)
+  {
+    *p_value_out = r.p_value;
+  }
+  if (used_lag_out)
+  {
+    *used_lag_out = r.used_lag;
+  }
 }
 
 // ============================================================

--- a/src/quickjs/js_bindings.cpp
+++ b/src/quickjs/js_bindings.cpp
@@ -604,6 +604,30 @@ static JSValue js_indicator_correlation(JSContext* ctx, JSValueConst, int, JSVal
   return jsArrayFromDoubles(ctx, output);
 }
 
+static JSValue js_indicator_adf(JSContext* ctx, JSValueConst, int argc, JSValueConst* argv)
+{
+  auto input = jsArrayToDoubles(ctx, argv[0]);
+  uint32_t maxLag = argc > 1 ? toUint32(ctx, argv[1]) : 4;
+  const char* reg = "c";
+  if (argc > 2 && JS_IsString(argv[2]))
+  {
+    reg = JS_ToCString(ctx, argv[2]);
+  }
+  double testStat = 0.0;
+  double pValue = 0.0;
+  size_t usedLag = 0;
+  flox_indicator_adf(input.data(), input.size(), maxLag, reg, &testStat, &pValue, &usedLag);
+  if (argc > 2 && JS_IsString(argv[2]))
+  {
+    JS_FreeCString(ctx, reg);
+  }
+  JSValue obj = JS_NewObject(ctx);
+  JS_SetPropertyStr(ctx, obj, "test_stat", JS_NewFloat64(ctx, testStat));
+  JS_SetPropertyStr(ctx, obj, "p_value", JS_NewFloat64(ctx, pValue));
+  JS_SetPropertyStr(ctx, obj, "used_lag", JS_NewUint32(ctx, static_cast<uint32_t>(usedLag)));
+  return obj;
+}
+
 // ============================================================
 // Targets (forward-looking labels, batch only)
 // ============================================================
@@ -2220,6 +2244,7 @@ void registerFloxBindings(JSContext* ctx)
   addGlobalFunc(ctx, "__flox_indicator_parkinson_vol", js_indicator_parkinson_vol, 3);
   addGlobalFunc(ctx, "__flox_indicator_rogers_satchell_vol", js_indicator_rogers_satchell_vol, 5);
   addGlobalFunc(ctx, "__flox_indicator_correlation", js_indicator_correlation, 3);
+  addGlobalFunc(ctx, "__flox_indicator_adf", js_indicator_adf, 3);
 
   // Targets (forward-looking labels)
   addGlobalFunc(ctx, "__flox_target_future_return", js_target_future_return, 2);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ endif()
 
 add_flox_test(test_indicators)
 add_flox_test(test_targets)
+add_flox_test(test_adf)
 
 if(FLOX_ENABLE_CAPI)
   add_flox_test(test_capi_registry)

--- a/tests/test_adf.cpp
+++ b/tests/test_adf.cpp
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+#include "flox/indicator/adf.h"
+
+using namespace flox::indicator;
+
+namespace
+{
+
+std::vector<double> randomWalk(size_t n, uint32_t seed = 42, double sigma = 1.0)
+{
+  std::mt19937 rng(seed);
+  std::normal_distribution<double> nd(0.0, sigma);
+  std::vector<double> y(n);
+  y[0] = 0.0;
+  for (size_t i = 1; i < n; ++i)
+  {
+    y[i] = y[i - 1] + nd(rng);
+  }
+  return y;
+}
+
+std::vector<double> stationaryAR1(size_t n, double phi, uint32_t seed = 42, double sigma = 1.0)
+{
+  std::mt19937 rng(seed);
+  std::normal_distribution<double> nd(0.0, sigma);
+  std::vector<double> y(n);
+  y[0] = nd(rng);
+  for (size_t i = 1; i < n; ++i)
+  {
+    y[i] = phi * y[i - 1] + nd(rng);
+  }
+  return y;
+}
+
+}  // namespace
+
+TEST(ADF, RandomWalkIsNonStationary)
+{
+  auto y = randomWalk(500);
+  auto r = adf(y, 4, AdfRegression::Constant);
+  // Random walk: cannot reject the unit-root null at 5%.
+  EXPECT_GT(r.test_stat, -2.861);
+  EXPECT_GT(r.p_value, 0.05);
+  EXPECT_LE(r.used_lag, 4u);
+}
+
+TEST(ADF, StationaryAR1IsRejected)
+{
+  // φ = 0.3 is well inside the unit circle; large sample → easy to reject.
+  auto y = stationaryAR1(500, 0.3);
+  auto r = adf(y, 4, AdfRegression::Constant);
+  EXPECT_LT(r.test_stat, -2.861) << "expected rejection at 5% level, got " << r.test_stat;
+  EXPECT_LT(r.p_value, 0.05);
+}
+
+TEST(ADF, RegressionStringParse)
+{
+  auto y = randomWalk(200);
+  auto rn = adf(y, 2, std::string("n"));
+  auto rc = adf(y, 2, std::string("c"));
+  auto rt = adf(y, 2, std::string("ct"));
+  EXPECT_TRUE(std::isfinite(rn.test_stat));
+  EXPECT_TRUE(std::isfinite(rc.test_stat));
+  EXPECT_TRUE(std::isfinite(rt.test_stat));
+}
+
+TEST(ADF, InvalidRegressionThrows)
+{
+  std::vector<double> y(20, 1.0);
+  EXPECT_THROW(adf(y, 1, std::string("xx")), std::invalid_argument);
+}
+
+TEST(ADF, NaNInputThrows)
+{
+  std::vector<double> y = {1.0, 2.0, std::nan(""), 4.0, 5.0};
+  EXPECT_THROW(adf(y, 1), std::invalid_argument);
+}
+
+TEST(ADF, TooShortInputThrows)
+{
+  std::vector<double> y = {1.0, 2.0, 3.0};
+  EXPECT_THROW(adf(y, 0), std::invalid_argument);
+}
+
+TEST(ADF, ZeroLagWorks)
+{
+  auto y = stationaryAR1(200, 0.5);
+  auto r = adf(y, 0, AdfRegression::Constant);
+  EXPECT_EQ(r.used_lag, 0u);
+  EXPECT_TRUE(std::isfinite(r.test_stat));
+}
+
+TEST(ADF, PValueMonotoneInTestStat)
+{
+  // Ensure p-value monotonicity by feeding two series with very different
+  // strengths of mean reversion.
+  auto rwalk = randomWalk(400);
+  auto stationary = stationaryAR1(400, 0.1);
+
+  auto rWalk = adf(rwalk, 3, AdfRegression::Constant);
+  auto rStat = adf(stationary, 3, AdfRegression::Constant);
+
+  EXPECT_LT(rStat.test_stat, rWalk.test_stat);
+  EXPECT_LE(rStat.p_value, rWalk.p_value);
+}

--- a/tests/test_quickjs.cpp
+++ b/tests/test_quickjs.cpp
@@ -148,6 +148,42 @@ TEST(JsIntegrationTest, TargetsBindings)
   JS_FreeValue(jsStrat.engine().context(), tail);
 }
 
+TEST(JsEngineTest, AdfBindingExposed)
+{
+  FloxJsEngine engine;
+  registerFloxBindings(engine.context());
+
+  // Build a deterministic random walk and call __flox_indicator_adf.
+  EXPECT_TRUE(engine.eval(R"(
+    var n = 200;
+    var seed = 42;
+    function rand() { seed = (seed * 1103515245 + 12345) & 0x7fffffff; return ((seed + 1) / 0x80000000); }
+    function gauss() {
+      var u1 = rand();
+      var u2 = rand();
+      return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+    }
+    var walk = [0];
+    for (var i = 1; i < n; ++i) walk.push(walk[i-1] + gauss());
+    var r = __flox_indicator_adf(walk, 4, "c");
+    var test_stat = r.test_stat;
+    var p_value = r.p_value;
+    var used_lag = r.used_lag;
+  )"));
+
+  JSValue ts = engine.getGlobalProperty("test_stat");
+  double tsVal = 0;
+  JS_ToFloat64(engine.context(), &tsVal, ts);
+  JS_FreeValue(engine.context(), ts);
+  EXPECT_TRUE(std::isfinite(tsVal));
+
+  JSValue ul = engine.getGlobalProperty("used_lag");
+  uint32_t ulVal = 0;
+  JS_ToUint32(engine.context(), &ulVal, ul);
+  JS_FreeValue(engine.context(), ul);
+  EXPECT_LE(ulVal, 4u);
+}
+
 TEST(JsIntegrationTest, LoadStrategyAndResolveSymbols)
 {
   TempJsFile script(R"(


### PR DESCRIPTION
## Summary

Closes #109.

Augmented Dickey-Fuller test for unit-root / stationarity diagnostics — the standard tool for "is this series mean-reverting or trending?" questions. Used in pairs trading, cointegration research, and regime work. Until now the gap pushed users to scipy/statsmodels.

```
adf(x, max_lag, regression="c") -> { test_stat, p_value, used_lag }
```

- Regression modes: `"n"` (none), `"c"` (constant), `"ct"` (constant + trend)
- Lag chosen by AIC over `[0..max_lag]`
- `test_stat` is `β / SE(β)` for the coefficient on `y[t-1]`
- `p_value` is interpolated from MacKinnon (1996) asymptotic critical values — approximate, but correct at the 1%/5%/10% levels. For tighter precision, compare `test_stat` directly to the published table.

Inherently batch — no streaming variant (ADF is a batch test by design, as the issue notes).

## Implementation

- OLS via normal equations + Gauss-Jordan inversion. Self-contained — no external linalg dependency.
- `AdfRegression` enum + string parser keep the API friendly across bindings.

## Bindings

- **C API** — `flox_indicator_adf(input, len, max_lag, regression, &test_stat, &p_value, &used_lag)`
- **Python** — `flox.adf(input, max_lag=4, regression="c")` → `dict`
- **Node** — `flox.adf(input, max_lag, regression)` → object
- **Codon** — `from flox.indicators import adf` → `AdfResult`
- **QuickJS** — `adf(data, max_lag, regression)` (top-level helper in `flox/indicators.js`)

## Test plan

- [x] C++ unit `tests/test_adf.cpp`: random walk does not reject H0; AR(1) with φ=0.3 rejects at 5%; regression-string parser; argument validation; NaN handling; zero-lag path; p-value monotonic in test_stat
- [x] Python smoke (`python/tests/test_bindings.py`): 4 new asserts comparing random walk vs white noise
- [x] Node smoke (`node/test/test_bindings.js`): 4 new asserts
- [x] QuickJS engine test (`JsEngineTest.AdfBindingExposed`): finite test_stat, used_lag ≤ max_lag
- [x] Codon: `codon_adf_smoke` example compiles via the C API
- [x] Full ctest: 45/45 passed
- [x] `clang-format` clean