### PR TITLE
feat(indicator): AutoCorrelation

### DIFF
--- a/codon/CMakeLists.txt
+++ b/codon/CMakeLists.txt
@@ -44,3 +44,6 @@ add_codon_executable(codon_targets_smoke
 
 add_codon_executable(codon_adf_smoke
   ${CMAKE_CURRENT_SOURCE_DIR}/examples/adf_smoke.codon)
+
+add_codon_executable(codon_autocorrelation_smoke
+  ${CMAKE_CURRENT_SOURCE_DIR}/examples/autocorrelation_smoke.codon)

--- a/codon/examples/autocorrelation_smoke.codon
+++ b/codon/examples/autocorrelation_smoke.codon
@@ -1,0 +1,13 @@
+# Smoke test: AutoCorrelation compiles + computes against the C API.
+
+from flox.indicators import autocorrelation, AutoCorrelation
+
+linear = [5.0 + 0.7 * float(i) for i in range(50)]
+ac = autocorrelation(linear, 10, 1)
+print("autocorrelation linear[10] =", ac[10])
+
+stream = AutoCorrelation(10, 1)
+last = 0.0
+for v in linear:
+    last = stream.update(v)
+print("streaming AutoCorrelation last =", last)

--- a/codon/flox/indicators.codon
+++ b/codon/flox/indicators.codon
@@ -35,6 +35,7 @@ from C import flox_indicator_rogers_satchell_vol(Ptr[f64], Ptr[f64], Ptr[f64], P
 from C import flox_indicator_correlation(Ptr[f64], Ptr[f64], int, int, Ptr[f64])
 from C import flox_indicator_adf(Ptr[f64], int, int, cobj,
                                   Ptr[f64], Ptr[f64], Ptr[int])
+from C import flox_indicator_autocorrelation(Ptr[f64], int, int, int, Ptr[f64])
 
 
 # ======================================================================
@@ -1185,6 +1186,70 @@ class Correlation:
         flox_indicator_correlation(x.arr.ptr, y.arr.ptr,
                                    n, period, result.arr.ptr)
         return result
+
+
+class AutoCorrelation:
+    _window: int
+    _lag: int
+    _buf: List[float]
+    _value: float
+
+    def __init__(self, window: int, lag: int):
+        self._window = window
+        self._lag = lag
+        self._buf = list[float]()
+        self._value = 0.0
+
+    def update(self, x: float) -> float:
+        self._buf.append(x)
+        needed = self._window + self._lag
+        if len(self._buf) > needed:
+            self._buf.pop(0)
+        if len(self._buf) >= needed:
+            w = float(self._window)
+            sx = 0.0
+            sy = 0.0
+            sxy = 0.0
+            sx2 = 0.0
+            sy2 = 0.0
+            for i in range(self._window):
+                xi = self._buf[i + self._lag]
+                yi = self._buf[i]
+                sx += xi
+                sy += yi
+                sxy += xi * yi
+                sx2 += xi * xi
+                sy2 += yi * yi
+            num = w * sxy - sx * sy
+            den = math.sqrt((w * sx2 - sx * sx) * (w * sy2 - sy * sy))
+            if den == 0.0:
+                self._value = math.nan
+            else:
+                self._value = num / den
+        return self._value
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @property
+    def ready(self) -> bool:
+        return len(self._buf) >= self._window + self._lag
+
+    def reset(self):
+        self._buf = list[float]()
+        self._value = 0.0
+
+    @staticmethod
+    def compute(data: List[float], window: int, lag: int) -> List[float]:
+        n = len(data)
+        result = [0.0] * n
+        flox_indicator_autocorrelation(data.arr.ptr, n, window, lag, result.arr.ptr)
+        return result
+
+
+def autocorrelation(data: List[float], window: int, lag: int) -> List[float]:
+    return AutoCorrelation.compute(data, window, lag)
 
 
 # Backward compatibility aliases

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -241,6 +241,10 @@ extern "C"
   // Writes the t-statistic, approximate p-value, and AIC-selected lag.
   void flox_indicator_adf(const double* input, size_t len, size_t max_lag, const char* regression,
                           double* test_stat_out, double* p_value_out, size_t* used_lag_out);
+  // AutoCorrelation: Pearson correlation between x[t] and x[t-lag] over a
+  // rolling window. First valid index is (window + lag - 1).
+  void flox_indicator_autocorrelation(const double* input, size_t len, size_t window, size_t lag,
+                                      double* output);
 
   // ============================================================
   // Targets (forward-looking labels, batch only)

--- a/include/flox/indicator/autocorrelation.h
+++ b/include/flox/indicator/autocorrelation.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+// AutoCorrelation(window, lag): Pearson correlation between x[t] and x[t-lag]
+// over a trailing window of `window` paired observations. Equivalent to
+// Correlation(window) applied to (x[lag..], x[..-lag]) but explicit about the
+// lag and warm-up.
+//
+//   first valid index is (window - 1 + lag).
+//
+// Reuses Pearson's standard closed form so output matches Correlation when
+// the same data is paired manually.
+class AutoCorrelation
+{
+ public:
+  AutoCorrelation(size_t window, size_t lag) noexcept : _window(window), _lag(lag)
+  {
+    assert(window >= 2);
+    assert(lag >= 1);
+  }
+
+  std::vector<double> compute(std::span<const double> x) const
+  {
+    std::vector<double> out(x.size(), std::nan(""));
+    if (!x.empty())
+    {
+      compute(x, out);
+    }
+    return out;
+  }
+
+  void compute(std::span<const double> x, std::span<double> output) const
+  {
+    const size_t n = x.size();
+    assert(output.size() >= n);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+      output[i] = std::nan("");
+    }
+
+    const size_t firstValid = _window + _lag - 1;
+    if (n <= firstValid)
+    {
+      return;
+    }
+
+    const double w = static_cast<double>(_window);
+
+    for (size_t t = firstValid; t < n; ++t)
+    {
+      double sx = 0, sy = 0, sxy = 0, sx2 = 0, sy2 = 0;
+      for (size_t i = 0; i < _window; ++i)
+      {
+        double xi = x[t - _window + 1 + i];
+        double yi = x[t - _window + 1 + i - _lag];
+        sx += xi;
+        sy += yi;
+        sxy += xi * yi;
+        sx2 += xi * xi;
+        sy2 += yi * yi;
+      }
+
+      double num = w * sxy - sx * sy;
+      double den = std::sqrt((w * sx2 - sx * sx) * (w * sy2 - sy * sy));
+      if (den == 0.0)
+      {
+        output[t] = std::nan("");
+        continue;
+      }
+      output[t] = num / den;
+    }
+  }
+
+  size_t period() const noexcept { return _window + _lag - 1; }
+  size_t window() const noexcept { return _window; }
+  size_t lag() const noexcept { return _lag; }
+
+ private:
+  size_t _window;
+  size_t _lag;
+};
+
+inline std::vector<double> autocorrelation(std::span<const double> x, size_t window, size_t lag)
+{
+  return AutoCorrelation(window, lag).compute(x);
+}
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::HasPeriod<flox::indicator::AutoCorrelation>);

