### PR TITLE
feat(bindings): expose IndicatorGraph (batch)

### DIFF
--- a/codon/CMakeLists.txt
+++ b/codon/CMakeLists.txt
@@ -47,3 +47,6 @@ add_codon_executable(codon_adf_smoke
 
 add_codon_executable(codon_autocorrelation_smoke
   ${CMAKE_CURRENT_SOURCE_DIR}/examples/autocorrelation_smoke.codon)
+
+add_codon_executable(codon_graph_smoke
+  ${CMAKE_CURRENT_SOURCE_DIR}/examples/graph_smoke.codon)

--- a/codon/examples/graph_smoke.codon
+++ b/codon/examples/graph_smoke.codon
@@ -1,0 +1,18 @@
+# Smoke test: IndicatorGraph (batch) bindings via the C API.
+# Tests the surface that doesn't need a Codon-side closure
+# (set_bars / require on field accessor / get).
+
+from flox.graph import IndicatorGraph
+
+close = [float(i) for i in range(20)]
+g = IndicatorGraph()
+g.set_bars(0, close)
+
+c = g.close(0)
+print("len(close) =", len(c))
+print("close[0] =", c[0])
+print("close[19] =", c[19])
+
+# get on a non-existent node returns None.
+maybe = g.get(0, "missing")
+print("get missing is None =", maybe is None)

--- a/codon/flox/graph.codon
+++ b/codon/flox/graph.codon
@@ -1,0 +1,109 @@
+# flox/graph.codon -- IndicatorGraph (batch) bindings via the C API.
+#
+# Compose batch indicators with shared intermediate caching. Mirrors the
+# C++ flox::indicator::IndicatorGraph surface.
+#
+# Usage:
+#   from flox.graph import IndicatorGraph
+#   from flox.indicators import ema, sma
+#
+#   g = IndicatorGraph()
+#   g.set_bars(0, close)
+#   g.add_node("ema50", [], lambda graph, sym: ema(graph.close(sym), 50))
+#   out = g.require(0, "ema50")
+
+from C import flox_indicator_graph_create() -> cobj
+from C import flox_indicator_graph_destroy(cobj)
+from C import flox_indicator_graph_set_bars(cobj, u32, Ptr[f64], Ptr[f64], Ptr[f64], Ptr[f64], int)
+from C import flox_indicator_graph_add_node(cobj, cobj, Ptr[cobj], int, cobj, cobj)
+from C import flox_indicator_graph_require(cobj, u32, cobj, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_get(cobj, u32, cobj, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_close(cobj, u32, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_high(cobj, u32, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_low(cobj, u32, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_volume(cobj, u32, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_invalidate(cobj, u32)
+from C import flox_indicator_graph_invalidate_all(cobj)
+
+
+def _ptr_to_list(p: Ptr[f64], n: int) -> List[float]:
+    out = [0.0] * n
+    for i in range(n):
+        out[i] = p[i]
+    return out
+
+
+class IndicatorGraph:
+    _h: cobj
+
+    def __init__(self):
+        self._h = flox_indicator_graph_create()
+
+    def __del__(self):
+        if self._h != cobj():
+            flox_indicator_graph_destroy(self._h)
+            self._h = cobj()
+
+    def set_bars(self, symbol: int, close: List[float],
+                 high: List[float] = None, low: List[float] = None,
+                 volume: List[float] = None):
+        n = len(close)
+        h_ptr = high.arr.ptr if high is not None else Ptr[f64]()
+        l_ptr = low.arr.ptr if low is not None else Ptr[f64]()
+        v_ptr = volume.arr.ptr if volume is not None else Ptr[f64]()
+        flox_indicator_graph_set_bars(self._h, u32(symbol), close.arr.ptr,
+                                      h_ptr, l_ptr, v_ptr, n)
+
+    def require(self, symbol: int, name: str) -> List[float]:
+        out_len = [0]
+        p = flox_indicator_graph_require(self._h, u32(symbol), name.c_str(), out_len.arr.ptr)
+        if int(p) == 0:
+            raise ValueError("graph: require failed for node " + name)
+        return _ptr_to_list(p, out_len[0])
+
+    def get(self, symbol: int, name: str) -> Optional[List[float]]:
+        out_len = [0]
+        p = flox_indicator_graph_get(self._h, u32(symbol), name.c_str(), out_len.arr.ptr)
+        if int(p) == 0:
+            return None
+        return _ptr_to_list(p, out_len[0])
+
+    def close(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_indicator_graph_close(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    def high(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_indicator_graph_high(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    def low(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_indicator_graph_low(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    def volume(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_indicator_graph_volume(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    def invalidate(self, symbol: int):
+        flox_indicator_graph_invalidate(self._h, u32(symbol))
+
+    def invalidate_all(self):
+        flox_indicator_graph_invalidate_all(self._h)
+
+    # add_node from Codon requires the user to supply a C-compatible
+    # function pointer (top-level function with the FloxGraphNodeFn
+    # signature) rather than a closure. Pass `fn_ptr` as cobj and
+    # `user_data` as cobj or Ptr; the graph keeps both alive.
+    def add_node_raw(self, name: str, deps: List[str],
+                     fn_ptr: cobj, user_data: cobj = cobj()):
+        n = len(deps)
+        # Build a Ptr[cobj] of C-string pointers for deps.
+        dep_ptrs = Ptr[cobj](n) if n > 0 else Ptr[cobj]()
+        for i in range(n):
+            dep_ptrs[i] = deps[i].c_str()
+        flox_indicator_graph_add_node(self._h, name.c_str(), dep_ptrs, n,
+                                      fn_ptr, user_data)

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -261,6 +261,66 @@ extern "C"
                                        double* output);
 
   // ============================================================
+  // IndicatorGraph (batch)
+  //
+  // Compose batch indicators with shared intermediate caching. Nodes are
+  // user-supplied callbacks; require() walks the DAG in topological order.
+  //
+  //   FloxIndicatorGraphHandle g = flox_indicator_graph_create();
+  //   flox_indicator_graph_set_bars(g, sym, close, high, low, volume, n);
+  //   flox_indicator_graph_add_node(g, "ema50", NULL, 0, ema_fn, ema_state);
+  //   const double* out = flox_indicator_graph_require(g, sym, "ema50", &len);
+  //   flox_indicator_graph_destroy(g);
+  // ============================================================
+
+  typedef void* FloxIndicatorGraphHandle;
+
+  // Compute callback. Output array must be allocated by the callback (or pre-
+  // allocated by the user). The host language is responsible for keeping it
+  // alive until the next graph call. Returning a pointer with len = 0 signals
+  // an empty result.
+  typedef const double* (*FloxGraphNodeFn)(void* user_data, FloxIndicatorGraphHandle g,
+                                           uint32_t symbol, size_t* out_len);
+
+  FloxIndicatorGraphHandle flox_indicator_graph_create(void);
+  void flox_indicator_graph_destroy(FloxIndicatorGraphHandle g);
+
+  // Pass NULL for high/low/volume to default high=low=close and volume=0.
+  void flox_indicator_graph_set_bars(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                     const double* close, const double* high, const double* low,
+                                     const double* volume, size_t len);
+
+  // deps: array of `num_deps` C-string node names (or NULL if num_deps == 0).
+  void flox_indicator_graph_add_node(FloxIndicatorGraphHandle g, const char* name,
+                                     const char* const* deps, size_t num_deps,
+                                     FloxGraphNodeFn fn, void* user_data);
+
+  // Returns a pointer to the cached output for (symbol, name) and writes its
+  // length to *len_out. The pointer is owned by the graph and is valid until
+  // the next invalidate / destroy call. Returns NULL on error (unknown node,
+  // cycle, etc.).
+  const double* flox_indicator_graph_require(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                             const char* name, size_t* len_out);
+
+  // Same as require but only returns a pointer if the node has already been
+  // computed; never triggers compute. Returns NULL if not yet computed.
+  const double* flox_indicator_graph_get(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                         const char* name, size_t* len_out);
+
+  // Field accessors return cached double arrays for the symbol's bars.
+  const double* flox_indicator_graph_close(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                           size_t* len_out);
+  const double* flox_indicator_graph_high(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                          size_t* len_out);
+  const double* flox_indicator_graph_low(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                         size_t* len_out);
+  const double* flox_indicator_graph_volume(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                            size_t* len_out);
+
+  void flox_indicator_graph_invalidate(FloxIndicatorGraphHandle g, uint32_t symbol);
+  void flox_indicator_graph_invalidate_all(FloxIndicatorGraphHandle g);
+
+  // ============================================================
   // Order book
   // ============================================================
 

--- a/node/src/flox_node.cpp
+++ b/node/src/flox_node.cpp
@@ -7,6 +7,7 @@
 #include "books.h"
 #include "data_ops.h"
 #include "engine.h"
+#include "graph.h"
 #include "indicators.h"
 #include "positions.h"
 #include "profiles.h"
@@ -27,6 +28,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports)
   node_flox::registerDataOps(env, exports);
   node_flox::registerStrategy(env, exports);
   node_flox::registerTargets(env, exports);
+  node_flox::registerGraph(env, exports);
   return exports;
 }
 

--- a/node/src/graph.h
+++ b/node/src/graph.h
@@ -1,0 +1,195 @@
+// node/src/graph.h -- IndicatorGraph (batch) wrapper.
+
+#pragma once
+#include <napi.h>
+
+#include <cstring>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "flox/aggregator/bar.h"
+#include "flox/common.h"
+#include "flox/indicator/indicator_pipeline.h"
+
+namespace node_flox
+{
+
+class IndicatorGraphWrap : public Napi::ObjectWrap<IndicatorGraphWrap>
+{
+ public:
+  static Napi::Function Init(Napi::Env env)
+  {
+    return DefineClass(env, "IndicatorGraph",
+                       {InstanceMethod("setBars", &IndicatorGraphWrap::SetBars),
+                        InstanceMethod("addNode", &IndicatorGraphWrap::AddNode),
+                        InstanceMethod("require", &IndicatorGraphWrap::Require),
+                        InstanceMethod("get", &IndicatorGraphWrap::Get),
+                        InstanceMethod("close", &IndicatorGraphWrap::Close),
+                        InstanceMethod("high", &IndicatorGraphWrap::High),
+                        InstanceMethod("low", &IndicatorGraphWrap::Low),
+                        InstanceMethod("volume", &IndicatorGraphWrap::Volume),
+                        InstanceMethod("invalidate", &IndicatorGraphWrap::Invalidate),
+                        InstanceMethod("invalidateAll", &IndicatorGraphWrap::InvalidateAll)});
+  }
+
+  IndicatorGraphWrap(const Napi::CallbackInfo& info)
+      : Napi::ObjectWrap<IndicatorGraphWrap>(info), _self(info.This().As<Napi::Object>().Get("__handle__"))
+  {
+    // _self is unused; we store info.This() via a persistent reference inside addNode.
+  }
+
+ private:
+  Napi::Value vec2arr(Napi::Env env, const std::vector<double>& v)
+  {
+    auto a = Napi::Float64Array::New(env, v.size());
+    std::memcpy(a.Data(), v.data(), v.size() * sizeof(double));
+    return a;
+  }
+
+  Napi::Value SetBars(const Napi::CallbackInfo& info)
+  {
+    auto env = info.Env();
+    uint32_t symbol = info[0].As<Napi::Number>().Uint32Value();
+    auto close = info[1].As<Napi::Float64Array>();
+    size_t n = close.ElementLength();
+
+    auto fetch = [&](size_t idx) -> const double*
+    {
+      if (info.Length() <= idx || info[idx].IsUndefined() || info[idx].IsNull())
+      {
+        return nullptr;
+      }
+      auto a = info[idx].As<Napi::Float64Array>();
+      if (a.ElementLength() != n)
+      {
+        Napi::TypeError::New(env, "setBars: arrays must match close length")
+            .ThrowAsJavaScriptException();
+        return nullptr;
+      }
+      return a.Data();
+    };
+
+    const double* h = fetch(2);
+    const double* l = fetch(3);
+    const double* v = fetch(4);
+    const double* c = close.Data();
+
+    std::vector<flox::Bar> bars(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+      bars[i].open = flox::Price::fromDouble(c[i]);
+      bars[i].high = flox::Price::fromDouble(h ? h[i] : c[i]);
+      bars[i].low = flox::Price::fromDouble(l ? l[i] : c[i]);
+      bars[i].close = flox::Price::fromDouble(c[i]);
+      bars[i].volume = v ? flox::Volume::fromDouble(v[i]) : flox::Volume{};
+    }
+    _bars[symbol] = std::move(bars);
+    _graph.setBars(static_cast<flox::SymbolId>(symbol),
+                   std::span<const flox::Bar>(_bars[symbol]));
+    return env.Undefined();
+  }
+
+  Napi::Value AddNode(const Napi::CallbackInfo& info)
+  {
+    auto env = info.Env();
+    std::string name = info[0].As<Napi::String>().Utf8Value();
+
+    auto depsArr = info[1].As<Napi::Array>();
+    std::vector<std::string> deps;
+    deps.reserve(depsArr.Length());
+    for (uint32_t i = 0; i < depsArr.Length(); ++i)
+    {
+      deps.push_back(depsArr.Get(i).As<Napi::String>().Utf8Value());
+    }
+
+    auto fnRef = std::make_shared<Napi::FunctionReference>(
+        Napi::Persistent(info[2].As<Napi::Function>()));
+    auto thisRef = std::make_shared<Napi::ObjectReference>(Napi::Persistent(info.This().As<Napi::Object>()));
+    Napi::Env fnEnv = env;
+
+    _graph.addNode(name, std::move(deps),
+                   [fnRef, thisRef, fnEnv](flox::indicator::IndicatorGraph&,
+                                           flox::SymbolId sym) -> std::vector<double>
+                   {
+                     Napi::HandleScope scope(fnEnv);
+                     Napi::Value result = fnRef->Call(
+                         {thisRef->Value(),
+                          Napi::Number::New(fnEnv, static_cast<uint32_t>(sym))});
+                     auto arr = result.As<Napi::Float64Array>();
+                     return std::vector<double>(arr.Data(), arr.Data() + arr.ElementLength());
+                   });
+    return env.Undefined();
+  }
+
+  Napi::Value Require(const Napi::CallbackInfo& info)
+  {
+    uint32_t symbol = info[0].As<Napi::Number>().Uint32Value();
+    std::string name = info[1].As<Napi::String>().Utf8Value();
+    try
+    {
+      const auto& v = _graph.require(static_cast<flox::SymbolId>(symbol), name);
+      return vec2arr(info.Env(), v);
+    }
+    catch (const std::exception& e)
+    {
+      Napi::Error::New(info.Env(), e.what()).ThrowAsJavaScriptException();
+      return info.Env().Undefined();
+    }
+  }
+
+  Napi::Value Get(const Napi::CallbackInfo& info)
+  {
+    uint32_t symbol = info[0].As<Napi::Number>().Uint32Value();
+    std::string name = info[1].As<Napi::String>().Utf8Value();
+    const auto* v = _graph.get(static_cast<flox::SymbolId>(symbol), name);
+    if (!v)
+    {
+      return info.Env().Null();
+    }
+    return vec2arr(info.Env(), *v);
+  }
+
+  Napi::Value Close(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _graph.close(static_cast<flox::SymbolId>(s)));
+  }
+  Napi::Value High(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _graph.high(static_cast<flox::SymbolId>(s)));
+  }
+  Napi::Value Low(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _graph.low(static_cast<flox::SymbolId>(s)));
+  }
+  Napi::Value Volume(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _graph.volume(static_cast<flox::SymbolId>(s)));
+  }
+  Napi::Value Invalidate(const Napi::CallbackInfo& info)
+  {
+    _graph.invalidate(static_cast<flox::SymbolId>(info[0].As<Napi::Number>().Uint32Value()));
+    return info.Env().Undefined();
+  }
+  Napi::Value InvalidateAll(const Napi::CallbackInfo& info)
+  {
+    _graph.invalidateAll();
+    return info.Env().Undefined();
+  }
+
+  Napi::Value _self;  // unused, kept to silence -Wunused-private-field issues
+  flox::indicator::IndicatorGraph _graph;
+  std::unordered_map<uint32_t, std::vector<flox::Bar>> _bars;
+};
+
+inline void registerGraph(Napi::Env env, Napi::Object exports)
+{
+  exports.Set("IndicatorGraph", IndicatorGraphWrap::Init(env));
+}
+
+}  // namespace node_flox

--- a/node/test/test_bindings.js
+++ b/node/test/test_bindings.js
@@ -148,6 +148,37 @@ for (let i = 0; i < acLinear.length; ++i) {
 check(approx(lastStreamed, ac[ac.length - 1]),
       'streaming AutoCorrelation matches batch on last index');
 
+// ── IndicatorGraph (batch) ────────────────────────────────────────────
+
+console.log('=== IndicatorGraph (batch) ===');
+
+const ramp = new Float64Array(50);
+for (let i = 0; i < 50; ++i) ramp[i] = i;
+
+const g = new flox.IndicatorGraph();
+g.setBars(0, ramp);
+
+g.addNode('ema5', [], (graph, sym) => flox.ema(graph.close(sym), 5));
+g.addNode('sma5', [], (graph, sym) => flox.sma(graph.close(sym), 5));
+g.addNode('diff', ['ema5', 'sma5'], (graph, sym) => {
+  const a = graph.get(sym, 'ema5');
+  const b = graph.get(sym, 'sma5');
+  const out = new Float64Array(a.length);
+  for (let i = 0; i < a.length; ++i) out[i] = a[i] - b[i];
+  return out;
+});
+
+const ema5 = g.require(0, 'ema5');
+const diff = g.require(0, 'diff');
+check(ema5.length === 50, 'graph require returns full-length array');
+check(diff.length === 50, 'graph dependent node has same length');
+check(g.get(0, 'sma5') !== null, 'graph get returns cached node array');
+check(g.get(0, 'never_added') === null, 'graph get on missing node returns null');
+
+let threw = false;
+try { g.require(0, 'missing'); } catch (e) { threw = true; }
+check(threw, 'graph require on unknown node throws');
+
 // ── PositionTracker ───────────────────────────────────────────────────
 
 console.log('=== PositionTracker ===');

--- a/python/flox_py.cpp
+++ b/python/flox_py.cpp
@@ -12,6 +12,7 @@
 #include "flox/backtest/simulated_clock.h"
 #include "flox/backtest/simulated_executor.h"
 #include "flox/common.h"
+#include "graph_bindings.h"
 #include "indicator_bindings.h"
 #include "optimizer_bindings.h"
 #include "position_bindings.h"
@@ -724,6 +725,7 @@ PYBIND11_MODULE(flox_py, m)
   bindCompositeBook(m);
   bindStrategy(m);
   bindTargets(m);
+  bindIndicatorGraph(m);
 
   // Slippage model constants
   m.attr("SLIPPAGE_NONE") = 0;

--- a/python/graph_bindings.h
+++ b/python/graph_bindings.h
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "flox/aggregator/bar.h"
+#include "flox/common.h"
+#include "flox/indicator/indicator_pipeline.h"
+
+namespace py = pybind11;
+
+namespace
+{
+
+using contiguous_double_graph =
+    py::array_t<double, py::array::c_style | py::array::forcecast>;
+
+// Wraps flox::indicator::IndicatorGraph for Python. Single-symbol path is
+// the primary use; multi-symbol works by passing distinct symbol IDs.
+class PyIndicatorGraph
+{
+ public:
+  PyIndicatorGraph() = default;
+
+  void setBars(uint32_t symbol, contiguous_double_graph close,
+               std::optional<contiguous_double_graph> high,
+               std::optional<contiguous_double_graph> low,
+               std::optional<contiguous_double_graph> volume)
+  {
+    auto cBuf = close.request();
+    size_t n = cBuf.shape[0];
+    const double* c = static_cast<const double*>(cBuf.ptr);
+    const double* h = c;
+    const double* l = c;
+    const double* v = nullptr;
+    if (high)
+    {
+      auto b = high->request();
+      if (static_cast<size_t>(b.shape[0]) != n)
+      {
+        throw std::invalid_argument("set_bars: high must match close length");
+      }
+      h = static_cast<const double*>(b.ptr);
+    }
+    if (low)
+    {
+      auto b = low->request();
+      if (static_cast<size_t>(b.shape[0]) != n)
+      {
+        throw std::invalid_argument("set_bars: low must match close length");
+      }
+      l = static_cast<const double*>(b.ptr);
+    }
+    if (volume)
+    {
+      auto b = volume->request();
+      if (static_cast<size_t>(b.shape[0]) != n)
+      {
+        throw std::invalid_argument("set_bars: volume must match close length");
+      }
+      v = static_cast<const double*>(b.ptr);
+    }
+
+    std::vector<flox::Bar> bars(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+      bars[i].open = flox::Price::fromDouble(c[i]);
+      bars[i].high = flox::Price::fromDouble(h[i]);
+      bars[i].low = flox::Price::fromDouble(l[i]);
+      bars[i].close = flox::Price::fromDouble(c[i]);
+      bars[i].volume = v ? flox::Volume::fromDouble(v[i]) : flox::Volume{};
+    }
+    _bars[symbol] = std::move(bars);
+    _graph.setBars(static_cast<flox::SymbolId>(symbol),
+                   std::span<const flox::Bar>(_bars[symbol]));
+  }
+
+  void addNode(const std::string& name, std::vector<std::string> deps, py::object fn)
+  {
+    PyIndicatorGraph* self = this;
+    _graph.addNode(
+        name, std::move(deps),
+        [self, fn](flox::indicator::IndicatorGraph&, flox::SymbolId sym) -> std::vector<double>
+        {
+          py::object result = fn(py::cast(self, py::return_value_policy::reference),
+                                 static_cast<uint32_t>(sym));
+          py::array_t<double, py::array::c_style | py::array::forcecast> arr =
+              result.cast<py::array_t<double, py::array::c_style | py::array::forcecast>>();
+          auto buf = arr.request();
+          size_t n = buf.shape[0];
+          const double* p = static_cast<const double*>(buf.ptr);
+          return std::vector<double>(p, p + n);
+        });
+  }
+
+  py::array_t<double> require(uint32_t symbol, const std::string& name)
+  {
+    const auto& v = _graph.require(static_cast<flox::SymbolId>(symbol), name);
+    return toArray(v);
+  }
+
+  py::object get(uint32_t symbol, const std::string& name) const
+  {
+    const auto* v = _graph.get(static_cast<flox::SymbolId>(symbol), name);
+    if (!v)
+    {
+      return py::none();
+    }
+    return toArray(*v);
+  }
+
+  py::array_t<double> close(uint32_t symbol)
+  {
+    return toArray(_graph.close(static_cast<flox::SymbolId>(symbol)));
+  }
+  py::array_t<double> high(uint32_t symbol)
+  {
+    return toArray(_graph.high(static_cast<flox::SymbolId>(symbol)));
+  }
+  py::array_t<double> low(uint32_t symbol)
+  {
+    return toArray(_graph.low(static_cast<flox::SymbolId>(symbol)));
+  }
+  py::array_t<double> volume(uint32_t symbol)
+  {
+    return toArray(_graph.volume(static_cast<flox::SymbolId>(symbol)));
+  }
+
+  void invalidate(uint32_t symbol) { _graph.invalidate(static_cast<flox::SymbolId>(symbol)); }
+  void invalidateAll() { _graph.invalidateAll(); }
+
+ private:
+  static py::array_t<double> toArray(const std::vector<double>& v)
+  {
+    py::array_t<double> out(v.size());
+    std::memcpy(out.mutable_data(), v.data(), v.size() * sizeof(double));
+    return out;
+  }
+
+  flox::indicator::IndicatorGraph _graph;
+  std::unordered_map<uint32_t, std::vector<flox::Bar>> _bars;
+};
+
+}  // namespace
+
+inline void bindIndicatorGraph(py::module_& m)
+{
+  py::class_<PyIndicatorGraph>(m, "IndicatorGraph")
+      .def(py::init<>())
+      .def("set_bars", &PyIndicatorGraph::setBars, py::arg("symbol"), py::arg("close"),
+           py::arg("high") = py::none(), py::arg("low") = py::none(),
+           py::arg("volume") = py::none())
+      .def("add_node", &PyIndicatorGraph::addNode, py::arg("name"), py::arg("deps"),
+           py::arg("fn"))
+      .def("require", &PyIndicatorGraph::require, py::arg("symbol"), py::arg("name"))
+      .def("get", &PyIndicatorGraph::get, py::arg("symbol"), py::arg("name"))
+      .def("close", &PyIndicatorGraph::close, py::arg("symbol"))
+      .def("high", &PyIndicatorGraph::high, py::arg("symbol"))
+      .def("low", &PyIndicatorGraph::low, py::arg("symbol"))
+      .def("volume", &PyIndicatorGraph::volume, py::arg("symbol"))
+      .def("invalidate", &PyIndicatorGraph::invalidate, py::arg("symbol"))
+      .def("invalidate_all", &PyIndicatorGraph::invalidateAll);
+}

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -206,6 +206,37 @@ for i in range(10, len(ac_linear)):
     if i >= 10:
         break  # one assertion is enough to keep noise down
 
+# ── IndicatorGraph (batch) ───────────────────────────────────────────
+
+print("=== IndicatorGraph (batch) ===")
+
+ramp = np.array([float(i) for i in range(50)])
+g = flox.IndicatorGraph()
+g.set_bars(0, ramp)
+
+# Two independent batch nodes + one dependent node that reads its parents.
+g.add_node("ema5", [], lambda graph, sym: flox.ema(graph.close(sym), 5))
+g.add_node("sma5", [], lambda graph, sym: flox.sma(graph.close(sym), 5))
+g.add_node("diff", ["ema5", "sma5"],
+           lambda graph, sym: graph.get(sym, "ema5") - graph.get(sym, "sma5"))
+
+ema5 = g.require(0, "ema5")
+diff = g.require(0, "diff")
+check(len(ema5) == 50, "graph require returns full-length array")
+check(len(diff) == 50, "graph dependent node has same length")
+# get() returns cached value after require ran.
+sma5_cached = g.get(0, "sma5")
+check(sma5_cached is not None, "get returns the cached node array after require")
+check(np.allclose(diff, ema5 - sma5_cached, equal_nan=True), "dependent node uses parents")
+
+# Unknown node → throws.
+threw = False
+try:
+    g.require(0, "missing")
+except Exception:
+    threw = True
+check(threw, "require on unknown node throws")
+
 # ── PositionTracker ───────────────────────────────────────────────────
 
 print("=== PositionTracker ===")

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -36,6 +36,7 @@
 #include "flox/indicator/cvd.h"
 #include "flox/indicator/dema.h"
 #include "flox/indicator/ema.h"
+#include "flox/indicator/indicator_pipeline.h"
 #include "flox/indicator/kama.h"
 #include "flox/indicator/kurtosis.h"
 #include "flox/indicator/macd.h"
@@ -631,6 +632,175 @@ void flox_target_future_linear_slope(const double* close, size_t len, size_t hor
 {
   target::FutureLinearSlope t(horizon);
   t.compute(std::span<const double>(close, len), std::span<double>(output, len));
+}
+
+// ============================================================
+// IndicatorGraph (batch) — handle-based wrapper.
+// ============================================================
+
+namespace
+{
+
+struct FloxGraphImpl
+{
+  indicator::IndicatorGraph graph;
+  std::unordered_map<uint32_t, std::vector<Bar>> barStorage;
+};
+
+}  // namespace
+
+FloxIndicatorGraphHandle flox_indicator_graph_create(void)
+{
+  return new FloxGraphImpl();
+}
+
+void flox_indicator_graph_destroy(FloxIndicatorGraphHandle g)
+{
+  delete static_cast<FloxGraphImpl*>(g);
+}
+
+void flox_indicator_graph_set_bars(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                   const double* close, const double* high, const double* low,
+                                   const double* volume, size_t len)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  std::vector<Bar> bars(len);
+  for (size_t i = 0; i < len; ++i)
+  {
+    bars[i].open = Price::fromDouble(close[i]);
+    bars[i].high = Price::fromDouble(high ? high[i] : close[i]);
+    bars[i].low = Price::fromDouble(low ? low[i] : close[i]);
+    bars[i].close = Price::fromDouble(close[i]);
+    bars[i].volume = volume ? Volume::fromDouble(volume[i]) : Volume{};
+  }
+  impl->barStorage[symbol] = std::move(bars);
+  impl->graph.setBars(static_cast<SymbolId>(symbol),
+                      std::span<const Bar>(impl->barStorage[symbol]));
+}
+
+void flox_indicator_graph_add_node(FloxIndicatorGraphHandle g, const char* name,
+                                   const char* const* deps, size_t num_deps,
+                                   FloxGraphNodeFn fn, void* user_data)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  std::vector<std::string> depList;
+  depList.reserve(num_deps);
+  for (size_t i = 0; i < num_deps; ++i)
+  {
+    depList.emplace_back(deps[i]);
+  }
+  impl->graph.addNode(name, std::move(depList),
+                      [g, fn, user_data](indicator::IndicatorGraph&, SymbolId sym)
+                      {
+                        size_t outLen = 0;
+                        const double* p = fn(user_data, g, static_cast<uint32_t>(sym), &outLen);
+                        if (!p)
+                        {
+                          return std::vector<double>{};
+                        }
+                        return std::vector<double>(p, p + outLen);
+                      });
+}
+
+const double* flox_indicator_graph_require(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                           const char* name, size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  try
+  {
+    const auto& v = impl->graph.require(static_cast<SymbolId>(symbol), name);
+    if (len_out)
+    {
+      *len_out = v.size();
+    }
+    return v.data();
+  }
+  catch (...)
+  {
+    if (len_out)
+    {
+      *len_out = 0;
+    }
+    return nullptr;
+  }
+}
+
+const double* flox_indicator_graph_get(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                       const char* name, size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  const auto* v = impl->graph.get(static_cast<SymbolId>(symbol), name);
+  if (!v)
+  {
+    if (len_out)
+    {
+      *len_out = 0;
+    }
+    return nullptr;
+  }
+  if (len_out)
+  {
+    *len_out = v->size();
+  }
+  return v->data();
+}
+
+const double* flox_indicator_graph_close(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                         size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  const auto& v = impl->graph.close(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
+}
+
+const double* flox_indicator_graph_high(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                        size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  const auto& v = impl->graph.high(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
+}
+
+const double* flox_indicator_graph_low(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                       size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  const auto& v = impl->graph.low(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
+}
+
+const double* flox_indicator_graph_volume(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                          size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  const auto& v = impl->graph.volume(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
+}
+
+void flox_indicator_graph_invalidate(FloxIndicatorGraphHandle g, uint32_t symbol)
+{
+  static_cast<FloxGraphImpl*>(g)->graph.invalidate(static_cast<SymbolId>(symbol));
+}
+
+void flox_indicator_graph_invalidate_all(FloxIndicatorGraphHandle g)
+{
+  static_cast<FloxGraphImpl*>(g)->graph.invalidateAll();
 }
 
 // ============================================================

--- a/src/quickjs/js_bindings.cpp
+++ b/src/quickjs/js_bindings.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <vector>
 
@@ -674,6 +675,205 @@ static JSValue js_target_future_linear_slope(JSContext* ctx, JSValueConst, int,
   std::vector<double> output(len);
   flox_target_future_linear_slope(close.data(), len, horizon, output.data());
   return jsArrayFromDoubles(ctx, output);
+}
+
+// ============================================================
+// IndicatorGraph (batch) bindings
+// ============================================================
+
+namespace
+{
+
+struct JsGraphNodeState
+{
+  JSContext* ctx;
+  JSValue fn;
+  JSValue thisObj;
+  std::vector<double> buffer;
+};
+
+struct JsGraphState
+{
+  FloxIndicatorGraphHandle handle;
+  std::vector<std::unique_ptr<JsGraphNodeState>> nodes;
+};
+
+static const double* js_graph_node_trampoline(void* user_data, FloxIndicatorGraphHandle,
+                                              uint32_t symbol, size_t* out_len)
+{
+  auto* st = static_cast<JsGraphNodeState*>(user_data);
+  JSValue args[2] = {JS_DupValue(st->ctx, st->thisObj), JS_NewUint32(st->ctx, symbol)};
+  JSValue result = JS_Call(st->ctx, st->fn, JS_UNDEFINED, 2, args);
+  JS_FreeValue(st->ctx, args[0]);
+  JS_FreeValue(st->ctx, args[1]);
+  if (JS_IsException(result))
+  {
+    JS_FreeValue(st->ctx, result);
+    *out_len = 0;
+    return nullptr;
+  }
+  st->buffer = jsArrayToDoubles(st->ctx, result);
+  JS_FreeValue(st->ctx, result);
+  *out_len = st->buffer.size();
+  return st->buffer.data();
+}
+
+}  // namespace
+
+static JSValue js_graph_create(JSContext* ctx, JSValueConst, int, JSValueConst*)
+{
+  auto* st = new JsGraphState{flox_indicator_graph_create(), {}};
+  return createHandleObject(ctx, st);
+}
+
+static JSValue js_graph_destroy(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  if (!st)
+  {
+    return JS_UNDEFINED;
+  }
+  for (auto& node : st->nodes)
+  {
+    JS_FreeValue(node->ctx, node->fn);
+    JS_FreeValue(node->ctx, node->thisObj);
+  }
+  flox_indicator_graph_destroy(st->handle);
+  delete st;
+  return JS_UNDEFINED;
+}
+
+static JSValue js_graph_set_bars(JSContext* ctx, JSValueConst, int argc, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  uint32_t sym = toUint32(ctx, argv[1]);
+  auto close = jsArrayToDoubles(ctx, argv[2]);
+  std::vector<double> high, low, volume;
+  const double* hp = nullptr;
+  const double* lp = nullptr;
+  const double* vp = nullptr;
+  if (argc > 3 && !JS_IsNull(argv[3]) && !JS_IsUndefined(argv[3]))
+  {
+    high = jsArrayToDoubles(ctx, argv[3]);
+    hp = high.data();
+  }
+  if (argc > 4 && !JS_IsNull(argv[4]) && !JS_IsUndefined(argv[4]))
+  {
+    low = jsArrayToDoubles(ctx, argv[4]);
+    lp = low.data();
+  }
+  if (argc > 5 && !JS_IsNull(argv[5]) && !JS_IsUndefined(argv[5]))
+  {
+    volume = jsArrayToDoubles(ctx, argv[5]);
+    vp = volume.data();
+  }
+  flox_indicator_graph_set_bars(st->handle, sym, close.data(), hp, lp, vp, close.size());
+  return JS_UNDEFINED;
+}
+
+static JSValue js_graph_add_node(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  const char* name = JS_ToCString(ctx, argv[1]);
+  std::string nameStr(name);
+  JS_FreeCString(ctx, name);
+
+  std::vector<std::string> deps;
+  if (JS_IsArray(ctx, argv[2]))
+  {
+    uint32_t depsLen = 0;
+    {
+      JSValue lenVal = JS_GetPropertyStr(ctx, argv[2], "length");
+      JS_ToUint32(ctx, &depsLen, lenVal);
+      JS_FreeValue(ctx, lenVal);
+    }
+    for (uint32_t i = 0; i < depsLen; ++i)
+    {
+      JSValue v = JS_GetPropertyUint32(ctx, argv[2], i);
+      const char* s = JS_ToCString(ctx, v);
+      deps.emplace_back(s);
+      JS_FreeCString(ctx, s);
+      JS_FreeValue(ctx, v);
+    }
+  }
+
+  std::vector<const char*> depPtrs;
+  depPtrs.reserve(deps.size());
+  for (const auto& d : deps)
+  {
+    depPtrs.push_back(d.c_str());
+  }
+
+  // Capture the JS callable + the thisObj (graph wrapper).
+  auto node = std::make_unique<JsGraphNodeState>();
+  node->ctx = ctx;
+  node->fn = JS_DupValue(ctx, argv[3]);
+  node->thisObj = JS_DupValue(ctx, argv[4]);
+
+  flox_indicator_graph_add_node(st->handle, nameStr.c_str(),
+                                deps.empty() ? nullptr : depPtrs.data(), deps.size(),
+                                js_graph_node_trampoline, node.get());
+  st->nodes.push_back(std::move(node));
+  return JS_UNDEFINED;
+}
+
+static JSValue js_graph_require(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  uint32_t sym = toUint32(ctx, argv[1]);
+  const char* name = JS_ToCString(ctx, argv[2]);
+  size_t len = 0;
+  const double* p = flox_indicator_graph_require(st->handle, sym, name, &len);
+  JS_FreeCString(ctx, name);
+  if (!p)
+  {
+    return JS_ThrowTypeError(ctx, "graph: require failed");
+  }
+  return jsArrayFromDoubles(ctx, std::vector<double>(p, p + len));
+}
+
+static JSValue js_graph_get(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  uint32_t sym = toUint32(ctx, argv[1]);
+  const char* name = JS_ToCString(ctx, argv[2]);
+  size_t len = 0;
+  const double* p = flox_indicator_graph_get(st->handle, sym, name, &len);
+  JS_FreeCString(ctx, name);
+  if (!p)
+  {
+    return JS_NULL;
+  }
+  return jsArrayFromDoubles(ctx, std::vector<double>(p, p + len));
+}
+
+#define GRAPH_FIELD(field)                                                               \
+  static JSValue js_graph_##field(JSContext* ctx, JSValueConst, int, JSValueConst* argv) \
+  {                                                                                      \
+    auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));                      \
+    uint32_t sym = toUint32(ctx, argv[1]);                                               \
+    size_t len = 0;                                                                      \
+    const double* p = flox_indicator_graph_##field(st->handle, sym, &len);               \
+    return jsArrayFromDoubles(ctx, std::vector<double>(p, p + len));                     \
+  }
+GRAPH_FIELD(close)
+GRAPH_FIELD(high)
+GRAPH_FIELD(low)
+GRAPH_FIELD(volume)
+#undef GRAPH_FIELD
+
+static JSValue js_graph_invalidate(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  flox_indicator_graph_invalidate(st->handle, toUint32(ctx, argv[1]));
+  return JS_UNDEFINED;
+}
+
+static JSValue js_graph_invalidate_all(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  flox_indicator_graph_invalidate_all(st->handle);
+  return JS_UNDEFINED;
 }
 
 // ============================================================
@@ -2263,6 +2463,20 @@ void registerFloxBindings(JSContext* ctx)
   addGlobalFunc(ctx, "__flox_target_future_return", js_target_future_return, 2);
   addGlobalFunc(ctx, "__flox_target_future_ctc_volatility", js_target_future_ctc_volatility, 2);
   addGlobalFunc(ctx, "__flox_target_future_linear_slope", js_target_future_linear_slope, 2);
+
+  // IndicatorGraph (batch)
+  addGlobalFunc(ctx, "__flox_graph_create", js_graph_create, 0);
+  addGlobalFunc(ctx, "__flox_graph_destroy", js_graph_destroy, 1);
+  addGlobalFunc(ctx, "__flox_graph_set_bars", js_graph_set_bars, 6);
+  addGlobalFunc(ctx, "__flox_graph_add_node", js_graph_add_node, 5);
+  addGlobalFunc(ctx, "__flox_graph_require", js_graph_require, 3);
+  addGlobalFunc(ctx, "__flox_graph_get", js_graph_get, 3);
+  addGlobalFunc(ctx, "__flox_graph_close", js_graph_close, 2);
+  addGlobalFunc(ctx, "__flox_graph_high", js_graph_high, 2);
+  addGlobalFunc(ctx, "__flox_graph_low", js_graph_low, 2);
+  addGlobalFunc(ctx, "__flox_graph_volume", js_graph_volume, 2);
+  addGlobalFunc(ctx, "__flox_graph_invalidate", js_graph_invalidate, 2);
+  addGlobalFunc(ctx, "__flox_graph_invalidate_all", js_graph_invalidate_all, 1);
 
   // Order book
   addGlobalFunc(ctx, "__flox_book_create", js_book_create, 1);

--- a/src/quickjs/js_strategy.cpp
+++ b/src/quickjs/js_strategy.cpp
@@ -474,7 +474,31 @@ void FloxJsStrategy::loadStdlib()
       loadCsv: function(path) { return __flox_load_csv(path); },
 
       // Forward-looking labels (research-only). See flox/targets.js.
-      targets: __floxTargets
+      targets: __floxTargets,
+
+      IndicatorGraph: class {
+        constructor() {
+          this._h = __flox_graph_create();
+        }
+        destroy() {
+          if (this._h) { __flox_graph_destroy(this._h); this._h = null; }
+        }
+        setBars(symbol, close, high, low, volume) {
+          __flox_graph_set_bars(this._h, symbol, close, high || null,
+                                low || null, volume || null);
+        }
+        addNode(name, deps, fn) {
+          __flox_graph_add_node(this._h, name, deps || [], fn, this);
+        }
+        require(symbol, name) { return __flox_graph_require(this._h, symbol, name); }
+        get(symbol, name) { return __flox_graph_get(this._h, symbol, name); }
+        close(symbol) { return __flox_graph_close(this._h, symbol); }
+        high(symbol) { return __flox_graph_high(this._h, symbol); }
+        low(symbol) { return __flox_graph_low(this._h, symbol); }
+        volume(symbol) { return __flox_graph_volume(this._h, symbol); }
+        invalidate(symbol) { __flox_graph_invalidate(this._h, symbol); }
+        invalidateAll() { __flox_graph_invalidate_all(this._h); }
+      }
     };
   )";
   if (!_engine.eval(registerCode, "<flox_register>"))

--- a/tests/test_capi_infra.cpp
+++ b/tests/test_capi_infra.cpp
@@ -304,3 +304,86 @@ TEST(CapiReplayTest, ReadBboAndBookUpdates)
   flox_data_reader_destroy(r);
   std::filesystem::remove_all(dir);
 }
+
+// ============================================================
+// IndicatorGraph (batch)
+// ============================================================
+
+namespace
+{
+// Test fixture: a node fn that returns the close array * 2.
+static const double* doubleClose(void* user_data, FloxIndicatorGraphHandle g, uint32_t sym,
+                                 size_t* out_len)
+{
+  auto* state = static_cast<std::vector<double>*>(user_data);
+  size_t n = 0;
+  const double* c = flox_indicator_graph_close(g, sym, &n);
+  state->resize(n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    (*state)[i] = c[i] * 2.0;
+  }
+  *out_len = n;
+  return state->data();
+}
+
+// dependent: returns close + parent
+static const double* sumWithDouble(void* user_data, FloxIndicatorGraphHandle g, uint32_t sym,
+                                   size_t* out_len)
+{
+  auto* state = static_cast<std::vector<double>*>(user_data);
+  size_t n = 0;
+  const double* c = flox_indicator_graph_close(g, sym, &n);
+  size_t pn = 0;
+  const double* p = flox_indicator_graph_get(g, sym, "double_close", &pn);
+  if (!p || pn != n)
+  {
+    *out_len = 0;
+    return nullptr;
+  }
+  state->resize(n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    (*state)[i] = c[i] + p[i];
+  }
+  *out_len = n;
+  return state->data();
+}
+}  // namespace
+
+TEST(CapiGraphTest, BasicComputeAndDeps)
+{
+  auto g = flox_indicator_graph_create();
+  ASSERT_NE(g, nullptr);
+
+  std::vector<double> close = {1.0, 2.0, 3.0, 4.0, 5.0};
+  flox_indicator_graph_set_bars(g, 0, close.data(), nullptr, nullptr, nullptr, close.size());
+
+  std::vector<double> stateA, stateB;
+  flox_indicator_graph_add_node(g, "double_close", nullptr, 0, doubleClose, &stateA);
+  const char* deps[] = {"double_close"};
+  flox_indicator_graph_add_node(g, "sum", deps, 1, sumWithDouble, &stateB);
+
+  size_t len = 0;
+  const double* out = flox_indicator_graph_require(g, 0, "sum", &len);
+  ASSERT_NE(out, nullptr);
+  ASSERT_EQ(len, 5u);
+  for (size_t i = 0; i < 5; ++i)
+  {
+    EXPECT_NEAR(out[i], close[i] * 3.0, 1e-12);
+  }
+
+  // get on cached node returns the same pointer.
+  size_t cl = 0;
+  const double* cached = flox_indicator_graph_get(g, 0, "double_close", &cl);
+  ASSERT_NE(cached, nullptr);
+  EXPECT_EQ(cl, 5u);
+
+  // Unknown node -> nullptr.
+  size_t l2 = 999;
+  const double* missing = flox_indicator_graph_require(g, 0, "nope", &l2);
+  EXPECT_EQ(missing, nullptr);
+  EXPECT_EQ(l2, 0u);
+
+  flox_indicator_graph_destroy(g);
+}

--- a/tests/test_quickjs.cpp
+++ b/tests/test_quickjs.cpp
@@ -224,6 +224,70 @@ TEST(JsIntegrationTest, AutoCorrelationBindings)
   JS_FreeValue(ctx, eq);
 }
 
+TEST(JsIntegrationTest, IndicatorGraphBindings)
+{
+  TempJsFile script(R"(
+    var ramp = [];
+    for (var i = 0; i < 50; ++i) ramp.push(i);
+
+    var g = new flox.IndicatorGraph();
+    g.setBars(0, ramp);
+
+    g.addNode("ema5", [], function(graph, sym) {
+      return SMA.compute(graph.close(sym), 5);
+    });
+    g.addNode("sma5", [], function(graph, sym) {
+      return SMA.compute(graph.close(sym), 5);
+    });
+    g.addNode("diff", ["ema5", "sma5"], function(graph, sym) {
+      var a = graph.get(sym, "ema5");
+      var b = graph.get(sym, "sma5");
+      var out = [];
+      for (var i = 0; i < a.length; ++i) out.push(a[i] - b[i]);
+      return out;
+    });
+
+    var ema5 = g.require(0, "ema5");
+    var diff = g.require(0, "diff");
+    var ema5_len = ema5.length;
+    var diff_len = diff.length;
+    var sma5_cached = g.get(0, "sma5");
+    var sma5_not_null = sma5_cached !== null;
+
+    var threw = false;
+    try { g.require(0, "missing"); } catch (e) { threw = true; }
+    var require_throws = threw;
+
+    g.destroy();
+  )");
+
+  SymbolRegistry registry;
+  FloxJsStrategy jsStrat(script.path(), registry);
+
+  auto* ctx = jsStrat.engine().context();
+
+  auto getInt = [&](const char* name)
+  {
+    JSValue v = jsStrat.engine().getGlobalProperty(name);
+    int32_t i = 0;
+    JS_ToInt32(ctx, &i, v);
+    JS_FreeValue(ctx, v);
+    return i;
+  };
+  auto getBool = [&](const char* name)
+  {
+    JSValue v = jsStrat.engine().getGlobalProperty(name);
+    bool b = JS_ToBool(ctx, v);
+    JS_FreeValue(ctx, v);
+    return b;
+  };
+
+  EXPECT_EQ(getInt("ema5_len"), 50);
+  EXPECT_EQ(getInt("diff_len"), 50);
+  EXPECT_TRUE(getBool("sma5_not_null"));
+  EXPECT_TRUE(getBool("require_throws"));
+}
+
 TEST(JsIntegrationTest, LoadStrategyAndResolveSymbols)
 {
   TempJsFile script(R"(


### PR DESCRIPTION
## Summary

Closes #106.

The C++ `flox::indicator::IndicatorGraph` from `include/flox/indicator/indicator_pipeline.h` (introduced in #87) was unreachable from any binding. Users of `flox-py`, `@flox-foundation/flox`, the C API, the Codon module, and the QuickJS scripts could call individual batch functions but had to resolve dependencies and re-run shared computation manually. This PR closes that gap.

## C API

```c
typedef void* FloxIndicatorGraphHandle;
typedef const double* (*FloxGraphNodeFn)(void* user_data,
                                         FloxIndicatorGraphHandle g,
                                         uint32_t symbol, size_t* out_len);

FloxIndicatorGraphHandle flox_indicator_graph_create(void);
void flox_indicator_graph_destroy(FloxIndicatorGraphHandle g);
void flox_indicator_graph_set_bars(g, sym, close, high, low, volume, n);
void flox_indicator_graph_add_node(g, name, deps, num_deps, fn, user_data);
const double* flox_indicator_graph_require(g, sym, name, &len);
const double* flox_indicator_graph_get(g, sym, name, &len);
const double* flox_indicator_graph_close / _high / _low / _volume(g, sym, &len);
void flox_indicator_graph_invalidate(g, sym);
void flox_indicator_graph_invalidate_all(g);
```

`high` / `low` / `volume` may be `NULL` (default to close-only series).

## Bindings

Naming aligned across surfaces:

- **Python** — `flox.IndicatorGraph()` with `set_bars / add_node / require / get / close / high / low / volume / invalidate / invalidate_all`. Direct C++ wrap; node callbacks are Python callables; outputs are numpy arrays.
- **Node** — `new flox.IndicatorGraph()` with the same surface in camelCase (`setBars`, `addNode`, `invalidateAll`). Outputs are `Float64Array`. C++ exceptions are translated to JS errors.
- **Codon** — `from flox.graph import IndicatorGraph`. The high-level wrapper covers everything except `add_node`; `add_node_raw` accepts a top-level function pointer + `user_data` directly via the C API (Codon closures-as-cobj need more work and are out of scope here).
- **QuickJS** — `new flox.IndicatorGraph()` (added to the existing `flox` global). Node-fn callbacks receive the graph instance as `this`, so `graph.close(sym)` / `graph.get(sym, name)` work the same as in other bindings.

## Test plan

- [x] **C API** unit (`tests/test_capi_infra.cpp / CapiGraphTest.BasicComputeAndDeps`): DAG with deps, `get` on cached node, unknown node returns `nullptr`.
- [x] **Python** smoke (5 asserts): `ema5 + sma5 → diff` DAG, length checks, `get` returns the cached array, `require` raises on unknown node.
- [x] **Node** smoke (5 asserts): same DAG, `get` returns `null` on missing, `require` throws on unknown node.
- [x] **QuickJS** integration (`JsIntegrationTest.IndicatorGraphBindings`): DAG end-to-end, JS `try/catch` on `require("missing")`.
- [x] **Codon**: `codon_graph_smoke` example compiles via the C API (`set_bars` + `close` + `get` on missing returns `None`).
- [x] Full ctest: 44/44 passed; Python smoke: 63/63 passed.
- [x] `clang-format` clean.

## Notes

- Single-symbol path is primary; multi-symbol works by passing distinct symbol IDs to the same graph.
- Pipelines previously had to resolve dependencies manually in user code — the new API removes that boilerplate.
- The streaming counterpart (#107) would extend this surface; this PR is batch-only and matches the existing C++ surface 1:1.