--- a/node/src/indicators.h
+++ b/node/src/indicators.h
@@ -22,6 +22,7 @@
 #include "flox/indicator/vwap.h"
 
 #include "flox/indicator/adf.h"
+#include "flox/indicator/autocorrelation.h"
 #include "flox/indicator/correlation.h"
 #include "flox/indicator/kurtosis.h"
 #include "flox/indicator/parkinson_vol.h"
@@ -301,6 +302,18 @@ inline Napi::Value batch_adf(const Napi::CallbackInfo& info)
   o.Set("p_value", Napi::Number::New(info.Env(), r.p_value));
   o.Set("used_lag", Napi::Number::New(info.Env(), static_cast<double>(r.used_lag)));
   return o;
+}
+
+inline Napi::Value batch_autocorrelation(const Napi::CallbackInfo& info)
+{
+  auto in = info[0].As<Napi::Float64Array>();
+  size_t n = in.ElementLength();
+  size_t window = info[1].As<Napi::Number>().Uint32Value();
+  size_t lag = info[2].As<Napi::Number>().Uint32Value();
+  std::vector<double> out(n);
+  flox::indicator::AutoCorrelation(window, lag)
+      .compute(std::span<const double>(in.Data(), n), std::span<double>(out.data(), n));
+  return vec2arr(info.Env(), out);
 }
 
 // ── Streaming indicator classes ─────────────────────────────────────
@@ -1515,6 +1528,73 @@ class CorrelationWrap : public Napi::ObjectWrap<CorrelationWrap>
   std::vector<double> _xbuf, _ybuf;
 };
 
+class AutoCorrelationWrap : public Napi::ObjectWrap<AutoCorrelationWrap>
+{
+ public:
+  static Napi::Function Init(Napi::Env env)
+  {
+    return DefineClass(env, "AutoCorrelation",
+                       {InstanceMethod("update", &AutoCorrelationWrap::Update),
+                        InstanceMethod("reset", &AutoCorrelationWrap::Reset),
+                        InstanceAccessor("value", &AutoCorrelationWrap::Value, nullptr),
+                        InstanceAccessor("ready", &AutoCorrelationWrap::Ready, nullptr)});
+  }
+  AutoCorrelationWrap(const Napi::CallbackInfo& info)
+      : Napi::ObjectWrap<AutoCorrelationWrap>(info),
+        _window(info[0].As<Napi::Number>().Uint32Value()),
+        _lag(info[1].As<Napi::Number>().Uint32Value()) {}
+
+ private:
+  Napi::Value Update(const Napi::CallbackInfo& info)
+  {
+    double x = info[0].As<Napi::Number>().DoubleValue();
+    _buf.push_back(x);
+    size_t needed = _window + _lag;
+    if (_buf.size() > needed)
+    {
+      _buf.erase(_buf.begin());
+    }
+    if (_buf.size() < needed)
+    {
+      return info.Env().Undefined();
+    }
+    double w = static_cast<double>(_window);
+    double sx = 0, sy = 0, sxy = 0, sx2 = 0, sy2 = 0;
+    for (size_t i = 0; i < _window; ++i)
+    {
+      double xi = _buf[i + _lag];
+      double yi = _buf[i];
+      sx += xi;
+      sy += yi;
+      sxy += xi * yi;
+      sx2 += xi * xi;
+      sy2 += yi * yi;
+    }
+    double num = w * sxy - sx * sy;
+    double den = std::sqrt((w * sx2 - sx * sx) * (w * sy2 - sy * sy));
+    if (den == 0.0)
+    {
+      return info.Env().Undefined();
+    }
+    _v = num / den;
+    return Napi::Number::New(info.Env(), _v);
+  }
+  Napi::Value Value(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), _v); }
+  Napi::Value Ready(const Napi::CallbackInfo& info)
+  {
+    return Napi::Boolean::New(info.Env(), _buf.size() >= _window + _lag);
+  }
+  void Reset(const Napi::CallbackInfo&)
+  {
+    _v = 0;
+    _buf.clear();
+  }
+  size_t _window;
+  size_t _lag;
+  double _v = 0;
+  std::vector<double> _buf;
+};
+
 // ── Registration ────────────────────────────────────────────────────
 
 inline void registerIndicators(Napi::Env env, Napi::Object exports)
@@ -1546,6 +1626,7 @@ inline void registerIndicators(Napi::Env env, Napi::Object exports)
   exports.Set("rogers_satchell_vol", Napi::Function::New(env, batch_rogers_satchell_vol));
   exports.Set("correlation", Napi::Function::New(env, batch_correlation));
   exports.Set("adf", Napi::Function::New(env, batch_adf));
+  exports.Set("autocorrelation", Napi::Function::New(env, batch_autocorrelation));
 
   // Streaming
   exports.Set("SMA", SMAWrap::Init(env));
@@ -1571,6 +1652,7 @@ inline void registerIndicators(Napi::Env env, Napi::Object exports)
   exports.Set("ParkinsonVol", ParkinsonVolWrap::Init(env));
   exports.Set("RogersSatchellVol", RogersSatchellVolWrap::Init(env));
   exports.Set("Correlation", CorrelationWrap::Init(env));
+  exports.Set("AutoCorrelation", AutoCorrelationWrap::Init(env));
 }
 
 }  // namespace node_flox

--- a/node/test/test_bindings.js
+++ b/node/test/test_bindings.js
@@ -130,6 +130,23 @@ for (let i = 0; i < N; ++i) noise[i] = gen2() * 0.5;
 const r2 = flox.adf(noise, 4, 'c');
 check(r2.test_stat < r.test_stat, 'stationary series produces lower test_stat');
 check(r2.p_value < 0.05, 'adf rejects H0 for white noise');
+// ── AutoCorrelation ───────────────────────────────────────────────────
+
+console.log('=== AutoCorrelation ===');
+
+const acLinear = new Float64Array(50);
+for (let i = 0; i < 50; ++i) acLinear[i] = 5.0 + 0.7 * i;
+const ac = flox.autocorrelation(acLinear, 10, 1);
+check(Number.isNaN(ac[9]), 'autocorrelation warmup is NaN');
+check(approx(ac[10], 1.0), 'autocorrelation linear lag=1 == 1.0');
+
+const acStream = new flox.AutoCorrelation(10, 1);
+let lastStreamed = undefined;
+for (let i = 0; i < acLinear.length; ++i) {
+  lastStreamed = acStream.update(acLinear[i]);
+}
+check(approx(lastStreamed, ac[ac.length - 1]),
+      'streaming AutoCorrelation matches batch on last index');
 
 // ── PositionTracker ───────────────────────────────────────────────────
 

--- a/python/indicator_bindings.h
+++ b/python/indicator_bindings.h
@@ -11,6 +11,7 @@
 #include "flox/indicator/adf.h"
 #include "flox/indicator/adx.h"
 #include "flox/indicator/atr.h"
+#include "flox/indicator/autocorrelation.h"
 #include "flox/indicator/bollinger.h"
 #include "flox/indicator/cci.h"
 #include "flox/indicator/chop.h"
@@ -1087,6 +1088,59 @@ class PyCorrelation
   std::vector<double> _xbuf, _ybuf;
 };
 
+class PyAutoCorrelation
+{
+ public:
+  PyAutoCorrelation(size_t window, size_t lag) : _window(window), _lag(lag) {}
+  py::object update(double x)
+  {
+    _buf.push_back(x);
+    size_t needed = _window + _lag;
+    if (_buf.size() > needed)
+    {
+      _buf.erase(_buf.begin());
+    }
+    if (_buf.size() < needed)
+    {
+      return py::none();
+    }
+    double w = static_cast<double>(_window);
+    double sx = 0, sy = 0, sxy = 0, sx2 = 0, sy2 = 0;
+    for (size_t i = 0; i < _window; ++i)
+    {
+      double xi = _buf[i + _lag];
+      double yi = _buf[i];
+      sx += xi;
+      sy += yi;
+      sxy += xi * yi;
+      sx2 += xi * xi;
+      sy2 += yi * yi;
+    }
+    double num = w * sxy - sx * sy;
+    double den = std::sqrt((w * sx2 - sx * sx) * (w * sy2 - sy * sy));
+    if (den == 0.0)
+    {
+      return py::none();
+    }
+    _value = num / den;
+    return py::cast(_value);
+  }
+  py::object getValue() const { return optVal(_value, isReady()); }
+  bool isReady() const { return _buf.size() >= _window + _lag; }
+  void reset()
+  {
+    _value = 0;
+    _buf.clear();
+  }
+  PyAutoCorrelation fresh() const { return PyAutoCorrelation(_window, _lag); }
+
+ private:
+  size_t _window;
+  size_t _lag;
+  double _value = 0;
+  std::vector<double> _buf;
+};
+
 }  // namespace
 
 inline void bindIndicators(py::module_& m)
@@ -1581,6 +1635,23 @@ inline void bindIndicators(py::module_& m)
       py::arg("input"), py::arg("max_lag") = 4, py::arg("regression") = "c");
 
   m.def(
+      "autocorrelation",
+      [](contiguous_double input, size_t window, size_t lag) -> py::array_t<double>
+      {
+        size_t n = input.request().shape[0];
+        const double* p = input.data();
+        py::array_t<double> result(n);
+        auto* o = result.mutable_data();
+        {
+          py::gil_scoped_release release;
+          flox::indicator::AutoCorrelation(window, lag)
+              .compute(std::span<const double>(p, n), std::span<double>(o, n));
+        }
+        return result;
+      },
+      py::arg("input"), py::arg("window"), py::arg("lag"));
+
+  m.def(
       "correlation",
       [](contiguous_double x, contiguous_double y, size_t period) -> py::array_t<double>
       {
@@ -1794,4 +1865,12 @@ inline void bindIndicators(py::module_& m)
       .def("fresh", &PyCorrelation::fresh)
       .def_property_readonly("value", &PyCorrelation::getValue)
       .def_property_readonly("ready", &PyCorrelation::isReady);
+
+  py::class_<PyAutoCorrelation>(m, "AutoCorrelation")
+      .def(py::init<size_t, size_t>(), py::arg("window"), py::arg("lag"))
+      .def("update", &PyAutoCorrelation::update, py::arg("value"))
+      .def("reset", &PyAutoCorrelation::reset)
+      .def("fresh", &PyAutoCorrelation::fresh)
+      .def_property_readonly("value", &PyAutoCorrelation::getValue)
+      .def_property_readonly("ready", &PyAutoCorrelation::isReady);
 }

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -183,6 +183,28 @@ stationary = rng.standard_normal(500) * 0.5
 res2 = flox.adf(stationary, max_lag=4, regression="c")
 check(res2["test_stat"] < res["test_stat"], "stationary series produces lower test_stat")
 check(res2["p_value"] < 0.05, "adf rejects unit root for white noise")
+# ── AutoCorrelation ──────────────────────────────────────────────────
+
+print("=== AutoCorrelation ===")
+
+# Linear y = a + b*t -> lag-1 autocorrelation == 1.
+ac_linear = np.array([5.0 + 0.7 * i for i in range(50)])
+ac = flox.autocorrelation(ac_linear, 10, 1)
+check(math.isnan(ac[9]), "autocorrelation warmup at index < window+lag-1 is NaN")
+check(approx(ac[10], 1.0), "autocorrelation on linear series, lag=1 == 1.0")
+check(approx(ac[40], 1.0), "autocorrelation on linear series at later index == 1.0")
+
+# Streaming class matches the batch function on the same input.
+stream = flox.AutoCorrelation(10, 1)
+streamed = []
+for v in ac_linear:
+    streamed.append(stream.update(float(v)))
+# Streaming is ready at index window+lag-1 = 10 (0-based).
+for i in range(10, len(ac_linear)):
+    check(approx(float(streamed[i]), float(ac[i])),
+          f"streaming AC matches batch at i={i}")
+    if i >= 10:
+        break  # one assertion is enough to keep noise down
 
 # ── PositionTracker ───────────────────────────────────────────────────
 

--- a/quickjs/flox/indicators.js
+++ b/quickjs/flox/indicators.js
@@ -791,3 +791,40 @@ function adf(data, max_lag, regression) {
     return __flox_indicator_adf(data, max_lag === undefined ? 4 : max_lag,
                                 regression === undefined ? "c" : regression);
 }
+
+// ============================================================
+// AutoCorrelation
+// ============================================================
+
+class AutoCorrelation {
+    constructor(window, lag) {
+        this._window = window;
+        this._lag = lag;
+        this._buf = [];
+        this._value = NaN;
+    }
+    update(x) {
+        this._buf.push(x);
+        var needed = this._window + this._lag;
+        if (this._buf.length > needed) this._buf.shift();
+        if (this._buf.length < needed) return this._value;
+        var w = this._window;
+        var sx = 0, sy = 0, sxy = 0, sx2 = 0, sy2 = 0;
+        for (var i = 0; i < w; ++i) {
+            var xi = this._buf[i + this._lag];
+            var yi = this._buf[i];
+            sx += xi; sy += yi;
+            sxy += xi * yi;
+            sx2 += xi * xi;
+            sy2 += yi * yi;
+        }
+        var num = w * sxy - sx * sy;
+        var den = Math.sqrt((w * sx2 - sx * sx) * (w * sy2 - sy * sy));
+        this._value = den === 0 ? NaN : num / den;
+        return this._value;
+    }
+    get value() { return this._value; }
+    get ready() { return this._buf.length >= this._window + this._lag; }
+    reset() { this._buf = []; this._value = NaN; }
+    static compute(data, window, lag) { return __flox_indicator_autocorrelation(data, window, lag); }
+}

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -28,6 +28,7 @@
 #include "flox/indicator/adf.h"
 #include "flox/indicator/adx.h"
 #include "flox/indicator/atr.h"
+#include "flox/indicator/autocorrelation.h"
 #include "flox/indicator/bollinger.h"
 #include "flox/indicator/cci.h"
 #include "flox/indicator/chop.h"
@@ -599,6 +600,13 @@ void flox_indicator_adf(const double* input, size_t len, size_t max_lag, const c
   {
     *used_lag_out = r.used_lag;
   }
+}
+
+void flox_indicator_autocorrelation(const double* input, size_t len, size_t window, size_t lag,
+                                    double* output)
+{
+  indicator::AutoCorrelation ind(window, lag);
+  ind.compute(std::span<const double>(input, len), std::span<double>(output, len));
 }
 
 // ============================================================

--- a/src/quickjs/js_bindings.cpp
+++ b/src/quickjs/js_bindings.cpp
@@ -628,6 +628,18 @@ static JSValue js_indicator_adf(JSContext* ctx, JSValueConst, int argc, JSValueC
   return obj;
 }
 
+static JSValue js_indicator_autocorrelation(JSContext* ctx, JSValueConst, int,
+                                            JSValueConst* argv)
+{
+  auto in = jsArrayToDoubles(ctx, argv[0]);
+  uint32_t window = toUint32(ctx, argv[1]);
+  uint32_t lag = toUint32(ctx, argv[2]);
+  size_t len = in.size();
+  std::vector<double> output(len);
+  flox_indicator_autocorrelation(in.data(), len, window, lag, output.data());
+  return jsArrayFromDoubles(ctx, output);
+}
+
 // ============================================================
 // Targets (forward-looking labels, batch only)
 // ============================================================
@@ -2245,6 +2257,7 @@ void registerFloxBindings(JSContext* ctx)
   addGlobalFunc(ctx, "__flox_indicator_rogers_satchell_vol", js_indicator_rogers_satchell_vol, 5);
   addGlobalFunc(ctx, "__flox_indicator_correlation", js_indicator_correlation, 3);
   addGlobalFunc(ctx, "__flox_indicator_adf", js_indicator_adf, 3);
+  addGlobalFunc(ctx, "__flox_indicator_autocorrelation", js_indicator_autocorrelation, 3);
 
   // Targets (forward-looking labels)
   addGlobalFunc(ctx, "__flox_target_future_return", js_target_future_return, 2);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ endif()
 add_flox_test(test_indicators)
 add_flox_test(test_targets)
 add_flox_test(test_adf)
+add_flox_test(test_autocorrelation)
 
 if(FLOX_ENABLE_CAPI)
   add_flox_test(test_capi_registry)

--- a/tests/test_autocorrelation.cpp
+++ b/tests/test_autocorrelation.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+#include "flox/indicator/autocorrelation.h"
+#include "flox/indicator/correlation.h"
+
+using namespace flox::indicator;
+
+TEST(AutoCorrelation, MatchesCorrelationOnPairedSeries)
+{
+  // Reference: build (x[lag..], x[..-lag]) explicitly and run Correlation.
+  std::mt19937 rng(123);
+  std::uniform_real_distribution<double> u(-1.0, 1.0);
+  std::vector<double> x(50);
+  for (auto& v : x)
+  {
+    v = u(rng);
+  }
+
+  const size_t window = 10;
+  const size_t lag = 3;
+
+  auto autoOut = AutoCorrelation(window, lag).compute(x);
+
+  std::vector<double> a(x.begin() + lag, x.end());
+  std::vector<double> b(x.begin(), x.end() - lag);
+  auto refOut = Correlation(window).compute(a, b);
+
+  // AutoCorrelation reports at index (t in original frame) = window+lag-1+i;
+  // Correlation on the paired arrays reports at index (window-1+i).
+  for (size_t i = 0; i + window - 1 < a.size(); ++i)
+  {
+    size_t origIdx = window + lag - 1 + i;
+    size_t pairedIdx = window - 1 + i;
+    if (std::isnan(refOut[pairedIdx]))
+    {
+      EXPECT_TRUE(std::isnan(autoOut[origIdx]));
+    }
+    else
+    {
+      EXPECT_NEAR(autoOut[origIdx], refOut[pairedIdx], 1e-12);
+    }
+  }
+}
+
+TEST(AutoCorrelation, WarmupNaN)
+{
+  std::vector<double> x(20, 1.0);
+  auto out = AutoCorrelation(5, 2).compute(x);
+  // First valid index is window+lag-1 = 6.
+  for (size_t i = 0; i < 6; ++i)
+  {
+    EXPECT_TRUE(std::isnan(out[i]));
+  }
+}
+
+TEST(AutoCorrelation, ConstantSeriesIsNan)
+{
+  // Zero variance → undefined correlation.
+  std::vector<double> x(30, 1.0);
+  auto out = AutoCorrelation(5, 1).compute(x);
+  for (size_t i = 5; i < x.size(); ++i)
+  {
+    EXPECT_TRUE(std::isnan(out[i])) << "i=" << i;
+  }
+}
+
+TEST(AutoCorrelation, LinearSeriesLag1IsOne)
+{
+  // For y = a + b*t, lag-1 autocorrelation over any window is exactly 1
+  // (perfect linear pairing).
+  std::vector<double> x(50);
+  for (size_t i = 0; i < x.size(); ++i)
+  {
+    x[i] = 5.0 + 0.7 * static_cast<double>(i);
+  }
+  auto out = AutoCorrelation(10, 1).compute(x);
+  for (size_t i = 10; i < x.size(); ++i)
+  {
+    EXPECT_NEAR(out[i], 1.0, 1e-10) << "i=" << i;
+  }
+}
+
+TEST(AutoCorrelation, FreeFunctionMatchesClass)
+{
+  std::vector<double> x = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto a = AutoCorrelation(3, 1).compute(x);
+  auto b = autocorrelation(x, 3, 1);
+  ASSERT_EQ(a.size(), b.size());
+  for (size_t i = 0; i < a.size(); ++i)
+  {
+    if (std::isnan(a[i]))
+    {
+      EXPECT_TRUE(std::isnan(b[i]));
+    }
+    else
+    {
+      EXPECT_DOUBLE_EQ(a[i], b[i]);
+    }
+  }
+}

--- a/tests/test_quickjs.cpp
+++ b/tests/test_quickjs.cpp
@@ -184,6 +184,46 @@ TEST(JsEngineTest, AdfBindingExposed)
   EXPECT_LE(ulVal, 4u);
 }
 
+TEST(JsIntegrationTest, AutoCorrelationBindings)
+{
+  TempJsFile script(R"(
+    var linear = [];
+    for (var i = 0; i < 50; ++i) linear.push(5.0 + 0.7 * i);
+
+    // Batch: AutoCorrelation.compute / __flox_indicator_autocorrelation.
+    var ac = AutoCorrelation.compute(linear, 10, 1);
+    var batch_at_10 = ac[10];
+    var warmup_nan = isNaN(ac[9]);
+
+    // Streaming class.
+    var stream = new AutoCorrelation(10, 1);
+    var lastStream = NaN;
+    for (var j = 0; j < linear.length; ++j) {
+      lastStream = stream.update(linear[j]);
+    }
+    var stream_eq_batch = Math.abs(lastStream - ac[ac.length - 1]) < 1e-9;
+  )");
+
+  SymbolRegistry registry;
+  FloxJsStrategy jsStrat(script.path(), registry);
+
+  auto* ctx = jsStrat.engine().context();
+
+  JSValue v = jsStrat.engine().getGlobalProperty("batch_at_10");
+  double d = 0;
+  JS_ToFloat64(ctx, &d, v);
+  JS_FreeValue(ctx, v);
+  EXPECT_NEAR(d, 1.0, 1e-10);
+
+  JSValue w = jsStrat.engine().getGlobalProperty("warmup_nan");
+  EXPECT_TRUE(JS_ToBool(ctx, w));
+  JS_FreeValue(ctx, w);
+
+  JSValue eq = jsStrat.engine().getGlobalProperty("stream_eq_batch");
+  EXPECT_TRUE(JS_ToBool(ctx, eq));
+  JS_FreeValue(ctx, eq);
+}
+
 TEST(JsIntegrationTest, LoadStrategyAndResolveSymbols)
 {
   TempJsFile script(R"(


### PR DESCRIPTION
## Summary

Closes #108.

`Correlation(x, y, window)` exists; `AutoCorrelation(x, window, lag)` did not. Until now users had to express it as `Correlation(x[lag:], x[:-lag], window)` — easy to get wrong on alignment and head NaNs.

```
AutoCorrelation(window, lag).compute(x)
autocorrelation(x, window, lag)
```

Pearson correlation between `x[t]` and `x[t-lag]` over the trailing window of `window` paired observations. First valid index is `window + lag - 1`. By construction matches `Correlation(window)` applied to `(x[lag:], x[:-lag])` — verified in tests.

Common need for serial-dependence / mean-reversion diagnostics.

## Bindings

Both batch and streaming exposed across all surfaces, mirroring the existing `Correlation` ones:

- **C API** — `flox_indicator_autocorrelation(input, len, window, lag, output)`
- **Python** — `flox.autocorrelation(input, window, lag)` batch; `flox.AutoCorrelation(window, lag)` streaming class with `update / value / ready / reset / fresh`, matching the warm-up semantics of every other Py streaming indicator.
- **Node** — `flox.autocorrelation` batch; `flox.AutoCorrelation` streaming class
- **Codon** — `AutoCorrelation` class with `.update` / `.compute`; `autocorrelation()` free function
- **QuickJS** — `AutoCorrelation` class with streaming `update` / `value` / `ready`; `AutoCorrelation.compute(data, window, lag)` static

## Test plan

- [x] C++ unit (`tests/test_autocorrelation.cpp`):
  - Equivalence to `Correlation` on `(x[lag:], x[:-lag])` on a 50-sample random series
  - Warm-up NaN before `window + lag - 1`
  - Constant series → NaN (zero variance)
  - Lag-1 ACF on a linear series == 1
  - Free function matches class output
- [x] Python smoke: warm-up NaN, lag-1 == 1 on linear series, streaming matches batch
- [x] Node smoke: same three asserts, plus streaming class
- [x] QuickJS integration (`JsIntegrationTest.AutoCorrelationBindings`): batch correctness + streaming-vs-batch equivalence
- [x] Codon: `codon_autocorrelation_smoke` example compiles via the C API
- [x] Full ctest: 45/45 passed
- [x] `clang-format` clean