### PR TITLE
ci(parity): batch ↔ streaming parity tests for all dual-exposed indicators (closes #111)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
     - name: Verify Python bindings
       run: PYTHONPATH=build/python python3 python/tests/test_bindings.py
 
+    - name: Parity tests (batch vs streaming, all dual-exposed indicators)
+      run: PYTHONPATH=build/python python3 python/tests/test_parity.py
+
     - name: Run Python example
       run: PYTHONPATH=build/python python3 docs/examples/python_backtest_vs_live.py
 

--- a/codon/CMakeLists.txt
+++ b/codon/CMakeLists.txt
@@ -41,3 +41,6 @@ add_codon_executable(codon_full_backtest
 
 add_codon_executable(codon_targets_smoke
   ${CMAKE_CURRENT_SOURCE_DIR}/examples/targets_smoke.codon)
+
+add_codon_executable(codon_graph_smoke
+  ${CMAKE_CURRENT_SOURCE_DIR}/examples/graph_smoke.codon)

--- a/codon/CMakeLists.txt
+++ b/codon/CMakeLists.txt
@@ -44,3 +44,6 @@ add_codon_executable(codon_targets_smoke
 
 add_codon_executable(codon_graph_smoke
   ${CMAKE_CURRENT_SOURCE_DIR}/examples/graph_smoke.codon)
+
+add_codon_executable(codon_streaming_graph_smoke
+  ${CMAKE_CURRENT_SOURCE_DIR}/examples/streaming_graph_smoke.codon)

--- a/codon/examples/graph_smoke.codon
+++ b/codon/examples/graph_smoke.codon
@@ -1,0 +1,18 @@
+# Smoke test: IndicatorGraph (batch) bindings via the C API.
+# Tests the surface that doesn't need a Codon-side closure
+# (set_bars / require on field accessor / get).
+
+from flox.graph import IndicatorGraph
+
+close = [float(i) for i in range(20)]
+g = IndicatorGraph()
+g.set_bars(0, close)
+
+c = g.close(0)
+print("len(close) =", len(c))
+print("close[0] =", c[0])
+print("close[19] =", c[19])
+
+# get on a non-existent node returns None.
+maybe = g.get(0, "missing")
+print("get missing is None =", maybe is None)

--- a/codon/examples/streaming_graph_smoke.codon
+++ b/codon/examples/streaming_graph_smoke.codon
@@ -1,0 +1,43 @@
+from flox.graph import StreamingIndicatorGraph, IndicatorGraph
+import math
+
+# Streaming graph smoke test.
+# Node fn must be a top-level function (Codon constraint on C fn ptrs).
+
+@export
+def double_close_fn(user_data: cobj, g: cobj, sym: u32, out_len: Ptr[int]) -> Ptr[f64]:
+    from flox.graph import flox_indicator_graph_close
+    n = [0]
+    p = flox_indicator_graph_close(g, sym, n.arr.ptr)
+    result = Ptr[f64](n[0])
+    for i in range(n[0]):
+        result[i] = p[i] * 2.0
+    out_len[0] = n[0]
+    return result
+
+
+closes = [10.0, 20.0, 30.0, 40.0, 50.0]
+
+sg = StreamingIndicatorGraph()
+sg.add_node_raw("double_close", [], double_close_fn.__raw__())
+
+for c in closes:
+    sg.step(0, c)
+
+last = sg.current(0, "double_close")
+assert abs(last - 100.0) < 1e-9, f"streaming current: expected 100.0, got {last}"
+assert sg.bar_count(0) == 5, f"bar_count: expected 5, got {sg.bar_count(0)}"
+
+# Parity check with batch.
+bg = IndicatorGraph()
+bg.set_bars(0, closes)
+bg.add_node_raw("double_close", [], double_close_fn.__raw__())
+batch_out = bg.require(0, "double_close")
+assert abs(batch_out[-1] - last) < 1e-9, "streaming != batch"
+
+# Reset.
+sg.reset(0)
+assert sg.bar_count(0) == 0, "after reset bar_count should be 0"
+assert math.isnan(sg.current(0, "double_close")), "after reset current should be NaN"
+
+print("streaming_graph_smoke: OK")

--- a/codon/flox/graph.codon
+++ b/codon/flox/graph.codon
@@ -1,0 +1,109 @@
+# flox/graph.codon -- IndicatorGraph (batch) bindings via the C API.
+#
+# Compose batch indicators with shared intermediate caching. Mirrors the
+# C++ flox::indicator::IndicatorGraph surface.
+#
+# Usage:
+#   from flox.graph import IndicatorGraph
+#   from flox.indicators import ema, sma
+#
+#   g = IndicatorGraph()
+#   g.set_bars(0, close)
+#   g.add_node("ema50", [], lambda graph, sym: ema(graph.close(sym), 50))
+#   out = g.require(0, "ema50")
+
+from C import flox_indicator_graph_create() -> cobj
+from C import flox_indicator_graph_destroy(cobj)
+from C import flox_indicator_graph_set_bars(cobj, u32, Ptr[f64], Ptr[f64], Ptr[f64], Ptr[f64], int)
+from C import flox_indicator_graph_add_node(cobj, cobj, Ptr[cobj], int, cobj, cobj)
+from C import flox_indicator_graph_require(cobj, u32, cobj, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_get(cobj, u32, cobj, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_close(cobj, u32, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_high(cobj, u32, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_low(cobj, u32, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_volume(cobj, u32, Ptr[int]) -> Ptr[f64]
+from C import flox_indicator_graph_invalidate(cobj, u32)
+from C import flox_indicator_graph_invalidate_all(cobj)
+
+
+def _ptr_to_list(p: Ptr[f64], n: int) -> List[float]:
+    out = [0.0] * n
+    for i in range(n):
+        out[i] = p[i]
+    return out
+
+
+class IndicatorGraph:
+    _h: cobj
+
+    def __init__(self):
+        self._h = flox_indicator_graph_create()
+
+    def __del__(self):
+        if self._h != cobj():
+            flox_indicator_graph_destroy(self._h)
+            self._h = cobj()
+
+    def set_bars(self, symbol: int, close: List[float],
+                 high: List[float] = None, low: List[float] = None,
+                 volume: List[float] = None):
+        n = len(close)
+        h_ptr = high.arr.ptr if high is not None else Ptr[f64]()
+        l_ptr = low.arr.ptr if low is not None else Ptr[f64]()
+        v_ptr = volume.arr.ptr if volume is not None else Ptr[f64]()
+        flox_indicator_graph_set_bars(self._h, u32(symbol), close.arr.ptr,
+                                      h_ptr, l_ptr, v_ptr, n)
+
+    def require(self, symbol: int, name: str) -> List[float]:
+        out_len = [0]
+        p = flox_indicator_graph_require(self._h, u32(symbol), name.c_str(), out_len.arr.ptr)
+        if int(p) == 0:
+            raise ValueError("graph: require failed for node " + name)
+        return _ptr_to_list(p, out_len[0])
+
+    def get(self, symbol: int, name: str) -> Optional[List[float]]:
+        out_len = [0]
+        p = flox_indicator_graph_get(self._h, u32(symbol), name.c_str(), out_len.arr.ptr)
+        if int(p) == 0:
+            return None
+        return _ptr_to_list(p, out_len[0])
+
+    def close(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_indicator_graph_close(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    def high(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_indicator_graph_high(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    def low(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_indicator_graph_low(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    def volume(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_indicator_graph_volume(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    def invalidate(self, symbol: int):
+        flox_indicator_graph_invalidate(self._h, u32(symbol))
+
+    def invalidate_all(self):
+        flox_indicator_graph_invalidate_all(self._h)
+
+    # add_node from Codon requires the user to supply a C-compatible
+    # function pointer (top-level function with the FloxGraphNodeFn
+    # signature) rather than a closure. Pass `fn_ptr` as cobj and
+    # `user_data` as cobj or Ptr; the graph keeps both alive.
+    def add_node_raw(self, name: str, deps: List[str],
+                     fn_ptr: cobj, user_data: cobj = cobj()):
+        n = len(deps)
+        # Build a Ptr[cobj] of C-string pointers for deps.
+        dep_ptrs = Ptr[cobj](n) if n > 0 else Ptr[cobj]()
+        for i in range(n):
+            dep_ptrs[i] = deps[i].c_str()
+        flox_indicator_graph_add_node(self._h, name.c_str(), dep_ptrs, n,
+                                      fn_ptr, user_data)

--- a/codon/flox/graph.codon
+++ b/codon/flox/graph.codon
@@ -25,6 +25,19 @@ from C import flox_indicator_graph_volume(cobj, u32, Ptr[int]) -> Ptr[f64]
 from C import flox_indicator_graph_invalidate(cobj, u32)
 from C import flox_indicator_graph_invalidate_all(cobj)
 
+from C import flox_streaming_graph_create() -> cobj
+from C import flox_streaming_graph_destroy(cobj)
+from C import flox_streaming_graph_add_node(cobj, cobj, Ptr[cobj], int, cobj, cobj)
+from C import flox_streaming_graph_step(cobj, u32, f64, f64, f64, f64, f64)
+from C import flox_streaming_graph_current(cobj, u32, cobj) -> f64
+from C import flox_streaming_graph_bar_count(cobj, u32) -> u32
+from C import flox_streaming_graph_reset(cobj, u32)
+from C import flox_streaming_graph_reset_all(cobj)
+from C import flox_streaming_graph_close(cobj, u32, Ptr[int]) -> Ptr[f64]
+from C import flox_streaming_graph_high(cobj, u32, Ptr[int]) -> Ptr[f64]
+from C import flox_streaming_graph_low(cobj, u32, Ptr[int]) -> Ptr[f64]
+from C import flox_streaming_graph_volume(cobj, u32, Ptr[int]) -> Ptr[f64]
+
 
 def _ptr_to_list(p: Ptr[f64], n: int) -> List[float]:
     out = [0.0] * n
@@ -106,4 +119,65 @@ class IndicatorGraph:
         for i in range(n):
             dep_ptrs[i] = deps[i].c_str()
         flox_indicator_graph_add_node(self._h, name.c_str(), dep_ptrs, n,
+                                      fn_ptr, user_data)
+
+
+class StreamingIndicatorGraph:
+    _h: cobj
+
+    def __init__(self):
+        self._h = flox_streaming_graph_create()
+
+    def __del__(self):
+        if self._h != cobj():
+            flox_streaming_graph_destroy(self._h)
+            self._h = cobj()
+
+    def step(self, symbol: int, close: float, high: float = -1.0,
+             low: float = -1.0, volume: float = 0.0):
+        h = high if high >= 0.0 else close
+        l = low if low >= 0.0 else close
+        flox_streaming_graph_step(self._h, u32(symbol), close, h, l, close, volume)
+
+    def current(self, symbol: int, name: str) -> float:
+        return flox_streaming_graph_current(self._h, u32(symbol), name.c_str())
+
+    def bar_count(self, symbol: int) -> int:
+        return int(flox_streaming_graph_bar_count(self._h, u32(symbol)))
+
+    def reset(self, symbol: int):
+        flox_streaming_graph_reset(self._h, u32(symbol))
+
+    def reset_all(self):
+        flox_streaming_graph_reset_all(self._h)
+
+    def close(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_streaming_graph_close(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    def high(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_streaming_graph_high(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    def low(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_streaming_graph_low(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    def volume(self, symbol: int) -> List[float]:
+        out_len = [0]
+        p = flox_streaming_graph_volume(self._h, u32(symbol), out_len.arr.ptr)
+        return _ptr_to_list(p, out_len[0])
+
+    # add_node_raw: same constraint as IndicatorGraph — fn_ptr must be a
+    # top-level C-compatible function pointer (no closures).
+    def add_node_raw(self, name: str, deps: List[str],
+                     fn_ptr: cobj, user_data: cobj = cobj()):
+        n = len(deps)
+        dep_ptrs = Ptr[cobj](n) if n > 0 else Ptr[cobj]()
+        for i in range(n):
+            dep_ptrs[i] = deps[i].c_str()
+        flox_streaming_graph_add_node(self._h, name.c_str(), dep_ptrs, n,
                                       fn_ptr, user_data)

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -252,6 +252,66 @@ extern "C"
                                        double* output);
 
   // ============================================================
+  // IndicatorGraph (batch)
+  //
+  // Compose batch indicators with shared intermediate caching. Nodes are
+  // user-supplied callbacks; require() walks the DAG in topological order.
+  //
+  //   FloxIndicatorGraphHandle g = flox_indicator_graph_create();
+  //   flox_indicator_graph_set_bars(g, sym, close, high, low, volume, n);
+  //   flox_indicator_graph_add_node(g, "ema50", NULL, 0, ema_fn, ema_state);
+  //   const double* out = flox_indicator_graph_require(g, sym, "ema50", &len);
+  //   flox_indicator_graph_destroy(g);
+  // ============================================================
+
+  typedef void* FloxIndicatorGraphHandle;
+
+  // Compute callback. Output array must be allocated by the callback (or pre-
+  // allocated by the user). The host language is responsible for keeping it
+  // alive until the next graph call. Returning a pointer with len = 0 signals
+  // an empty result.
+  typedef const double* (*FloxGraphNodeFn)(void* user_data, FloxIndicatorGraphHandle g,
+                                           uint32_t symbol, size_t* out_len);
+
+  FloxIndicatorGraphHandle flox_indicator_graph_create(void);
+  void flox_indicator_graph_destroy(FloxIndicatorGraphHandle g);
+
+  // Pass NULL for high/low/volume to default high=low=close and volume=0.
+  void flox_indicator_graph_set_bars(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                     const double* close, const double* high, const double* low,
+                                     const double* volume, size_t len);
+
+  // deps: array of `num_deps` C-string node names (or NULL if num_deps == 0).
+  void flox_indicator_graph_add_node(FloxIndicatorGraphHandle g, const char* name,
+                                     const char* const* deps, size_t num_deps,
+                                     FloxGraphNodeFn fn, void* user_data);
+
+  // Returns a pointer to the cached output for (symbol, name) and writes its
+  // length to *len_out. The pointer is owned by the graph and is valid until
+  // the next invalidate / destroy call. Returns NULL on error (unknown node,
+  // cycle, etc.).
+  const double* flox_indicator_graph_require(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                             const char* name, size_t* len_out);
+
+  // Same as require but only returns a pointer if the node has already been
+  // computed; never triggers compute. Returns NULL if not yet computed.
+  const double* flox_indicator_graph_get(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                         const char* name, size_t* len_out);
+
+  // Field accessors return cached double arrays for the symbol's bars.
+  const double* flox_indicator_graph_close(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                           size_t* len_out);
+  const double* flox_indicator_graph_high(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                          size_t* len_out);
+  const double* flox_indicator_graph_low(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                         size_t* len_out);
+  const double* flox_indicator_graph_volume(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                            size_t* len_out);
+
+  void flox_indicator_graph_invalidate(FloxIndicatorGraphHandle g, uint32_t symbol);
+  void flox_indicator_graph_invalidate_all(FloxIndicatorGraphHandle g);
+
+  // ============================================================
   // Order book
   // ============================================================
 

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -312,6 +312,54 @@ extern "C"
   void flox_indicator_graph_invalidate_all(FloxIndicatorGraphHandle g);
 
   // ============================================================
+  // StreamingIndicatorGraph
+  //
+  // Same node definitions as the batch graph; step() advances one bar at a
+  // time and stores each node's last output as the current value.
+  //
+  //   FloxStreamingGraphHandle sg = flox_streaming_graph_create();
+  //   flox_streaming_graph_add_node(sg, "ema5", NULL, 0, ema_fn, state);
+  //   // live bar loop:
+  //   flox_streaming_graph_step(sg, sym, open, high, low, close, volume);
+  //   double v = flox_streaming_graph_current(sg, sym, "ema5");
+  //   flox_streaming_graph_destroy(sg);
+  // ============================================================
+
+  typedef void* FloxStreamingGraphHandle;
+
+  FloxStreamingGraphHandle flox_streaming_graph_create(void);
+  void flox_streaming_graph_destroy(FloxStreamingGraphHandle sg);
+
+  // Same signature as flox_indicator_graph_add_node; node fns receive a
+  // FloxIndicatorGraphHandle pointing to the inner batch graph.
+  void flox_streaming_graph_add_node(FloxStreamingGraphHandle sg, const char* name,
+                                     const char* const* deps, size_t num_deps,
+                                     FloxGraphNodeFn fn, void* user_data);
+
+  // Advance one bar. open/high/low/close/volume are doubles.
+  void flox_streaming_graph_step(FloxStreamingGraphHandle sg, uint32_t symbol, double open,
+                                 double high, double low, double close, double volume);
+
+  // Current (last-bar) value for a node. Returns NaN if not yet computed.
+  double flox_streaming_graph_current(FloxStreamingGraphHandle sg, uint32_t symbol,
+                                      const char* name);
+
+  uint32_t flox_streaming_graph_bar_count(FloxStreamingGraphHandle sg, uint32_t symbol);
+
+  void flox_streaming_graph_reset(FloxStreamingGraphHandle sg, uint32_t symbol);
+  void flox_streaming_graph_reset_all(FloxStreamingGraphHandle sg);
+
+  // Field accessors — return the accumulated history arrays (same as batch graph after step).
+  const double* flox_streaming_graph_close(FloxStreamingGraphHandle sg, uint32_t symbol,
+                                           size_t* len_out);
+  const double* flox_streaming_graph_high(FloxStreamingGraphHandle sg, uint32_t symbol,
+                                          size_t* len_out);
+  const double* flox_streaming_graph_low(FloxStreamingGraphHandle sg, uint32_t symbol,
+                                         size_t* len_out);
+  const double* flox_streaming_graph_volume(FloxStreamingGraphHandle sg, uint32_t symbol,
+                                            size_t* len_out);
+
+  // ============================================================
   // Order book
   // ============================================================
 

--- a/include/flox/indicator/streaming_graph.h
+++ b/include/flox/indicator/streaming_graph.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "flox/aggregator/bar.h"
+#include "flox/common.h"
+#include "flox/indicator/indicator_pipeline.h"
+
+#include <cmath>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace flox::indicator
+{
+
+// Streaming wrapper around IndicatorGraph.
+//
+// Accumulates bars one at a time via step(). After each step the batch graph
+// runs on the full accumulated history and each node's last value is stored as
+// the current output. This guarantees exact parity with a batch run on the same
+// bars.
+//
+//   StreamingIndicatorGraph sg;
+//   sg.addNode("ema5", {}, [](auto& g, auto sym) {
+//       return EMA(5).compute(g.close(sym));
+//   });
+//   for (const auto& bar : live_bars)
+//   {
+//     sg.step(sym, bar);
+//     double val = sg.current(sym, "ema5"); // NaN until warm-up done
+//   }
+class StreamingIndicatorGraph
+{
+ public:
+  using ComputeFn = IndicatorGraph::ComputeFn;
+
+  void addNode(std::string name, std::vector<std::string> deps, ComputeFn fn)
+  {
+    _nodeNames.push_back(name);
+    _graph.addNode(std::move(name), std::move(deps), std::move(fn));
+  }
+
+  void step(SymbolId symbol, const Bar& bar)
+  {
+    _history[symbol].push_back(bar);
+    _graph.setBars(symbol, _history[symbol]);
+    for (const auto& name : _nodeNames)
+    {
+      try
+      {
+        const auto& v = _graph.require(symbol, name);
+        _current[{symbol, name}] = v.empty() ? std::nan("") : v.back();
+      }
+      catch (...)
+      {
+        _current[{symbol, name}] = std::nan("");
+      }
+    }
+  }
+
+  // Returns the most recent computed value for (symbol, name).
+  // Returns NaN if no bars have been stepped or the node is not warm yet.
+  double current(SymbolId symbol, const std::string& name) const
+  {
+    auto it = _current.find({symbol, name});
+    return it != _current.end() ? it->second : std::nan("");
+  }
+
+  size_t barCount(SymbolId symbol) const
+  {
+    auto it = _history.find(symbol);
+    return it != _history.end() ? it->second.size() : 0;
+  }
+
+  void reset(SymbolId symbol)
+  {
+    _history.erase(symbol);
+    _graph.invalidate(symbol);
+    for (auto it = _current.begin(); it != _current.end();)
+    {
+      if (it->first.first == symbol)
+      {
+        it = _current.erase(it);
+      }
+      else
+      {
+        ++it;
+      }
+    }
+  }
+
+  void resetAll()
+  {
+    _history.clear();
+    _graph.invalidateAll();
+    _current.clear();
+  }
+
+  IndicatorGraph& batchGraph() { return _graph; }
+
+ private:
+  IndicatorGraph _graph;
+  std::vector<std::string> _nodeNames;
+  std::unordered_map<SymbolId, std::vector<Bar>> _history;
+
+  using CurrentKey = std::pair<SymbolId, std::string>;
+  struct CurrentKeyHash
+  {
+    size_t operator()(const CurrentKey& k) const
+    {
+      return std::hash<SymbolId>{}(k.first) ^ (std::hash<std::string>{}(k.second) * 2654435761u);
+    }
+  };
+  std::unordered_map<CurrentKey, double, CurrentKeyHash> _current;
+};
+
+}  // namespace flox::indicator

--- a/node/src/flox_node.cpp
+++ b/node/src/flox_node.cpp
@@ -7,6 +7,7 @@
 #include "books.h"
 #include "data_ops.h"
 #include "engine.h"
+#include "graph.h"
 #include "indicators.h"
 #include "positions.h"
 #include "profiles.h"
@@ -27,6 +28,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports)
   node_flox::registerDataOps(env, exports);
   node_flox::registerStrategy(env, exports);
   node_flox::registerTargets(env, exports);
+  node_flox::registerGraph(env, exports);
   return exports;
 }
 

--- a/node/src/graph.h
+++ b/node/src/graph.h
@@ -1,0 +1,195 @@
+// node/src/graph.h -- IndicatorGraph (batch) wrapper.
+
+#pragma once
+#include <napi.h>
+
+#include <cstring>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "flox/aggregator/bar.h"
+#include "flox/common.h"
+#include "flox/indicator/indicator_pipeline.h"
+
+namespace node_flox
+{
+
+class IndicatorGraphWrap : public Napi::ObjectWrap<IndicatorGraphWrap>
+{
+ public:
+  static Napi::Function Init(Napi::Env env)
+  {
+    return DefineClass(env, "IndicatorGraph",
+                       {InstanceMethod("setBars", &IndicatorGraphWrap::SetBars),
+                        InstanceMethod("addNode", &IndicatorGraphWrap::AddNode),
+                        InstanceMethod("require", &IndicatorGraphWrap::Require),
+                        InstanceMethod("get", &IndicatorGraphWrap::Get),
+                        InstanceMethod("close", &IndicatorGraphWrap::Close),
+                        InstanceMethod("high", &IndicatorGraphWrap::High),
+                        InstanceMethod("low", &IndicatorGraphWrap::Low),
+                        InstanceMethod("volume", &IndicatorGraphWrap::Volume),
+                        InstanceMethod("invalidate", &IndicatorGraphWrap::Invalidate),
+                        InstanceMethod("invalidateAll", &IndicatorGraphWrap::InvalidateAll)});
+  }
+
+  IndicatorGraphWrap(const Napi::CallbackInfo& info)
+      : Napi::ObjectWrap<IndicatorGraphWrap>(info), _self(info.This().As<Napi::Object>().Get("__handle__"))
+  {
+    // _self is unused; we store info.This() via a persistent reference inside addNode.
+  }
+
+ private:
+  Napi::Value vec2arr(Napi::Env env, const std::vector<double>& v)
+  {
+    auto a = Napi::Float64Array::New(env, v.size());
+    std::memcpy(a.Data(), v.data(), v.size() * sizeof(double));
+    return a;
+  }
+
+  Napi::Value SetBars(const Napi::CallbackInfo& info)
+  {
+    auto env = info.Env();
+    uint32_t symbol = info[0].As<Napi::Number>().Uint32Value();
+    auto close = info[1].As<Napi::Float64Array>();
+    size_t n = close.ElementLength();
+
+    auto fetch = [&](size_t idx) -> const double*
+    {
+      if (info.Length() <= idx || info[idx].IsUndefined() || info[idx].IsNull())
+      {
+        return nullptr;
+      }
+      auto a = info[idx].As<Napi::Float64Array>();
+      if (a.ElementLength() != n)
+      {
+        Napi::TypeError::New(env, "setBars: arrays must match close length")
+            .ThrowAsJavaScriptException();
+        return nullptr;
+      }
+      return a.Data();
+    };
+
+    const double* h = fetch(2);
+    const double* l = fetch(3);
+    const double* v = fetch(4);
+    const double* c = close.Data();
+
+    std::vector<flox::Bar> bars(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+      bars[i].open = flox::Price::fromDouble(c[i]);
+      bars[i].high = flox::Price::fromDouble(h ? h[i] : c[i]);
+      bars[i].low = flox::Price::fromDouble(l ? l[i] : c[i]);
+      bars[i].close = flox::Price::fromDouble(c[i]);
+      bars[i].volume = v ? flox::Volume::fromDouble(v[i]) : flox::Volume{};
+    }
+    _bars[symbol] = std::move(bars);
+    _graph.setBars(static_cast<flox::SymbolId>(symbol),
+                   std::span<const flox::Bar>(_bars[symbol]));
+    return env.Undefined();
+  }
+
+  Napi::Value AddNode(const Napi::CallbackInfo& info)
+  {
+    auto env = info.Env();
+    std::string name = info[0].As<Napi::String>().Utf8Value();
+
+    auto depsArr = info[1].As<Napi::Array>();
+    std::vector<std::string> deps;
+    deps.reserve(depsArr.Length());
+    for (uint32_t i = 0; i < depsArr.Length(); ++i)
+    {
+      deps.push_back(depsArr.Get(i).As<Napi::String>().Utf8Value());
+    }
+
+    auto fnRef = std::make_shared<Napi::FunctionReference>(
+        Napi::Persistent(info[2].As<Napi::Function>()));
+    auto thisRef = std::make_shared<Napi::ObjectReference>(Napi::Persistent(info.This().As<Napi::Object>()));
+    Napi::Env fnEnv = env;
+
+    _graph.addNode(name, std::move(deps),
+                   [fnRef, thisRef, fnEnv](flox::indicator::IndicatorGraph&,
+                                           flox::SymbolId sym) -> std::vector<double>
+                   {
+                     Napi::HandleScope scope(fnEnv);
+                     Napi::Value result = fnRef->Call(
+                         {thisRef->Value(),
+                          Napi::Number::New(fnEnv, static_cast<uint32_t>(sym))});
+                     auto arr = result.As<Napi::Float64Array>();
+                     return std::vector<double>(arr.Data(), arr.Data() + arr.ElementLength());
+                   });
+    return env.Undefined();
+  }
+
+  Napi::Value Require(const Napi::CallbackInfo& info)
+  {
+    uint32_t symbol = info[0].As<Napi::Number>().Uint32Value();
+    std::string name = info[1].As<Napi::String>().Utf8Value();
+    try
+    {
+      const auto& v = _graph.require(static_cast<flox::SymbolId>(symbol), name);
+      return vec2arr(info.Env(), v);
+    }
+    catch (const std::exception& e)
+    {
+      Napi::Error::New(info.Env(), e.what()).ThrowAsJavaScriptException();
+      return info.Env().Undefined();
+    }
+  }
+
+  Napi::Value Get(const Napi::CallbackInfo& info)
+  {
+    uint32_t symbol = info[0].As<Napi::Number>().Uint32Value();
+    std::string name = info[1].As<Napi::String>().Utf8Value();
+    const auto* v = _graph.get(static_cast<flox::SymbolId>(symbol), name);
+    if (!v)
+    {
+      return info.Env().Null();
+    }
+    return vec2arr(info.Env(), *v);
+  }
+
+  Napi::Value Close(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _graph.close(static_cast<flox::SymbolId>(s)));
+  }
+  Napi::Value High(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _graph.high(static_cast<flox::SymbolId>(s)));
+  }
+  Napi::Value Low(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _graph.low(static_cast<flox::SymbolId>(s)));
+  }
+  Napi::Value Volume(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _graph.volume(static_cast<flox::SymbolId>(s)));
+  }
+  Napi::Value Invalidate(const Napi::CallbackInfo& info)
+  {
+    _graph.invalidate(static_cast<flox::SymbolId>(info[0].As<Napi::Number>().Uint32Value()));
+    return info.Env().Undefined();
+  }
+  Napi::Value InvalidateAll(const Napi::CallbackInfo& info)
+  {
+    _graph.invalidateAll();
+    return info.Env().Undefined();
+  }
+
+  Napi::Value _self;  // unused, kept to silence -Wunused-private-field issues
+  flox::indicator::IndicatorGraph _graph;
+  std::unordered_map<uint32_t, std::vector<flox::Bar>> _bars;
+};
+
+inline void registerGraph(Napi::Env env, Napi::Object exports)
+{
+  exports.Set("IndicatorGraph", IndicatorGraphWrap::Init(env));
+}
+
+}  // namespace node_flox

--- a/node/src/graph.h
+++ b/node/src/graph.h
@@ -12,6 +12,7 @@
 #include "flox/aggregator/bar.h"
 #include "flox/common.h"
 #include "flox/indicator/indicator_pipeline.h"
+#include "flox/indicator/streaming_graph.h"
 
 namespace node_flox
 {
@@ -187,9 +188,150 @@ class IndicatorGraphWrap : public Napi::ObjectWrap<IndicatorGraphWrap>
   std::unordered_map<uint32_t, std::vector<flox::Bar>> _bars;
 };
 
+class StreamingIndicatorGraphWrap : public Napi::ObjectWrap<StreamingIndicatorGraphWrap>
+{
+ public:
+  static Napi::Function Init(Napi::Env env)
+  {
+    return DefineClass(
+        env, "StreamingIndicatorGraph",
+        {InstanceMethod("addNode", &StreamingIndicatorGraphWrap::AddNode),
+         InstanceMethod("step", &StreamingIndicatorGraphWrap::Step),
+         InstanceMethod("current", &StreamingIndicatorGraphWrap::Current),
+         InstanceMethod("barCount", &StreamingIndicatorGraphWrap::BarCount),
+         InstanceMethod("reset", &StreamingIndicatorGraphWrap::Reset),
+         InstanceMethod("resetAll", &StreamingIndicatorGraphWrap::ResetAll),
+         InstanceMethod("close", &StreamingIndicatorGraphWrap::Close),
+         InstanceMethod("high", &StreamingIndicatorGraphWrap::High),
+         InstanceMethod("low", &StreamingIndicatorGraphWrap::Low),
+         InstanceMethod("volume", &StreamingIndicatorGraphWrap::Volume)});
+  }
+
+  StreamingIndicatorGraphWrap(const Napi::CallbackInfo& info)
+      : Napi::ObjectWrap<StreamingIndicatorGraphWrap>(info)
+  {
+  }
+
+ private:
+  Napi::Value vec2arr(Napi::Env env, const std::vector<double>& v)
+  {
+    auto a = Napi::Float64Array::New(env, v.size());
+    std::memcpy(a.Data(), v.data(), v.size() * sizeof(double));
+    return a;
+  }
+
+  Napi::Value AddNode(const Napi::CallbackInfo& info)
+  {
+    auto env = info.Env();
+    std::string name = info[0].As<Napi::String>().Utf8Value();
+
+    auto depsArr = info[1].As<Napi::Array>();
+    std::vector<std::string> deps;
+    deps.reserve(depsArr.Length());
+    for (uint32_t i = 0; i < depsArr.Length(); ++i)
+    {
+      deps.push_back(depsArr.Get(i).As<Napi::String>().Utf8Value());
+    }
+
+    auto fnRef = std::make_shared<Napi::FunctionReference>(
+        Napi::Persistent(info[2].As<Napi::Function>()));
+    auto thisRef = std::make_shared<Napi::ObjectReference>(
+        Napi::Persistent(info.This().As<Napi::Object>()));
+    Napi::Env fnEnv = env;
+
+    _sg.addNode(name, std::move(deps),
+                [fnRef, thisRef, fnEnv](flox::indicator::IndicatorGraph&,
+                                        flox::SymbolId sym) -> std::vector<double>
+                {
+                  Napi::HandleScope scope(fnEnv);
+                  Napi::Value result = fnRef->Call(
+                      {thisRef->Value(),
+                       Napi::Number::New(fnEnv, static_cast<uint32_t>(sym))});
+                  auto arr = result.As<Napi::Float64Array>();
+                  return std::vector<double>(arr.Data(), arr.Data() + arr.ElementLength());
+                });
+    return env.Undefined();
+  }
+
+  Napi::Value Step(const Napi::CallbackInfo& info)
+  {
+    auto env = info.Env();
+    uint32_t symbol = info[0].As<Napi::Number>().Uint32Value();
+    double c = info[1].As<Napi::Number>().DoubleValue();
+    double h = info.Length() > 2 && !info[2].IsUndefined() && !info[2].IsNull()
+                   ? info[2].As<Napi::Number>().DoubleValue()
+                   : c;
+    double l = info.Length() > 3 && !info[3].IsUndefined() && !info[3].IsNull()
+                   ? info[3].As<Napi::Number>().DoubleValue()
+                   : c;
+    double v = info.Length() > 4 && !info[4].IsUndefined() && !info[4].IsNull()
+                   ? info[4].As<Napi::Number>().DoubleValue()
+                   : 0.0;
+    flox::Bar bar;
+    bar.open = flox::Price::fromDouble(c);
+    bar.high = flox::Price::fromDouble(h);
+    bar.low = flox::Price::fromDouble(l);
+    bar.close = flox::Price::fromDouble(c);
+    bar.volume = flox::Volume::fromDouble(v);
+    _sg.step(static_cast<flox::SymbolId>(symbol), bar);
+    return env.Undefined();
+  }
+
+  Napi::Value Current(const Napi::CallbackInfo& info)
+  {
+    uint32_t symbol = info[0].As<Napi::Number>().Uint32Value();
+    std::string name = info[1].As<Napi::String>().Utf8Value();
+    return Napi::Number::New(info.Env(),
+                             _sg.current(static_cast<flox::SymbolId>(symbol), name));
+  }
+
+  Napi::Value BarCount(const Napi::CallbackInfo& info)
+  {
+    uint32_t symbol = info[0].As<Napi::Number>().Uint32Value();
+    return Napi::Number::New(info.Env(),
+                             static_cast<double>(_sg.barCount(static_cast<flox::SymbolId>(symbol))));
+  }
+
+  Napi::Value Reset(const Napi::CallbackInfo& info)
+  {
+    _sg.reset(static_cast<flox::SymbolId>(info[0].As<Napi::Number>().Uint32Value()));
+    return info.Env().Undefined();
+  }
+
+  Napi::Value ResetAll(const Napi::CallbackInfo& info)
+  {
+    _sg.resetAll();
+    return info.Env().Undefined();
+  }
+
+  Napi::Value Close(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _sg.batchGraph().close(static_cast<flox::SymbolId>(s)));
+  }
+  Napi::Value High(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _sg.batchGraph().high(static_cast<flox::SymbolId>(s)));
+  }
+  Napi::Value Low(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _sg.batchGraph().low(static_cast<flox::SymbolId>(s)));
+  }
+  Napi::Value Volume(const Napi::CallbackInfo& info)
+  {
+    uint32_t s = info[0].As<Napi::Number>().Uint32Value();
+    return vec2arr(info.Env(), _sg.batchGraph().volume(static_cast<flox::SymbolId>(s)));
+  }
+
+  flox::indicator::StreamingIndicatorGraph _sg;
+};
+
 inline void registerGraph(Napi::Env env, Napi::Object exports)
 {
   exports.Set("IndicatorGraph", IndicatorGraphWrap::Init(env));
+  exports.Set("StreamingIndicatorGraph", StreamingIndicatorGraphWrap::Init(env));
 }
 
 }  // namespace node_flox

--- a/node/test/test_bindings.js
+++ b/node/test/test_bindings.js
@@ -129,6 +129,41 @@ let threw = false;
 try { g.require(0, 'missing'); } catch (e) { threw = true; }
 check(threw, 'graph require on unknown node throws');
 
+// ── StreamingIndicatorGraph ────────────────────────────────────────────
+
+console.log('=== StreamingIndicatorGraph ===');
+
+const sg = new flox.StreamingIndicatorGraph();
+sg.addNode('double_close', [], (graph, sym) => {
+  const c = graph.close(sym);
+  const out = new Float64Array(c.length);
+  for (let i = 0; i < c.length; ++i) out[i] = c[i] * 2.0;
+  return out;
+});
+
+const closesS = [10.0, 20.0, 30.0, 40.0, 50.0];
+for (const c of closesS) sg.step(0, c);
+
+check(Math.abs(sg.current(0, 'double_close') - 100.0) < 1e-9, 'streaming current after 5 steps');
+check(sg.barCount(0) === 5, 'streaming barCount == 5');
+
+// Parity check.
+const bg2 = new flox.IndicatorGraph();
+bg2.setBars(0, new Float64Array(closesS));
+bg2.addNode('double_close', [], (graph, sym) => {
+  const c = graph.close(sym);
+  const out = new Float64Array(c.length);
+  for (let i = 0; i < c.length; ++i) out[i] = c[i] * 2.0;
+  return out;
+});
+const batchDc = bg2.require(0, 'double_close');
+check(Math.abs(sg.current(0, 'double_close') - batchDc[batchDc.length - 1]) < 1e-9,
+      'streaming current == batch last element');
+
+sg.reset(0);
+check(sg.barCount(0) === 0, 'after reset barCount == 0');
+check(Number.isNaN(sg.current(0, 'double_close')), 'after reset current is NaN');
+
 // ── PositionTracker ───────────────────────────────────────────────────
 
 console.log('=== PositionTracker ===');

--- a/node/test/test_bindings.js
+++ b/node/test/test_bindings.js
@@ -98,6 +98,37 @@ const sl = flox.targets.future_linear_slope(linear, 4);
 check(approx(sl[0], 0.5), 'targets.future_linear_slope linear-series == 0.5');
 check(Number.isNaN(sl[19]), 'targets.future_linear_slope tail NaN');
 
+// ── IndicatorGraph (batch) ────────────────────────────────────────────
+
+console.log('=== IndicatorGraph (batch) ===');
+
+const ramp = new Float64Array(50);
+for (let i = 0; i < 50; ++i) ramp[i] = i;
+
+const g = new flox.IndicatorGraph();
+g.setBars(0, ramp);
+
+g.addNode('ema5', [], (graph, sym) => flox.ema(graph.close(sym), 5));
+g.addNode('sma5', [], (graph, sym) => flox.sma(graph.close(sym), 5));
+g.addNode('diff', ['ema5', 'sma5'], (graph, sym) => {
+  const a = graph.get(sym, 'ema5');
+  const b = graph.get(sym, 'sma5');
+  const out = new Float64Array(a.length);
+  for (let i = 0; i < a.length; ++i) out[i] = a[i] - b[i];
+  return out;
+});
+
+const ema5 = g.require(0, 'ema5');
+const diff = g.require(0, 'diff');
+check(ema5.length === 50, 'graph require returns full-length array');
+check(diff.length === 50, 'graph dependent node has same length');
+check(g.get(0, 'sma5') !== null, 'graph get returns cached node array');
+check(g.get(0, 'never_added') === null, 'graph get on missing node returns null');
+
+let threw = false;
+try { g.require(0, 'missing'); } catch (e) { threw = true; }
+check(threw, 'graph require on unknown node throws');
+
 // ── PositionTracker ───────────────────────────────────────────────────
 
 console.log('=== PositionTracker ===');

--- a/python/flox_py.cpp
+++ b/python/flox_py.cpp
@@ -12,6 +12,7 @@
 #include "flox/backtest/simulated_clock.h"
 #include "flox/backtest/simulated_executor.h"
 #include "flox/common.h"
+#include "graph_bindings.h"
 #include "indicator_bindings.h"
 #include "optimizer_bindings.h"
 #include "position_bindings.h"
@@ -724,6 +725,7 @@ PYBIND11_MODULE(flox_py, m)
   bindCompositeBook(m);
   bindStrategy(m);
   bindTargets(m);
+  bindIndicatorGraph(m);
 
   // Slippage model constants
   m.attr("SLIPPAGE_NONE") = 0;

--- a/python/graph_bindings.h
+++ b/python/graph_bindings.h
@@ -12,6 +12,7 @@
 #include "flox/aggregator/bar.h"
 #include "flox/common.h"
 #include "flox/indicator/indicator_pipeline.h"
+#include "flox/indicator/streaming_graph.h"
 
 namespace py = pybind11;
 
@@ -147,6 +148,85 @@ class PyIndicatorGraph
   std::unordered_map<uint32_t, std::vector<flox::Bar>> _bars;
 };
 
+class PyStreamingIndicatorGraph
+{
+ public:
+  PyStreamingIndicatorGraph() = default;
+
+  void addNode(const std::string& name, std::vector<std::string> deps, py::object fn)
+  {
+    PyStreamingIndicatorGraph* self = this;
+    _sg.addNode(
+        name, std::move(deps),
+        [self, fn](flox::indicator::IndicatorGraph&, flox::SymbolId sym) -> std::vector<double>
+        {
+          py::object result = fn(py::cast(self, py::return_value_policy::reference),
+                                 static_cast<uint32_t>(sym));
+          py::array_t<double, py::array::c_style | py::array::forcecast> arr =
+              result.cast<py::array_t<double, py::array::c_style | py::array::forcecast>>();
+          auto buf = arr.request();
+          size_t n = buf.shape[0];
+          const double* p = static_cast<const double*>(buf.ptr);
+          return std::vector<double>(p, p + n);
+        });
+  }
+
+  void step(uint32_t symbol, double close, std::optional<double> high, std::optional<double> low,
+            std::optional<double> volume)
+  {
+    flox::Bar bar;
+    double h = high.value_or(close);
+    double l = low.value_or(close);
+    double v = volume.value_or(0.0);
+    bar.open = flox::Price::fromDouble(close);
+    bar.high = flox::Price::fromDouble(h);
+    bar.low = flox::Price::fromDouble(l);
+    bar.close = flox::Price::fromDouble(close);
+    bar.volume = flox::Volume::fromDouble(v);
+    _sg.step(static_cast<flox::SymbolId>(symbol), bar);
+  }
+
+  double current(uint32_t symbol, const std::string& name) const
+  {
+    return _sg.current(static_cast<flox::SymbolId>(symbol), name);
+  }
+
+  size_t barCount(uint32_t symbol) const
+  {
+    return _sg.barCount(static_cast<flox::SymbolId>(symbol));
+  }
+
+  void reset(uint32_t symbol) { _sg.reset(static_cast<flox::SymbolId>(symbol)); }
+  void resetAll() { _sg.resetAll(); }
+
+  py::array_t<double> close(uint32_t symbol)
+  {
+    return toArray(_sg.batchGraph().close(static_cast<flox::SymbolId>(symbol)));
+  }
+  py::array_t<double> high(uint32_t symbol)
+  {
+    return toArray(_sg.batchGraph().high(static_cast<flox::SymbolId>(symbol)));
+  }
+  py::array_t<double> low(uint32_t symbol)
+  {
+    return toArray(_sg.batchGraph().low(static_cast<flox::SymbolId>(symbol)));
+  }
+  py::array_t<double> volume(uint32_t symbol)
+  {
+    return toArray(_sg.batchGraph().volume(static_cast<flox::SymbolId>(symbol)));
+  }
+
+ private:
+  static py::array_t<double> toArray(const std::vector<double>& v)
+  {
+    py::array_t<double> out(v.size());
+    std::memcpy(out.mutable_data(), v.data(), v.size() * sizeof(double));
+    return out;
+  }
+
+  flox::indicator::StreamingIndicatorGraph _sg;
+};
+
 }  // namespace
 
 inline void bindIndicatorGraph(py::module_& m)
@@ -166,4 +246,20 @@ inline void bindIndicatorGraph(py::module_& m)
       .def("volume", &PyIndicatorGraph::volume, py::arg("symbol"))
       .def("invalidate", &PyIndicatorGraph::invalidate, py::arg("symbol"))
       .def("invalidate_all", &PyIndicatorGraph::invalidateAll);
+
+  py::class_<PyStreamingIndicatorGraph>(m, "StreamingIndicatorGraph")
+      .def(py::init<>())
+      .def("add_node", &PyStreamingIndicatorGraph::addNode, py::arg("name"), py::arg("deps"),
+           py::arg("fn"))
+      .def("step", &PyStreamingIndicatorGraph::step, py::arg("symbol"), py::arg("close"),
+           py::arg("high") = py::none(), py::arg("low") = py::none(),
+           py::arg("volume") = py::none())
+      .def("current", &PyStreamingIndicatorGraph::current, py::arg("symbol"), py::arg("name"))
+      .def("bar_count", &PyStreamingIndicatorGraph::barCount, py::arg("symbol"))
+      .def("reset", &PyStreamingIndicatorGraph::reset, py::arg("symbol"))
+      .def("reset_all", &PyStreamingIndicatorGraph::resetAll)
+      .def("close", &PyStreamingIndicatorGraph::close, py::arg("symbol"))
+      .def("high", &PyStreamingIndicatorGraph::high, py::arg("symbol"))
+      .def("low", &PyStreamingIndicatorGraph::low, py::arg("symbol"))
+      .def("volume", &PyStreamingIndicatorGraph::volume, py::arg("symbol"));
 }

--- a/python/graph_bindings.h
+++ b/python/graph_bindings.h
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "flox/aggregator/bar.h"
+#include "flox/common.h"
+#include "flox/indicator/indicator_pipeline.h"
+
+namespace py = pybind11;
+
+namespace
+{
+
+using contiguous_double_graph =
+    py::array_t<double, py::array::c_style | py::array::forcecast>;
+
+// Wraps flox::indicator::IndicatorGraph for Python. Single-symbol path is
+// the primary use; multi-symbol works by passing distinct symbol IDs.
+class PyIndicatorGraph
+{
+ public:
+  PyIndicatorGraph() = default;
+
+  void setBars(uint32_t symbol, contiguous_double_graph close,
+               std::optional<contiguous_double_graph> high,
+               std::optional<contiguous_double_graph> low,
+               std::optional<contiguous_double_graph> volume)
+  {
+    auto cBuf = close.request();
+    size_t n = cBuf.shape[0];
+    const double* c = static_cast<const double*>(cBuf.ptr);
+    const double* h = c;
+    const double* l = c;
+    const double* v = nullptr;
+    if (high)
+    {
+      auto b = high->request();
+      if (static_cast<size_t>(b.shape[0]) != n)
+      {
+        throw std::invalid_argument("set_bars: high must match close length");
+      }
+      h = static_cast<const double*>(b.ptr);
+    }
+    if (low)
+    {
+      auto b = low->request();
+      if (static_cast<size_t>(b.shape[0]) != n)
+      {
+        throw std::invalid_argument("set_bars: low must match close length");
+      }
+      l = static_cast<const double*>(b.ptr);
+    }
+    if (volume)
+    {
+      auto b = volume->request();
+      if (static_cast<size_t>(b.shape[0]) != n)
+      {
+        throw std::invalid_argument("set_bars: volume must match close length");
+      }
+      v = static_cast<const double*>(b.ptr);
+    }
+
+    std::vector<flox::Bar> bars(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+      bars[i].open = flox::Price::fromDouble(c[i]);
+      bars[i].high = flox::Price::fromDouble(h[i]);
+      bars[i].low = flox::Price::fromDouble(l[i]);
+      bars[i].close = flox::Price::fromDouble(c[i]);
+      bars[i].volume = v ? flox::Volume::fromDouble(v[i]) : flox::Volume{};
+    }
+    _bars[symbol] = std::move(bars);
+    _graph.setBars(static_cast<flox::SymbolId>(symbol),
+                   std::span<const flox::Bar>(_bars[symbol]));
+  }
+
+  void addNode(const std::string& name, std::vector<std::string> deps, py::object fn)
+  {
+    PyIndicatorGraph* self = this;
+    _graph.addNode(
+        name, std::move(deps),
+        [self, fn](flox::indicator::IndicatorGraph&, flox::SymbolId sym) -> std::vector<double>
+        {
+          py::object result = fn(py::cast(self, py::return_value_policy::reference),
+                                 static_cast<uint32_t>(sym));
+          py::array_t<double, py::array::c_style | py::array::forcecast> arr =
+              result.cast<py::array_t<double, py::array::c_style | py::array::forcecast>>();
+          auto buf = arr.request();
+          size_t n = buf.shape[0];
+          const double* p = static_cast<const double*>(buf.ptr);
+          return std::vector<double>(p, p + n);
+        });
+  }
+
+  py::array_t<double> require(uint32_t symbol, const std::string& name)
+  {
+    const auto& v = _graph.require(static_cast<flox::SymbolId>(symbol), name);
+    return toArray(v);
+  }
+
+  py::object get(uint32_t symbol, const std::string& name) const
+  {
+    const auto* v = _graph.get(static_cast<flox::SymbolId>(symbol), name);
+    if (!v)
+    {
+      return py::none();
+    }
+    return toArray(*v);
+  }
+
+  py::array_t<double> close(uint32_t symbol)
+  {
+    return toArray(_graph.close(static_cast<flox::SymbolId>(symbol)));
+  }
+  py::array_t<double> high(uint32_t symbol)
+  {
+    return toArray(_graph.high(static_cast<flox::SymbolId>(symbol)));
+  }
+  py::array_t<double> low(uint32_t symbol)
+  {
+    return toArray(_graph.low(static_cast<flox::SymbolId>(symbol)));
+  }
+  py::array_t<double> volume(uint32_t symbol)
+  {
+    return toArray(_graph.volume(static_cast<flox::SymbolId>(symbol)));
+  }
+
+  void invalidate(uint32_t symbol) { _graph.invalidate(static_cast<flox::SymbolId>(symbol)); }
+  void invalidateAll() { _graph.invalidateAll(); }
+
+ private:
+  static py::array_t<double> toArray(const std::vector<double>& v)
+  {
+    py::array_t<double> out(v.size());
+    std::memcpy(out.mutable_data(), v.data(), v.size() * sizeof(double));
+    return out;
+  }
+
+  flox::indicator::IndicatorGraph _graph;
+  std::unordered_map<uint32_t, std::vector<flox::Bar>> _bars;
+};
+
+}  // namespace
+
+inline void bindIndicatorGraph(py::module_& m)
+{
+  py::class_<PyIndicatorGraph>(m, "IndicatorGraph")
+      .def(py::init<>())
+      .def("set_bars", &PyIndicatorGraph::setBars, py::arg("symbol"), py::arg("close"),
+           py::arg("high") = py::none(), py::arg("low") = py::none(),
+           py::arg("volume") = py::none())
+      .def("add_node", &PyIndicatorGraph::addNode, py::arg("name"), py::arg("deps"),
+           py::arg("fn"))
+      .def("require", &PyIndicatorGraph::require, py::arg("symbol"), py::arg("name"))
+      .def("get", &PyIndicatorGraph::get, py::arg("symbol"), py::arg("name"))
+      .def("close", &PyIndicatorGraph::close, py::arg("symbol"))
+      .def("high", &PyIndicatorGraph::high, py::arg("symbol"))
+      .def("low", &PyIndicatorGraph::low, py::arg("symbol"))
+      .def("volume", &PyIndicatorGraph::volume, py::arg("symbol"))
+      .def("invalidate", &PyIndicatorGraph::invalidate, py::arg("symbol"))
+      .def("invalidate_all", &PyIndicatorGraph::invalidateAll);
+}

--- a/python/graph_bindings.h
+++ b/python/graph_bindings.h
@@ -196,6 +196,12 @@ class PyStreamingIndicatorGraph
     return _sg.barCount(static_cast<flox::SymbolId>(symbol));
   }
 
+  py::array_t<double> require(uint32_t symbol, const std::string& name)
+  {
+    const auto& v = _sg.batchGraph().require(static_cast<flox::SymbolId>(symbol), name);
+    return toArray(v);
+  }
+
   void reset(uint32_t symbol) { _sg.reset(static_cast<flox::SymbolId>(symbol)); }
   void resetAll() { _sg.resetAll(); }
 
@@ -254,6 +260,7 @@ inline void bindIndicatorGraph(py::module_& m)
       .def("step", &PyStreamingIndicatorGraph::step, py::arg("symbol"), py::arg("close"),
            py::arg("high") = py::none(), py::arg("low") = py::none(),
            py::arg("volume") = py::none())
+      .def("require", &PyStreamingIndicatorGraph::require, py::arg("symbol"), py::arg("name"))
       .def("current", &PyStreamingIndicatorGraph::current, py::arg("symbol"), py::arg("name"))
       .def("bar_count", &PyStreamingIndicatorGraph::barCount, py::arg("symbol"))
       .def("reset", &PyStreamingIndicatorGraph::reset, py::arg("symbol"))

--- a/python/indicator_bindings.h
+++ b/python/indicator_bindings.h
@@ -230,21 +230,23 @@ class PyATR
   PyATR(size_t period) : _period(period) {}
   py::object update(double high, double low, double close)
   {
-    double tr;
-    if (_count == 0)
-    {
-      tr = high - low;
-    }
-    else
-    {
-      tr = std::max({high - low, std::abs(high - _prevClose), std::abs(low - _prevClose)});
-    }
-    _prevClose = close;
     _count++;
-    if (_count <= _period)
+    if (_count == 1)
+    {
+      // Bar 0: store close only; TR requires a previous close
+      _prevClose = close;
+      return py::none();
+    }
+    double tr = std::max({high - low, std::abs(high - _prevClose), std::abs(low - _prevClose)});
+    _prevClose = close;
+    // Seed phase: accumulate TR[1..period]
+    if (_count <= _period + 1)
     {
       _sum += tr;
-      _value = _sum / _count;
+      if (_count == _period + 1)
+      {
+        _value = _sum / static_cast<double>(_period);
+      }
     }
     else
     {
@@ -253,7 +255,7 @@ class PyATR
     return optVal(_value, isReady());
   }
   py::object getValue() const { return optVal(_value, isReady()); }
-  bool isReady() const { return _count >= _period; }
+  bool isReady() const { return _count >= _period + 1; }
   void reset()
   {
     _count = 0;
@@ -275,11 +277,19 @@ class PyDEMA
   py::object update(double value)
   {
     _ema1.update(value);
-    double e1 = _ema1.isReady() ? py::cast<double>(_ema1.getValue()) : 0;
+    if (!_ema1.isReady())
+    {
+      return py::none();
+    }
+    double e1 = py::cast<double>(_ema1.getValue());
     _ema2.update(e1);
-    double e2 = _ema2.isReady() ? py::cast<double>(_ema2.getValue()) : 0;
-    _value = 2 * e1 - e2;
-    return optVal(_value, isReady());
+    if (!_ema2.isReady())
+    {
+      return py::none();
+    }
+    double e2 = py::cast<double>(_ema2.getValue());
+    _value = 2.0 * e1 - e2;
+    return py::cast(_value);
   }
   py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _ema2.isReady(); }
@@ -304,13 +314,25 @@ class PyTEMA
   py::object update(double value)
   {
     _ema1.update(value);
-    double e1 = _ema1.isReady() ? py::cast<double>(_ema1.getValue()) : 0;
+    if (!_ema1.isReady())
+    {
+      return py::none();
+    }
+    double e1 = py::cast<double>(_ema1.getValue());
     _ema2.update(e1);
-    double e2 = _ema2.isReady() ? py::cast<double>(_ema2.getValue()) : 0;
+    if (!_ema2.isReady())
+    {
+      return py::none();
+    }
+    double e2 = py::cast<double>(_ema2.getValue());
     _ema3.update(e2);
-    double e3 = _ema3.isReady() ? py::cast<double>(_ema3.getValue()) : 0;
-    _value = 3 * e1 - 3 * e2 + e3;
-    return optVal(_value, isReady());
+    if (!_ema3.isReady())
+    {
+      return py::none();
+    }
+    double e3 = py::cast<double>(_ema3.getValue());
+    _value = 3.0 * e1 - 3.0 * e2 + e3;
+    return py::cast(_value);
   }
   py::object getValue() const { return optVal(_value, isReady()); }
   bool isReady() const { return _ema3.isReady(); }
@@ -418,17 +440,33 @@ class PyMACD
   }
   py::object update(double value)
   {
-    _fastEma.update(value);
+    _history.push_back(value);
     _slowEma.update(value);
-    double f = _fastEma.isReady() ? py::cast<double>(_fastEma.getValue()) : 0;
-    double s = _slowEma.isReady() ? py::cast<double>(_slowEma.getValue()) : 0;
-    _line = f - s;
-    if (_slowEma.isReady())
+
+    if (!_slowEma.isReady())
     {
-      _signalEma.update(_line);
-      _ready = _signalEma.isReady();
-      _signalVal = _signalEma.isReady() ? py::cast<double>(_signalEma.getValue()) : 0;
+      return py::none();
     }
+
+    // TA-Lib convention: seed fast EMA at the same index as slow EMA,
+    // using the last `_fast` values from history.
+    if (!_fastSeeded)
+    {
+      for (size_t i = _history.size() - _fast; i < _history.size(); ++i)
+      {
+        _fastEma.update(_history[i]);
+      }
+      _fastSeeded = true;
+    }
+    else
+    {
+      _fastEma.update(value);
+    }
+
+    _line = py::cast<double>(_fastEma.getValue()) - py::cast<double>(_slowEma.getValue());
+    _signalEma.update(_line);
+    _ready = _signalEma.isReady();
+    _signalVal = _ready ? py::cast<double>(_signalEma.getValue()) : 0;
     _histogram = _line - _signalVal;
     return optVal(_line, _ready);
   }
@@ -442,6 +480,8 @@ class PyMACD
     _fastEma.reset();
     _slowEma.reset();
     _signalEma.reset();
+    _history.clear();
+    _fastSeeded = false;
     _line = 0;
     _signalVal = 0;
     _histogram = 0;
@@ -452,6 +492,8 @@ class PyMACD
  private:
   size_t _fast, _slow, _signal;
   PyEMA _fastEma, _slowEma, _signalEma;
+  std::vector<double> _history;
+  bool _fastSeeded = false;
   double _line = 0, _signalVal = 0, _histogram = 0;
   bool _ready = false;
 };

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -200,6 +200,32 @@ except Exception:
     threw = True
 check(threw, "require on unknown node throws")
 
+# ── StreamingIndicatorGraph ───────────────────────────────────────────
+
+print("=== StreamingIndicatorGraph ===")
+
+sg = flox.StreamingIndicatorGraph()
+sg.add_node("double_close", [], lambda graph, sym: graph.close(sym) * 2.0)
+
+closes_s = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+for c in closes_s:
+    sg.step(0, c)
+
+check(approx(sg.current(0, "double_close"), 100.0), "streaming current after 5 steps")
+check(sg.bar_count(0) == 5, "streaming bar_count == 5")
+
+# Parity: batch on same data → last element == streaming current.
+bg2 = flox.IndicatorGraph()
+bg2.set_bars(0, closes_s)
+bg2.add_node("double_close", [], lambda graph, sym: graph.close(sym) * 2.0)
+batch_dc = bg2.require(0, "double_close")
+check(approx(sg.current(0, "double_close"), batch_dc[-1]),
+      "streaming current == batch last element")
+
+sg.reset(0)
+check(sg.bar_count(0) == 0, "after reset bar_count == 0")
+check(math.isnan(sg.current(0, "double_close")), "after reset current is NaN")
+
 # ── PositionTracker ───────────────────────────────────────────────────
 
 print("=== PositionTracker ===")

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -169,6 +169,37 @@ sl = flox.targets.future_linear_slope(linear, 4)
 check(approx(sl[0], 0.5), "future_linear_slope on linear series == 0.5")
 check(math.isnan(sl[19]), "future_linear_slope tail is NaN")
 
+# ── IndicatorGraph (batch) ───────────────────────────────────────────
+
+print("=== IndicatorGraph (batch) ===")
+
+ramp = np.array([float(i) for i in range(50)])
+g = flox.IndicatorGraph()
+g.set_bars(0, ramp)
+
+# Two independent batch nodes + one dependent node that reads its parents.
+g.add_node("ema5", [], lambda graph, sym: flox.ema(graph.close(sym), 5))
+g.add_node("sma5", [], lambda graph, sym: flox.sma(graph.close(sym), 5))
+g.add_node("diff", ["ema5", "sma5"],
+           lambda graph, sym: graph.get(sym, "ema5") - graph.get(sym, "sma5"))
+
+ema5 = g.require(0, "ema5")
+diff = g.require(0, "diff")
+check(len(ema5) == 50, "graph require returns full-length array")
+check(len(diff) == 50, "graph dependent node has same length")
+# get() returns cached value after require ran.
+sma5_cached = g.get(0, "sma5")
+check(sma5_cached is not None, "get returns the cached node array after require")
+check(np.allclose(diff, ema5 - sma5_cached, equal_nan=True), "dependent node uses parents")
+
+# Unknown node → throws.
+threw = False
+try:
+    g.require(0, "missing")
+except Exception:
+    threw = True
+check(threw, "require on unknown node throws")
+
 # ── PositionTracker ───────────────────────────────────────────────────
 
 print("=== PositionTracker ===")

--- a/python/tests/test_parity.py
+++ b/python/tests/test_parity.py
@@ -1,0 +1,281 @@
+"""
+python/tests/test_parity.py — batch ↔ streaming parity tests.
+
+For every indicator exposed both as a batch function and a streaming class,
+generate a fixed-seed random input, run both paths, and assert the outputs
+agree within tolerance.  Failures are blocking CI.
+
+Run from repo root:
+    PYTHONPATH=build/python python3 python/tests/test_parity.py
+"""
+
+import sys
+import os
+import math
+
+build_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'build', 'python')
+sys.path.insert(0, os.path.abspath(build_dir))
+
+import flox_py as flox
+import numpy as np
+
+_passed = 0
+_failed = 0
+
+ATOL = 1e-9
+RTOL = 1e-9
+
+
+def check(condition, msg):
+    global _passed, _failed
+    if condition:
+        print(f"  ok  {msg}")
+        _passed += 1
+    else:
+        print(f"  FAIL  {msg}")
+        _failed += 1
+
+
+def parity_allclose(batch, streaming, name):
+    """Assert batch and streaming outputs agree on non-NaN positions."""
+    b = np.asarray(batch, dtype=np.float64)
+    s = np.asarray(streaming, dtype=np.float64)
+    check(len(b) == len(s), f"{name}: length match ({len(b)} vs {len(s)})")
+    nan_b = np.isnan(b)
+    nan_s = np.isnan(s)
+    check(np.array_equal(nan_b, nan_s), f"{name}: NaN mask match")
+    valid = ~nan_b & ~nan_s
+    if valid.any():
+        close = np.allclose(b[valid], s[valid], atol=ATOL, rtol=RTOL)
+        check(close, f"{name}: values agree (atol={ATOL}, rtol={RTOL})")
+        if not close:
+            worst = np.max(np.abs(b[valid] - s[valid]))
+            print(f"         max abs diff = {worst:.3e}")
+
+
+def rng_prices(n=50, seed=42, lo=100.0, hi=200.0):
+    rng = np.random.default_rng(seed)
+    return rng.uniform(lo, hi, n)
+
+
+def rng_hlc(n=50, seed=42):
+    """Returns high, low, close arrays with high >= close >= low > 0."""
+    rng = np.random.default_rng(seed)
+    mid = rng.uniform(100.0, 200.0, n)
+    spread = rng.uniform(0.5, 5.0, n)
+    high = mid + spread
+    low = mid - spread
+    close = mid + rng.uniform(-spread, spread, n)
+    close = np.clip(close, low, high)
+    return high, low, close
+
+
+def rng_ohlc(n=50, seed=42):
+    rng = np.random.default_rng(seed)
+    mid = rng.uniform(100.0, 200.0, n)
+    spread = rng.uniform(0.5, 5.0, n)
+    high = mid + spread
+    low = mid - spread
+    close = mid + rng.uniform(-spread * 0.9, spread * 0.9, n)
+    open_ = mid + rng.uniform(-spread * 0.9, spread * 0.9, n)
+    close = np.clip(close, low, high)
+    open_ = np.clip(open_, low, high)
+    return open_, high, low, close
+
+
+def streaming_collect(ind, updates):
+    """Drive a single-value streaming indicator; return array with NaN for not-ready."""
+    out = []
+    for v in updates:
+        val = ind.update(v)
+        out.append(float(val) if val is not None else math.nan)
+    return np.array(out)
+
+
+def streaming_collect_hlc(ind, high, low, close):
+    out = []
+    for h, l, c in zip(high, low, close):
+        val = ind.update(h, l, c)
+        out.append(float(val) if val is not None else math.nan)
+    return np.array(out)
+
+
+# ── Single-series indicators ──────────────────────────────────────────
+
+print("=== SMA parity ===")
+prices = rng_prices()
+period = 10
+batch = flox.sma(prices, period)
+stream = streaming_collect(flox.SMA(period), prices)
+parity_allclose(batch, stream, "SMA")
+
+print("=== EMA parity ===")
+batch = flox.ema(prices, period)
+stream = streaming_collect(flox.EMA(period), prices)
+parity_allclose(batch, stream, "EMA")
+
+print("=== RMA parity ===")
+batch = flox.rma(prices, period)
+stream = streaming_collect(flox.RMA(period), prices)
+parity_allclose(batch, stream, "RMA")
+
+print("=== RSI parity ===")
+batch = flox.rsi(prices, period)
+stream = streaming_collect(flox.RSI(period), prices)
+parity_allclose(batch, stream, "RSI")
+
+print("=== DEMA parity ===")
+batch = flox.dema(prices, period)
+stream = streaming_collect(flox.DEMA(period), prices)
+parity_allclose(batch, stream, "DEMA")
+
+print("=== TEMA parity ===")
+batch = flox.tema(prices, period)
+stream = streaming_collect(flox.TEMA(period), prices)
+parity_allclose(batch, stream, "TEMA")
+
+print("=== KAMA parity ===")
+batch = flox.kama(prices, period)
+stream = streaming_collect(flox.KAMA(period), prices)
+parity_allclose(batch, stream, "KAMA")
+
+print("=== Slope parity ===")
+batch = flox.slope(prices, period)
+stream = streaming_collect(flox.Slope(period), prices)
+parity_allclose(batch, stream, "Slope")
+
+print("=== Skewness parity ===")
+batch = flox.skewness(prices, period)
+stream = streaming_collect(flox.Skewness(period), prices)
+parity_allclose(batch, stream, "Skewness")
+
+print("=== Kurtosis parity ===")
+batch = flox.kurtosis(prices, period)
+stream = streaming_collect(flox.Kurtosis(period), prices)
+parity_allclose(batch, stream, "Kurtosis")
+
+print("=== RollingZScore parity ===")
+batch = flox.rolling_zscore(prices, period)
+stream = streaming_collect(flox.RollingZScore(period), prices)
+parity_allclose(batch, stream, "RollingZScore")
+
+print("=== ShannonEntropy parity ===")
+bins = 10
+batch = flox.shannon_entropy(prices, period, bins)
+stream = streaming_collect(flox.ShannonEntropy(period, bins), prices)
+parity_allclose(batch, stream, "ShannonEntropy")
+
+# ── Multi-series: high/low/close ──────────────────────────────────────
+
+high, low, close = rng_hlc()
+
+print("=== ATR parity ===")
+batch = flox.atr(high, low, close, period)
+stream = streaming_collect_hlc(flox.ATR(period), high, low, close)
+parity_allclose(batch, stream, "ATR")
+
+print("=== Stochastic parity ===")
+k_period, d_period = 14, 3
+b_stoch = flox.stochastic(high, low, close, k_period=k_period, d_period=d_period)
+batch_k = b_stoch["k"]
+s_stream = []
+st = flox.Stochastic(k_period, d_period)
+for h, l, c in zip(high, low, close):
+    val = st.update(h, l, c)
+    s_stream.append(float(val) if val is not None else math.nan)
+parity_allclose(batch_k, np.array(s_stream), "Stochastic/k")
+
+print("=== CCI parity ===")
+batch = flox.cci(high, low, close, period)
+stream = streaming_collect_hlc(flox.CCI(period), high, low, close)
+parity_allclose(batch, stream, "CCI")
+
+print("=== ParkinsonVol parity ===")
+batch = flox.parkinson_vol(high, low, period)
+out = []
+pv = flox.ParkinsonVol(period)
+for h, l in zip(high, low):
+    val = pv.update(h, l)
+    out.append(float(val) if val is not None else math.nan)
+parity_allclose(batch, np.array(out), "ParkinsonVol")
+
+print("=== RogersSatchellVol parity ===")
+open_, high2, low2, close2 = rng_ohlc()
+batch = flox.rogers_satchell_vol(open_, high2, low2, close2, period)
+out = []
+rsv = flox.RogersSatchellVol(period)
+for o, h, l, c in zip(open_, high2, low2, close2):
+    val = rsv.update(o, h, l, c)
+    out.append(float(val) if val is not None else math.nan)
+parity_allclose(batch, np.array(out), "RogersSatchellVol")
+
+# ── MACD ─────────────────────────────────────────────────────────────
+
+print("=== MACD parity ===")
+fast, slow, signal = 5, 10, 4
+b_macd = flox.macd(prices, fast=fast, slow=slow, signal=signal)
+batch_line = b_macd["line"]
+out = []
+m = flox.MACD(fast, slow, signal)
+for v in prices:
+    val = m.update(v)
+    out.append(float(val) if val is not None else math.nan)
+parity_allclose(batch_line, np.array(out), "MACD/line")
+
+# ── Bollinger ─────────────────────────────────────────────────────────
+
+print("=== Bollinger parity ===")
+b_bol = flox.bollinger(prices, period=period, stddev=2.0)
+batch_mid = b_bol["middle"]
+out = []
+bb = flox.Bollinger(period, 2.0)
+for v in prices:
+    val = bb.update(v)
+    out.append(float(val) if val is not None else math.nan)
+parity_allclose(batch_mid, np.array(out), "Bollinger/middle")
+
+# ── Correlation ──────────────────────────────────────────────────────
+
+print("=== Correlation parity ===")
+rng = np.random.default_rng(99)
+x = rng.uniform(0.0, 1.0, 50)
+y = rng.uniform(0.0, 1.0, 50)
+batch = flox.correlation(x, y, period)
+out = []
+cor = flox.Correlation(period)
+for xi, yi in zip(x, y):
+    val = cor.update(xi, yi)
+    out.append(float(val) if val is not None else math.nan)
+parity_allclose(batch, np.array(out), "Correlation")
+
+# ── IndicatorGraph batch vs streaming ────────────────────────────────
+
+print("=== IndicatorGraph streaming parity ===")
+prices_sg = rng_prices(n=30)
+high_sg, low_sg, close_sg = rng_hlc(n=30)
+
+# Batch graph
+bg = flox.IndicatorGraph()
+bg.add_node("close", [], lambda g, sym: g.close(sym))
+bg.add_node("dema5", ["close"], lambda g, sym: flox.dema(np.array(g.require(sym, "close")), 5))
+bg.set_bars(0, close_sg, high_sg, low_sg)
+batch_dema = list(bg.require(0, "dema5"))
+
+# Streaming graph
+sg = flox.StreamingIndicatorGraph()
+sg.add_node("close", [], lambda g, sym: g.close(sym))
+sg.add_node("dema5", ["close"], lambda g, sym: flox.dema(np.array(g.require(sym, "close")), 5))
+for i, (c, h, l) in enumerate(zip(close_sg, high_sg, low_sg)):
+    sg.step(0, c, h, l)
+stream_dema_last = sg.current(0, "dema5")
+check(
+    not math.isnan(stream_dema_last) and abs(stream_dema_last - batch_dema[-1]) < ATOL,
+    f"IndicatorGraph streaming last == batch last (diff={abs(stream_dema_last - batch_dema[-1]):.2e})"
+)
+check(sg.bar_count(0) == len(close_sg), "IndicatorGraph streaming bar_count matches input")
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+print(f"\n{_passed} passed, {_failed} failed")
+if _failed:
+    sys.exit(1)

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -34,6 +34,7 @@
 #include "flox/indicator/cvd.h"
 #include "flox/indicator/dema.h"
 #include "flox/indicator/ema.h"
+#include "flox/indicator/indicator_pipeline.h"
 #include "flox/indicator/kama.h"
 #include "flox/indicator/kurtosis.h"
 #include "flox/indicator/macd.h"
@@ -603,6 +604,175 @@ void flox_target_future_linear_slope(const double* close, size_t len, size_t hor
 {
   target::FutureLinearSlope t(horizon);
   t.compute(std::span<const double>(close, len), std::span<double>(output, len));
+}
+
+// ============================================================
+// IndicatorGraph (batch) — handle-based wrapper.
+// ============================================================
+
+namespace
+{
+
+struct FloxGraphImpl
+{
+  indicator::IndicatorGraph graph;
+  std::unordered_map<uint32_t, std::vector<Bar>> barStorage;
+};
+
+}  // namespace
+
+FloxIndicatorGraphHandle flox_indicator_graph_create(void)
+{
+  return new FloxGraphImpl();
+}
+
+void flox_indicator_graph_destroy(FloxIndicatorGraphHandle g)
+{
+  delete static_cast<FloxGraphImpl*>(g);
+}
+
+void flox_indicator_graph_set_bars(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                   const double* close, const double* high, const double* low,
+                                   const double* volume, size_t len)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  std::vector<Bar> bars(len);
+  for (size_t i = 0; i < len; ++i)
+  {
+    bars[i].open = Price::fromDouble(close[i]);
+    bars[i].high = Price::fromDouble(high ? high[i] : close[i]);
+    bars[i].low = Price::fromDouble(low ? low[i] : close[i]);
+    bars[i].close = Price::fromDouble(close[i]);
+    bars[i].volume = volume ? Volume::fromDouble(volume[i]) : Volume{};
+  }
+  impl->barStorage[symbol] = std::move(bars);
+  impl->graph.setBars(static_cast<SymbolId>(symbol),
+                      std::span<const Bar>(impl->barStorage[symbol]));
+}
+
+void flox_indicator_graph_add_node(FloxIndicatorGraphHandle g, const char* name,
+                                   const char* const* deps, size_t num_deps,
+                                   FloxGraphNodeFn fn, void* user_data)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  std::vector<std::string> depList;
+  depList.reserve(num_deps);
+  for (size_t i = 0; i < num_deps; ++i)
+  {
+    depList.emplace_back(deps[i]);
+  }
+  impl->graph.addNode(name, std::move(depList),
+                      [g, fn, user_data](indicator::IndicatorGraph&, SymbolId sym)
+                      {
+                        size_t outLen = 0;
+                        const double* p = fn(user_data, g, static_cast<uint32_t>(sym), &outLen);
+                        if (!p)
+                        {
+                          return std::vector<double>{};
+                        }
+                        return std::vector<double>(p, p + outLen);
+                      });
+}
+
+const double* flox_indicator_graph_require(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                           const char* name, size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  try
+  {
+    const auto& v = impl->graph.require(static_cast<SymbolId>(symbol), name);
+    if (len_out)
+    {
+      *len_out = v.size();
+    }
+    return v.data();
+  }
+  catch (...)
+  {
+    if (len_out)
+    {
+      *len_out = 0;
+    }
+    return nullptr;
+  }
+}
+
+const double* flox_indicator_graph_get(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                       const char* name, size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  const auto* v = impl->graph.get(static_cast<SymbolId>(symbol), name);
+  if (!v)
+  {
+    if (len_out)
+    {
+      *len_out = 0;
+    }
+    return nullptr;
+  }
+  if (len_out)
+  {
+    *len_out = v->size();
+  }
+  return v->data();
+}
+
+const double* flox_indicator_graph_close(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                         size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  const auto& v = impl->graph.close(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
+}
+
+const double* flox_indicator_graph_high(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                        size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  const auto& v = impl->graph.high(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
+}
+
+const double* flox_indicator_graph_low(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                       size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  const auto& v = impl->graph.low(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
+}
+
+const double* flox_indicator_graph_volume(FloxIndicatorGraphHandle g, uint32_t symbol,
+                                          size_t* len_out)
+{
+  auto* impl = static_cast<FloxGraphImpl*>(g);
+  const auto& v = impl->graph.volume(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
+}
+
+void flox_indicator_graph_invalidate(FloxIndicatorGraphHandle g, uint32_t symbol)
+{
+  static_cast<FloxGraphImpl*>(g)->graph.invalidate(static_cast<SymbolId>(symbol));
+}
+
+void flox_indicator_graph_invalidate_all(FloxIndicatorGraphHandle g)
+{
+  static_cast<FloxGraphImpl*>(g)->graph.invalidateAll();
 }
 
 // ============================================================

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -49,6 +49,7 @@
 #include "flox/indicator/slope.h"
 #include "flox/indicator/sma.h"
 #include "flox/indicator/stochastic.h"
+#include "flox/indicator/streaming_graph.h"
 #include "flox/indicator/vwap.h"
 #include "flox/target/future_ctc_volatility.h"
 #include "flox/target/future_linear_slope.h"
@@ -773,6 +774,195 @@ void flox_indicator_graph_invalidate(FloxIndicatorGraphHandle g, uint32_t symbol
 void flox_indicator_graph_invalidate_all(FloxIndicatorGraphHandle g)
 {
   static_cast<FloxGraphImpl*>(g)->graph.invalidateAll();
+}
+
+// ============================================================
+// StreamingIndicatorGraph — handle-based wrapper.
+// ============================================================
+
+namespace
+{
+
+struct FloxStreamingGraphImpl
+{
+  FloxGraphImpl batchImpl;
+  std::vector<std::string> nodeNames;
+  std::unordered_map<uint32_t, std::vector<Bar>> history;
+
+  using CurrentKey = std::pair<uint32_t, std::string>;
+  struct CurrentKeyHash
+  {
+    size_t operator()(const CurrentKey& k) const
+    {
+      return std::hash<uint32_t>{}(k.first) ^ (std::hash<std::string>{}(k.second) * 2654435761u);
+    }
+  };
+  std::unordered_map<CurrentKey, double, CurrentKeyHash> current;
+};
+
+}  // namespace
+
+FloxStreamingGraphHandle flox_streaming_graph_create(void)
+{
+  return new FloxStreamingGraphImpl();
+}
+
+void flox_streaming_graph_destroy(FloxStreamingGraphHandle sg)
+{
+  delete static_cast<FloxStreamingGraphImpl*>(sg);
+}
+
+void flox_streaming_graph_add_node(FloxStreamingGraphHandle sg, const char* name,
+                                   const char* const* deps, size_t num_deps, FloxGraphNodeFn fn,
+                                   void* user_data)
+{
+  auto* impl = static_cast<FloxStreamingGraphImpl*>(sg);
+  auto* batchHandle = static_cast<FloxIndicatorGraphHandle>(&impl->batchImpl);
+
+  impl->nodeNames.emplace_back(name);
+
+  std::vector<std::string> depList;
+  depList.reserve(num_deps);
+  for (size_t i = 0; i < num_deps; ++i)
+  {
+    depList.emplace_back(deps[i]);
+  }
+
+  impl->batchImpl.graph.addNode(
+      name, std::move(depList),
+      [batchHandle, fn, user_data](indicator::IndicatorGraph&, SymbolId sym)
+      {
+        size_t outLen = 0;
+        const double* p = fn(user_data, batchHandle, static_cast<uint32_t>(sym), &outLen);
+        if (!p)
+        {
+          return std::vector<double>{};
+        }
+        return std::vector<double>(p, p + outLen);
+      });
+}
+
+void flox_streaming_graph_step(FloxStreamingGraphHandle sg, uint32_t symbol, double open,
+                               double high, double low, double close, double volume)
+{
+  auto* impl = static_cast<FloxStreamingGraphImpl*>(sg);
+
+  Bar bar;
+  bar.open = Price::fromDouble(open);
+  bar.high = Price::fromDouble(high);
+  bar.low = Price::fromDouble(low);
+  bar.close = Price::fromDouble(close);
+  bar.volume = Volume::fromDouble(volume);
+
+  auto& hist = impl->history[symbol];
+  hist.push_back(bar);
+  impl->batchImpl.barStorage[symbol] = hist;
+  impl->batchImpl.graph.setBars(static_cast<SymbolId>(symbol),
+                                std::span<const Bar>(impl->batchImpl.barStorage[symbol]));
+
+  for (const auto& nodeName : impl->nodeNames)
+  {
+    try
+    {
+      const auto& v = impl->batchImpl.graph.require(static_cast<SymbolId>(symbol), nodeName);
+      impl->current[{symbol, nodeName}] = v.empty() ? std::nan("")
+                                                    : v.back();
+    }
+    catch (...)
+    {
+      impl->current[{symbol, nodeName}] = std::nan("");
+    }
+  }
+}
+
+double flox_streaming_graph_current(FloxStreamingGraphHandle sg, uint32_t symbol, const char* name)
+{
+  auto* impl = static_cast<FloxStreamingGraphImpl*>(sg);
+  auto it = impl->current.find({symbol, std::string(name)});
+  return it != impl->current.end() ? it->second : std::nan("");
+}
+
+uint32_t flox_streaming_graph_bar_count(FloxStreamingGraphHandle sg, uint32_t symbol)
+{
+  auto* impl = static_cast<FloxStreamingGraphImpl*>(sg);
+  auto it = impl->history.find(symbol);
+  return it != impl->history.end() ? static_cast<uint32_t>(it->second.size()) : 0u;
+}
+
+void flox_streaming_graph_reset(FloxStreamingGraphHandle sg, uint32_t symbol)
+{
+  auto* impl = static_cast<FloxStreamingGraphImpl*>(sg);
+  impl->history.erase(symbol);
+  impl->batchImpl.barStorage.erase(symbol);
+  impl->batchImpl.graph.invalidate(static_cast<SymbolId>(symbol));
+  for (auto it = impl->current.begin(); it != impl->current.end();)
+  {
+    if (it->first.first == symbol)
+    {
+      it = impl->current.erase(it);
+    }
+    else
+    {
+      ++it;
+    }
+  }
+}
+
+void flox_streaming_graph_reset_all(FloxStreamingGraphHandle sg)
+{
+  auto* impl = static_cast<FloxStreamingGraphImpl*>(sg);
+  impl->history.clear();
+  impl->batchImpl.barStorage.clear();
+  impl->batchImpl.graph.invalidateAll();
+  impl->current.clear();
+}
+
+const double* flox_streaming_graph_close(FloxStreamingGraphHandle sg, uint32_t symbol,
+                                         size_t* len_out)
+{
+  const auto& v =
+      static_cast<FloxStreamingGraphImpl*>(sg)->batchImpl.graph.close(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
+}
+
+const double* flox_streaming_graph_high(FloxStreamingGraphHandle sg, uint32_t symbol,
+                                        size_t* len_out)
+{
+  const auto& v =
+      static_cast<FloxStreamingGraphImpl*>(sg)->batchImpl.graph.high(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
+}
+
+const double* flox_streaming_graph_low(FloxStreamingGraphHandle sg, uint32_t symbol,
+                                       size_t* len_out)
+{
+  const auto& v =
+      static_cast<FloxStreamingGraphImpl*>(sg)->batchImpl.graph.low(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
+}
+
+const double* flox_streaming_graph_volume(FloxStreamingGraphHandle sg, uint32_t symbol,
+                                          size_t* len_out)
+{
+  const auto& v =
+      static_cast<FloxStreamingGraphImpl*>(sg)->batchImpl.graph.volume(static_cast<SymbolId>(symbol));
+  if (len_out)
+  {
+    *len_out = v.size();
+  }
+  return v.data();
 }
 
 // ============================================================

--- a/src/quickjs/js_bindings.cpp
+++ b/src/quickjs/js_bindings.cpp
@@ -839,6 +839,173 @@ static JSValue js_graph_invalidate_all(JSContext* ctx, JSValueConst, int, JSValu
 }
 
 // ============================================================
+// StreamingIndicatorGraph bindings
+// ============================================================
+
+namespace
+{
+
+struct JsStreamingState
+{
+  FloxStreamingGraphHandle handle;
+  std::vector<std::unique_ptr<JsGraphNodeState>> nodes;
+};
+
+static const double* js_streaming_node_trampoline(void* user_data, FloxIndicatorGraphHandle,
+                                                  uint32_t symbol, size_t* out_len)
+{
+  auto* st = static_cast<JsGraphNodeState*>(user_data);
+  JSValue args[2] = {JS_DupValue(st->ctx, st->thisObj), JS_NewUint32(st->ctx, symbol)};
+  JSValue result = JS_Call(st->ctx, st->fn, JS_UNDEFINED, 2, args);
+  JS_FreeValue(st->ctx, args[0]);
+  JS_FreeValue(st->ctx, args[1]);
+  if (JS_IsException(result))
+  {
+    JS_FreeValue(st->ctx, result);
+    *out_len = 0;
+    return nullptr;
+  }
+  st->buffer = jsArrayToDoubles(st->ctx, result);
+  JS_FreeValue(st->ctx, result);
+  *out_len = st->buffer.size();
+  return st->buffer.data();
+}
+
+}  // namespace
+
+static JSValue js_streaming_create(JSContext* ctx, JSValueConst, int, JSValueConst*)
+{
+  auto* st = new JsStreamingState{flox_streaming_graph_create(), {}};
+  return createHandleObject(ctx, st);
+}
+
+static JSValue js_streaming_destroy(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsStreamingState*>(getHandle(ctx, argv[0]));
+  if (!st)
+  {
+    return JS_UNDEFINED;
+  }
+  for (auto& node : st->nodes)
+  {
+    JS_FreeValue(node->ctx, node->fn);
+    JS_FreeValue(node->ctx, node->thisObj);
+  }
+  flox_streaming_graph_destroy(st->handle);
+  delete st;
+  return JS_UNDEFINED;
+}
+
+static JSValue js_streaming_add_node(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsStreamingState*>(getHandle(ctx, argv[0]));
+  const char* name = JS_ToCString(ctx, argv[1]);
+  std::string nameStr(name);
+  JS_FreeCString(ctx, name);
+
+  std::vector<std::string> deps;
+  if (JS_IsArray(ctx, argv[2]))
+  {
+    uint32_t depsLen = 0;
+    {
+      JSValue lenVal = JS_GetPropertyStr(ctx, argv[2], "length");
+      JS_ToUint32(ctx, &depsLen, lenVal);
+      JS_FreeValue(ctx, lenVal);
+    }
+    for (uint32_t i = 0; i < depsLen; ++i)
+    {
+      JSValue v = JS_GetPropertyUint32(ctx, argv[2], i);
+      const char* s = JS_ToCString(ctx, v);
+      deps.emplace_back(s);
+      JS_FreeCString(ctx, s);
+      JS_FreeValue(ctx, v);
+    }
+  }
+
+  std::vector<const char*> depPtrs;
+  depPtrs.reserve(deps.size());
+  for (const auto& d : deps)
+  {
+    depPtrs.push_back(d.c_str());
+  }
+
+  auto node = std::make_unique<JsGraphNodeState>();
+  node->ctx = ctx;
+  node->fn = JS_DupValue(ctx, argv[3]);
+  node->thisObj = JS_DupValue(ctx, argv[4]);
+
+  flox_streaming_graph_add_node(st->handle, nameStr.c_str(),
+                                deps.empty() ? nullptr : depPtrs.data(), deps.size(),
+                                js_streaming_node_trampoline, node.get());
+  st->nodes.push_back(std::move(node));
+  return JS_UNDEFINED;
+}
+
+static JSValue js_streaming_step(JSContext* ctx, JSValueConst, int argc, JSValueConst* argv)
+{
+  auto* st = static_cast<JsStreamingState*>(getHandle(ctx, argv[0]));
+  uint32_t sym = toUint32(ctx, argv[1]);
+  double c = toDouble(ctx, argv[2]);
+  double h = argc > 3 && !JS_IsUndefined(argv[3]) && !JS_IsNull(argv[3])
+                 ? toDouble(ctx, argv[3])
+                 : c;
+  double l = argc > 4 && !JS_IsUndefined(argv[4]) && !JS_IsNull(argv[4])
+                 ? toDouble(ctx, argv[4])
+                 : c;
+  double v = argc > 5 && !JS_IsUndefined(argv[5]) && !JS_IsNull(argv[5])
+                 ? toDouble(ctx, argv[5])
+                 : 0.0;
+  flox_streaming_graph_step(st->handle, sym, c, h, l, c, v);
+  return JS_UNDEFINED;
+}
+
+static JSValue js_streaming_current(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsStreamingState*>(getHandle(ctx, argv[0]));
+  uint32_t sym = toUint32(ctx, argv[1]);
+  const char* name = JS_ToCString(ctx, argv[2]);
+  double val = flox_streaming_graph_current(st->handle, sym, name);
+  JS_FreeCString(ctx, name);
+  return JS_NewFloat64(ctx, val);
+}
+
+static JSValue js_streaming_bar_count(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsStreamingState*>(getHandle(ctx, argv[0]));
+  uint32_t sym = toUint32(ctx, argv[1]);
+  return JS_NewUint32(ctx, flox_streaming_graph_bar_count(st->handle, sym));
+}
+
+static JSValue js_streaming_reset(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsStreamingState*>(getHandle(ctx, argv[0]));
+  flox_streaming_graph_reset(st->handle, toUint32(ctx, argv[1]));
+  return JS_UNDEFINED;
+}
+
+static JSValue js_streaming_reset_all(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsStreamingState*>(getHandle(ctx, argv[0]));
+  flox_streaming_graph_reset_all(st->handle);
+  return JS_UNDEFINED;
+}
+
+#define STREAMING_FIELD(field)                                                               \
+  static JSValue js_streaming_##field(JSContext* ctx, JSValueConst, int, JSValueConst* argv) \
+  {                                                                                          \
+    auto* st = static_cast<JsStreamingState*>(getHandle(ctx, argv[0]));                      \
+    uint32_t sym = toUint32(ctx, argv[1]);                                                   \
+    size_t len = 0;                                                                          \
+    const double* p = flox_streaming_graph_##field(st->handle, sym, &len);                   \
+    return jsArrayFromDoubles(ctx, std::vector<double>(p, p + len));                         \
+  }
+STREAMING_FIELD(close)
+STREAMING_FIELD(high)
+STREAMING_FIELD(low)
+STREAMING_FIELD(volume)
+#undef STREAMING_FIELD
+
+// ============================================================
 // Order book bindings
 // ============================================================
 
@@ -2348,6 +2515,20 @@ void registerFloxBindings(JSContext* ctx)
   addGlobalFunc(ctx, "__flox_graph_volume", js_graph_volume, 2);
   addGlobalFunc(ctx, "__flox_graph_invalidate", js_graph_invalidate, 2);
   addGlobalFunc(ctx, "__flox_graph_invalidate_all", js_graph_invalidate_all, 1);
+
+  // StreamingIndicatorGraph
+  addGlobalFunc(ctx, "__flox_streaming_create", js_streaming_create, 0);
+  addGlobalFunc(ctx, "__flox_streaming_destroy", js_streaming_destroy, 1);
+  addGlobalFunc(ctx, "__flox_streaming_add_node", js_streaming_add_node, 5);
+  addGlobalFunc(ctx, "__flox_streaming_step", js_streaming_step, 6);
+  addGlobalFunc(ctx, "__flox_streaming_current", js_streaming_current, 3);
+  addGlobalFunc(ctx, "__flox_streaming_bar_count", js_streaming_bar_count, 2);
+  addGlobalFunc(ctx, "__flox_streaming_reset", js_streaming_reset, 2);
+  addGlobalFunc(ctx, "__flox_streaming_reset_all", js_streaming_reset_all, 1);
+  addGlobalFunc(ctx, "__flox_streaming_close", js_streaming_close, 2);
+  addGlobalFunc(ctx, "__flox_streaming_high", js_streaming_high, 2);
+  addGlobalFunc(ctx, "__flox_streaming_low", js_streaming_low, 2);
+  addGlobalFunc(ctx, "__flox_streaming_volume", js_streaming_volume, 2);
 
   // Order book
   addGlobalFunc(ctx, "__flox_book_create", js_book_create, 1);

--- a/src/quickjs/js_bindings.cpp
+++ b/src/quickjs/js_bindings.cpp
@@ -641,6 +641,204 @@ static JSValue js_target_future_linear_slope(JSContext* ctx, JSValueConst, int,
 }
 
 // ============================================================
+// IndicatorGraph (batch) bindings
+// ============================================================
+
+namespace
+{
+
+struct JsGraphNodeState
+{
+  JSContext* ctx;
+  JSValue fn;
+  JSValue thisObj;
+  std::vector<double> buffer;
+};
+
+struct JsGraphState
+{
+  FloxIndicatorGraphHandle handle;
+  std::vector<std::unique_ptr<JsGraphNodeState>> nodes;
+};
+
+static const double* js_graph_node_trampoline(void* user_data, FloxIndicatorGraphHandle,
+                                              uint32_t symbol, size_t* out_len)
+{
+  auto* st = static_cast<JsGraphNodeState*>(user_data);
+  JSValue args[2] = {JS_DupValue(st->ctx, st->thisObj), JS_NewUint32(st->ctx, symbol)};
+  JSValue result = JS_Call(st->ctx, st->fn, JS_UNDEFINED, 2, args);
+  JS_FreeValue(st->ctx, args[0]);
+  JS_FreeValue(st->ctx, args[1]);
+  if (JS_IsException(result))
+  {
+    JS_FreeValue(st->ctx, result);
+    *out_len = 0;
+    return nullptr;
+  }
+  st->buffer = jsArrayToDoubles(st->ctx, result);
+  JS_FreeValue(st->ctx, result);
+  *out_len = st->buffer.size();
+  return st->buffer.data();
+}
+
+}  // namespace
+
+static JSValue js_graph_create(JSContext* ctx, JSValueConst, int, JSValueConst*)
+{
+  auto* st = new JsGraphState{flox_indicator_graph_create(), {}};
+  return createHandleObject(ctx, st);
+}
+
+static JSValue js_graph_destroy(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  if (!st)
+  {
+    return JS_UNDEFINED;
+  }
+  for (auto& node : st->nodes)
+  {
+    JS_FreeValue(node->ctx, node->fn);
+    JS_FreeValue(node->ctx, node->thisObj);
+  }
+  flox_indicator_graph_destroy(st->handle);
+  delete st;
+  return JS_UNDEFINED;
+}
+
+static JSValue js_graph_set_bars(JSContext* ctx, JSValueConst, int argc, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  uint32_t sym = toUint32(ctx, argv[1]);
+  auto close = jsArrayToDoubles(ctx, argv[2]);
+  std::vector<double> high, low, volume;
+  const double* hp = nullptr;
+  const double* lp = nullptr;
+  const double* vp = nullptr;
+  if (argc > 3 && !JS_IsNull(argv[3]) && !JS_IsUndefined(argv[3]))
+  {
+    high = jsArrayToDoubles(ctx, argv[3]);
+    hp = high.data();
+  }
+  if (argc > 4 && !JS_IsNull(argv[4]) && !JS_IsUndefined(argv[4]))
+  {
+    low = jsArrayToDoubles(ctx, argv[4]);
+    lp = low.data();
+  }
+  if (argc > 5 && !JS_IsNull(argv[5]) && !JS_IsUndefined(argv[5]))
+  {
+    volume = jsArrayToDoubles(ctx, argv[5]);
+    vp = volume.data();
+  }
+  flox_indicator_graph_set_bars(st->handle, sym, close.data(), hp, lp, vp, close.size());
+  return JS_UNDEFINED;
+}
+
+static JSValue js_graph_add_node(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  const char* name = JS_ToCString(ctx, argv[1]);
+  std::string nameStr(name);
+  JS_FreeCString(ctx, name);
+
+  std::vector<std::string> deps;
+  if (JS_IsArray(ctx, argv[2]))
+  {
+    uint32_t depsLen = 0;
+    {
+      JSValue lenVal = JS_GetPropertyStr(ctx, argv[2], "length");
+      JS_ToUint32(ctx, &depsLen, lenVal);
+      JS_FreeValue(ctx, lenVal);
+    }
+    for (uint32_t i = 0; i < depsLen; ++i)
+    {
+      JSValue v = JS_GetPropertyUint32(ctx, argv[2], i);
+      const char* s = JS_ToCString(ctx, v);
+      deps.emplace_back(s);
+      JS_FreeCString(ctx, s);
+      JS_FreeValue(ctx, v);
+    }
+  }
+
+  std::vector<const char*> depPtrs;
+  depPtrs.reserve(deps.size());
+  for (const auto& d : deps)
+  {
+    depPtrs.push_back(d.c_str());
+  }
+
+  auto node = std::make_unique<JsGraphNodeState>();
+  node->ctx = ctx;
+  node->fn = JS_DupValue(ctx, argv[3]);
+  node->thisObj = JS_DupValue(ctx, argv[4]);
+
+  flox_indicator_graph_add_node(st->handle, nameStr.c_str(),
+                                deps.empty() ? nullptr : depPtrs.data(), deps.size(),
+                                js_graph_node_trampoline, node.get());
+  st->nodes.push_back(std::move(node));
+  return JS_UNDEFINED;
+}
+
+static JSValue js_graph_require(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  uint32_t sym = toUint32(ctx, argv[1]);
+  const char* name = JS_ToCString(ctx, argv[2]);
+  size_t len = 0;
+  const double* p = flox_indicator_graph_require(st->handle, sym, name, &len);
+  JS_FreeCString(ctx, name);
+  if (!p)
+  {
+    return JS_ThrowTypeError(ctx, "graph: require failed");
+  }
+  return jsArrayFromDoubles(ctx, std::vector<double>(p, p + len));
+}
+
+static JSValue js_graph_get(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  uint32_t sym = toUint32(ctx, argv[1]);
+  const char* name = JS_ToCString(ctx, argv[2]);
+  size_t len = 0;
+  const double* p = flox_indicator_graph_get(st->handle, sym, name, &len);
+  JS_FreeCString(ctx, name);
+  if (!p)
+  {
+    return JS_NULL;
+  }
+  return jsArrayFromDoubles(ctx, std::vector<double>(p, p + len));
+}
+
+#define GRAPH_FIELD(field)                                                               \
+  static JSValue js_graph_##field(JSContext* ctx, JSValueConst, int, JSValueConst* argv) \
+  {                                                                                      \
+    auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));                      \
+    uint32_t sym = toUint32(ctx, argv[1]);                                               \
+    size_t len = 0;                                                                      \
+    const double* p = flox_indicator_graph_##field(st->handle, sym, &len);               \
+    return jsArrayFromDoubles(ctx, std::vector<double>(p, p + len));                     \
+  }
+GRAPH_FIELD(close)
+GRAPH_FIELD(high)
+GRAPH_FIELD(low)
+GRAPH_FIELD(volume)
+#undef GRAPH_FIELD
+
+static JSValue js_graph_invalidate(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  flox_indicator_graph_invalidate(st->handle, toUint32(ctx, argv[1]));
+  return JS_UNDEFINED;
+}
+
+static JSValue js_graph_invalidate_all(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto* st = static_cast<JsGraphState*>(getHandle(ctx, argv[0]));
+  flox_indicator_graph_invalidate_all(st->handle);
+  return JS_UNDEFINED;
+}
+
+// ============================================================
 // Order book bindings
 // ============================================================
 
@@ -2136,6 +2334,20 @@ void registerFloxBindings(JSContext* ctx)
   addGlobalFunc(ctx, "__flox_target_future_return", js_target_future_return, 2);
   addGlobalFunc(ctx, "__flox_target_future_ctc_volatility", js_target_future_ctc_volatility, 2);
   addGlobalFunc(ctx, "__flox_target_future_linear_slope", js_target_future_linear_slope, 2);
+
+  // IndicatorGraph (batch)
+  addGlobalFunc(ctx, "__flox_graph_create", js_graph_create, 0);
+  addGlobalFunc(ctx, "__flox_graph_destroy", js_graph_destroy, 1);
+  addGlobalFunc(ctx, "__flox_graph_set_bars", js_graph_set_bars, 6);
+  addGlobalFunc(ctx, "__flox_graph_add_node", js_graph_add_node, 5);
+  addGlobalFunc(ctx, "__flox_graph_require", js_graph_require, 3);
+  addGlobalFunc(ctx, "__flox_graph_get", js_graph_get, 3);
+  addGlobalFunc(ctx, "__flox_graph_close", js_graph_close, 2);
+  addGlobalFunc(ctx, "__flox_graph_high", js_graph_high, 2);
+  addGlobalFunc(ctx, "__flox_graph_low", js_graph_low, 2);
+  addGlobalFunc(ctx, "__flox_graph_volume", js_graph_volume, 2);
+  addGlobalFunc(ctx, "__flox_graph_invalidate", js_graph_invalidate, 2);
+  addGlobalFunc(ctx, "__flox_graph_invalidate_all", js_graph_invalidate_all, 1);
 
   // Order book
   addGlobalFunc(ctx, "__flox_book_create", js_book_create, 1);

--- a/src/quickjs/js_strategy.cpp
+++ b/src/quickjs/js_strategy.cpp
@@ -496,6 +496,32 @@ void FloxJsStrategy::loadStdlib()
         volume(symbol) { return __flox_graph_volume(this._h, symbol); }
         invalidate(symbol) { __flox_graph_invalidate(this._h, symbol); }
         invalidateAll() { __flox_graph_invalidate_all(this._h); }
+      },
+
+      StreamingIndicatorGraph: class {
+        constructor() {
+          this._h = __flox_streaming_create();
+        }
+        destroy() {
+          if (this._h) { __flox_streaming_destroy(this._h); this._h = null; }
+        }
+        addNode(name, deps, fn) {
+          __flox_streaming_add_node(this._h, name, deps || [], fn, this);
+        }
+        step(symbol, close, high, low, volume) {
+          __flox_streaming_step(this._h, symbol, close,
+                                high !== undefined ? high : null,
+                                low !== undefined ? low : null,
+                                volume !== undefined ? volume : null);
+        }
+        current(symbol, name) { return __flox_streaming_current(this._h, symbol, name); }
+        barCount(symbol) { return __flox_streaming_bar_count(this._h, symbol); }
+        reset(symbol) { __flox_streaming_reset(this._h, symbol); }
+        resetAll() { __flox_streaming_reset_all(this._h); }
+        close(symbol) { return __flox_streaming_close(this._h, symbol); }
+        high(symbol) { return __flox_streaming_high(this._h, symbol); }
+        low(symbol) { return __flox_streaming_low(this._h, symbol); }
+        volume(symbol) { return __flox_streaming_volume(this._h, symbol); }
       }
     };
   )";

--- a/src/quickjs/js_strategy.cpp
+++ b/src/quickjs/js_strategy.cpp
@@ -472,7 +472,31 @@ void FloxJsStrategy::loadStdlib()
       loadCsv: function(path) { return __flox_load_csv(path); },
 
       // Forward-looking labels (research-only). See flox/targets.js.
-      targets: __floxTargets
+      targets: __floxTargets,
+
+      IndicatorGraph: class {
+        constructor() {
+          this._h = __flox_graph_create();
+        }
+        destroy() {
+          if (this._h) { __flox_graph_destroy(this._h); this._h = null; }
+        }
+        setBars(symbol, close, high, low, volume) {
+          __flox_graph_set_bars(this._h, symbol, close, high || null,
+                                low || null, volume || null);
+        }
+        addNode(name, deps, fn) {
+          __flox_graph_add_node(this._h, name, deps || [], fn, this);
+        }
+        require(symbol, name) { return __flox_graph_require(this._h, symbol, name); }
+        get(symbol, name) { return __flox_graph_get(this._h, symbol, name); }
+        close(symbol) { return __flox_graph_close(this._h, symbol); }
+        high(symbol) { return __flox_graph_high(this._h, symbol); }
+        low(symbol) { return __flox_graph_low(this._h, symbol); }
+        volume(symbol) { return __flox_graph_volume(this._h, symbol); }
+        invalidate(symbol) { __flox_graph_invalidate(this._h, symbol); }
+        invalidateAll() { __flox_graph_invalidate_all(this._h); }
+      }
     };
   )";
   if (!_engine.eval(registerCode, "<flox_register>"))

--- a/tests/test_capi_infra.cpp
+++ b/tests/test_capi_infra.cpp
@@ -284,3 +284,92 @@ TEST(CapiGraphTest, BasicComputeAndDeps)
 
   flox_indicator_graph_destroy(g);
 }
+
+// ============================================================
+// StreamingIndicatorGraph (C API)
+// ============================================================
+
+TEST(CapiStreamingGraphTest, StepAndCurrent)
+{
+  auto sg = flox_streaming_graph_create();
+  ASSERT_NE(sg, nullptr);
+
+  std::vector<double> stateA, stateB;
+  flox_streaming_graph_add_node(sg, "double_close", nullptr, 0, doubleClose, &stateA);
+  const char* deps[] = {"double_close"};
+  flox_streaming_graph_add_node(sg, "sum", deps, 1, sumWithDouble, &stateB);
+
+  // Before any steps current returns NaN.
+  EXPECT_TRUE(std::isnan(flox_streaming_graph_current(sg, 0, "double_close")));
+  EXPECT_EQ(flox_streaming_graph_bar_count(sg, 0), 0u);
+
+  std::vector<double> closes = {1.0, 2.0, 3.0, 4.0, 5.0};
+  for (size_t i = 0; i < closes.size(); ++i)
+  {
+    double c = closes[i];
+    flox_streaming_graph_step(sg, 0, c, c, c, c, 0.0);
+    EXPECT_EQ(flox_streaming_graph_bar_count(sg, 0), i + 1);
+
+    // double_close node: returns close * 2 for the last bar
+    EXPECT_NEAR(flox_streaming_graph_current(sg, 0, "double_close"), c * 2.0, 1e-12);
+    // sum node: returns close + double_close = close * 3
+    EXPECT_NEAR(flox_streaming_graph_current(sg, 0, "sum"), c * 3.0, 1e-12);
+  }
+
+  flox_streaming_graph_destroy(sg);
+}
+
+TEST(CapiStreamingGraphTest, ParityWithBatch)
+{
+  // Verify streaming current values after N steps == batch result[N-1].
+  std::vector<double> stateA, stateB;
+
+  auto sg = flox_streaming_graph_create();
+  flox_streaming_graph_add_node(sg, "double_close", nullptr, 0, doubleClose, &stateA);
+  const char* deps[] = {"double_close"};
+  flox_streaming_graph_add_node(sg, "sum", deps, 1, sumWithDouble, &stateB);
+
+  std::vector<double> closes = {10.0, 20.0, 30.0, 40.0, 50.0};
+  for (double c : closes)
+  {
+    flox_streaming_graph_step(sg, 0, c, c, c, c, 0.0);
+  }
+
+  // Batch run on the same data.
+  std::vector<double> batchStateA, batchStateB;
+  auto bg = flox_indicator_graph_create();
+  flox_indicator_graph_add_node(bg, "double_close", nullptr, 0, doubleClose, &batchStateA);
+  flox_indicator_graph_add_node(bg, "sum", deps, 1, sumWithDouble, &batchStateB);
+  flox_indicator_graph_set_bars(bg, 0, closes.data(), nullptr, nullptr, nullptr, closes.size());
+
+  size_t len = 0;
+  const double* batchSum = flox_indicator_graph_require(bg, 0, "sum", &len);
+  ASSERT_EQ(len, closes.size());
+
+  // Streaming current == batch last element.
+  EXPECT_NEAR(flox_streaming_graph_current(sg, 0, "sum"), batchSum[len - 1], 1e-12);
+
+  flox_indicator_graph_destroy(bg);
+  flox_streaming_graph_destroy(sg);
+}
+
+TEST(CapiStreamingGraphTest, Reset)
+{
+  std::vector<double> stateA;
+  auto sg = flox_streaming_graph_create();
+  flox_streaming_graph_add_node(sg, "double_close", nullptr, 0, doubleClose, &stateA);
+
+  flox_streaming_graph_step(sg, 0, 5.0, 5.0, 5.0, 5.0, 0.0);
+  EXPECT_NEAR(flox_streaming_graph_current(sg, 0, "double_close"), 10.0, 1e-12);
+  EXPECT_EQ(flox_streaming_graph_bar_count(sg, 0), 1u);
+
+  flox_streaming_graph_reset(sg, 0);
+  EXPECT_EQ(flox_streaming_graph_bar_count(sg, 0), 0u);
+  EXPECT_TRUE(std::isnan(flox_streaming_graph_current(sg, 0, "double_close")));
+
+  // Can resume stepping after reset.
+  flox_streaming_graph_step(sg, 0, 7.0, 7.0, 7.0, 7.0, 0.0);
+  EXPECT_NEAR(flox_streaming_graph_current(sg, 0, "double_close"), 14.0, 1e-12);
+
+  flox_streaming_graph_destroy(sg);
+}

--- a/tests/test_capi_infra.cpp
+++ b/tests/test_capi_infra.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 #include <cmath>
+#include <vector>
 
 // ============================================================
 // Order book
@@ -199,4 +200,87 @@ TEST(CapiOrderTrackerTest, Lifecycle)
   EXPECT_EQ(flox_order_tracker_active_count(tracker), 0u);
 
   flox_order_tracker_destroy(tracker);
+}
+
+// ============================================================
+// IndicatorGraph (batch)
+// ============================================================
+
+namespace
+{
+// Test fixture: a node fn that returns the close array * 2.
+static const double* doubleClose(void* user_data, FloxIndicatorGraphHandle g, uint32_t sym,
+                                 size_t* out_len)
+{
+  auto* state = static_cast<std::vector<double>*>(user_data);
+  size_t n = 0;
+  const double* c = flox_indicator_graph_close(g, sym, &n);
+  state->resize(n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    (*state)[i] = c[i] * 2.0;
+  }
+  *out_len = n;
+  return state->data();
+}
+
+// dependent: returns close + parent
+static const double* sumWithDouble(void* user_data, FloxIndicatorGraphHandle g, uint32_t sym,
+                                   size_t* out_len)
+{
+  auto* state = static_cast<std::vector<double>*>(user_data);
+  size_t n = 0;
+  const double* c = flox_indicator_graph_close(g, sym, &n);
+  size_t pn = 0;
+  const double* p = flox_indicator_graph_get(g, sym, "double_close", &pn);
+  if (!p || pn != n)
+  {
+    *out_len = 0;
+    return nullptr;
+  }
+  state->resize(n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    (*state)[i] = c[i] + p[i];
+  }
+  *out_len = n;
+  return state->data();
+}
+}  // namespace
+
+TEST(CapiGraphTest, BasicComputeAndDeps)
+{
+  auto g = flox_indicator_graph_create();
+  ASSERT_NE(g, nullptr);
+
+  std::vector<double> close = {1.0, 2.0, 3.0, 4.0, 5.0};
+  flox_indicator_graph_set_bars(g, 0, close.data(), nullptr, nullptr, nullptr, close.size());
+
+  std::vector<double> stateA, stateB;
+  flox_indicator_graph_add_node(g, "double_close", nullptr, 0, doubleClose, &stateA);
+  const char* deps[] = {"double_close"};
+  flox_indicator_graph_add_node(g, "sum", deps, 1, sumWithDouble, &stateB);
+
+  size_t len = 0;
+  const double* out = flox_indicator_graph_require(g, 0, "sum", &len);
+  ASSERT_NE(out, nullptr);
+  ASSERT_EQ(len, 5u);
+  for (size_t i = 0; i < 5; ++i)
+  {
+    EXPECT_NEAR(out[i], close[i] * 3.0, 1e-12);
+  }
+
+  // get on cached node returns the same pointer.
+  size_t cl = 0;
+  const double* cached = flox_indicator_graph_get(g, 0, "double_close", &cl);
+  ASSERT_NE(cached, nullptr);
+  EXPECT_EQ(cl, 5u);
+
+  // Unknown node -> nullptr.
+  size_t l2 = 999;
+  const double* missing = flox_indicator_graph_require(g, 0, "nope", &l2);
+  EXPECT_EQ(missing, nullptr);
+  EXPECT_EQ(l2, 0u);
+
+  flox_indicator_graph_destroy(g);
 }

--- a/tests/test_quickjs.cpp
+++ b/tests/test_quickjs.cpp
@@ -148,6 +148,70 @@ TEST(JsIntegrationTest, TargetsBindings)
   JS_FreeValue(jsStrat.engine().context(), tail);
 }
 
+TEST(JsIntegrationTest, IndicatorGraphBindings)
+{
+  TempJsFile script(R"(
+    var ramp = [];
+    for (var i = 0; i < 50; ++i) ramp.push(i);
+
+    var g = new flox.IndicatorGraph();
+    g.setBars(0, ramp);
+
+    g.addNode("ema5", [], function(graph, sym) {
+      return SMA.compute(graph.close(sym), 5);
+    });
+    g.addNode("sma5", [], function(graph, sym) {
+      return SMA.compute(graph.close(sym), 5);
+    });
+    g.addNode("diff", ["ema5", "sma5"], function(graph, sym) {
+      var a = graph.get(sym, "ema5");
+      var b = graph.get(sym, "sma5");
+      var out = [];
+      for (var i = 0; i < a.length; ++i) out.push(a[i] - b[i]);
+      return out;
+    });
+
+    var ema5 = g.require(0, "ema5");
+    var diff = g.require(0, "diff");
+    var ema5_len = ema5.length;
+    var diff_len = diff.length;
+    var sma5_cached = g.get(0, "sma5");
+    var sma5_not_null = sma5_cached !== null;
+
+    var threw = false;
+    try { g.require(0, "missing"); } catch (e) { threw = true; }
+    var require_throws = threw;
+
+    g.destroy();
+  )");
+
+  SymbolRegistry registry;
+  FloxJsStrategy jsStrat(script.path(), registry);
+
+  auto* ctx = jsStrat.engine().context();
+
+  auto getInt = [&](const char* name)
+  {
+    JSValue v = jsStrat.engine().getGlobalProperty(name);
+    int32_t i = 0;
+    JS_ToInt32(ctx, &i, v);
+    JS_FreeValue(ctx, v);
+    return i;
+  };
+  auto getBool = [&](const char* name)
+  {
+    JSValue v = jsStrat.engine().getGlobalProperty(name);
+    bool b = JS_ToBool(ctx, v);
+    JS_FreeValue(ctx, v);
+    return b;
+  };
+
+  EXPECT_EQ(getInt("ema5_len"), 50);
+  EXPECT_EQ(getInt("diff_len"), 50);
+  EXPECT_TRUE(getBool("sma5_not_null"));
+  EXPECT_TRUE(getBool("require_throws"));
+}
+
 TEST(JsIntegrationTest, LoadStrategyAndResolveSymbols)
 {
   TempJsFile script(R"(

--- a/tests/test_quickjs.cpp
+++ b/tests/test_quickjs.cpp
@@ -212,6 +212,77 @@ TEST(JsIntegrationTest, IndicatorGraphBindings)
   EXPECT_TRUE(getBool("require_throws"));
 }
 
+TEST(JsIntegrationTest, StreamingIndicatorGraph)
+{
+  TempJsFile script(R"(
+    var sg = new flox.StreamingIndicatorGraph();
+    sg.addNode("double_close", [], function(graph, sym) {
+      var c = graph.close(sym);
+      var out = [];
+      for (var i = 0; i < c.length; ++i) out.push(c[i] * 2.0);
+      return out;
+    });
+
+    var closes = [10.0, 20.0, 30.0, 40.0, 50.0];
+    var lastDouble = 0;
+    var barCounts = [];
+    for (var i = 0; i < closes.length; ++i) {
+      sg.step(0, closes[i]);
+      lastDouble = sg.current(0, "double_close");
+      barCounts.push(sg.barCount(0));
+    }
+
+    // After 5 steps: current == last close * 2, bar counts 1..5.
+    var ok_last = Math.abs(lastDouble - 100.0) < 1e-9;
+    var ok_counts = barCounts[0] === 1 && barCounts[4] === 5;
+
+    // Parity: batch on same data should match.
+    var bg = new flox.IndicatorGraph();
+    bg.setBars(0, new Float64Array(closes));
+    bg.addNode("double_close", [], function(graph, sym) {
+      var c = graph.close(sym);
+      var out = [];
+      for (var i = 0; i < c.length; ++i) out.push(c[i] * 2.0);
+      return out;
+    });
+    var batchOut = bg.require(0, "double_close");
+    var parity = Math.abs(batchOut[batchOut.length - 1] - lastDouble) < 1e-9;
+    bg.destroy();
+
+    // Reset and verify bar count resets.
+    sg.reset(0);
+    var after_reset_count = sg.barCount(0);
+    var after_reset_nan = isNaN(sg.current(0, "double_close"));
+    sg.destroy();
+  )");
+
+  SymbolRegistry registry;
+  FloxJsStrategy jsStrat(script.path(), registry);
+  auto* ctx = jsStrat.engine().context();
+
+  auto getBool = [&](const char* name)
+  {
+    JSValue v = jsStrat.engine().getGlobalProperty(name);
+    bool b = JS_ToBool(ctx, v);
+    JS_FreeValue(ctx, v);
+    return b;
+  };
+  auto getInt = [&](const char* name)
+  {
+    JSValue v = jsStrat.engine().getGlobalProperty(name);
+    int32_t i = 0;
+    JS_ToInt32(ctx, &i, v);
+    JS_FreeValue(ctx, v);
+    return i;
+  };
+
+  EXPECT_TRUE(getBool("ok_last"));
+  EXPECT_TRUE(getBool("ok_counts"));
+  EXPECT_TRUE(getBool("parity"));
+  EXPECT_EQ(getInt("after_reset_count"), 0);
+  EXPECT_TRUE(getBool("after_reset_nan"));
+}
+
 TEST(JsIntegrationTest, LoadStrategyAndResolveSymbols)
 {
   TempJsFile script(R"(


### PR DESCRIPTION
## Summary

- Adds `python/tests/test_parity.py` — covers every indicator exposed both as a batch function and a streaming class: SMA, EMA, RMA, RSI, DEMA, TEMA, KAMA, Slope, Skewness, Kurtosis, RollingZScore, ShannonEntropy, ATR, Stochastic, CCI, ParkinsonVol, RogersSatchellVol, MACD, Bollinger, Correlation, plus `IndicatorGraph` streaming vs batch parity
- Adds "Parity tests" step to `linux-gcc` CI job — blocking, runs after the binding smoke test
- Fixes three real bugs discovered by the tests (see below)

## Bugs found and fixed

**PyDEMA / PyTEMA** — inner EMA(s) were fed `0` during outer-EMA warmup instead of waiting for it to become ready. This seeded the inner EMA with garbage, producing large value divergence vs the batch. Fix: only call `_ema2.update()` once `_ema1.isReady()`.

**PyATR** — bar-0 TR (just `H-L`, no previous close) was included in the SMA seed, but the batch ATR follows TA-Lib convention and skips bar 0 entirely (seeds from TR[1..period]). Off-by-one warmup + wrong seed value. Fix: skip bar 0, require `period + 1` updates before ready.

**PyMACD** — fast EMA was seeded independently from the start; the batch seeds the fast EMA at the slow EMA start point using the last `fast` values (TA-Lib convention). Fix: accumulate history, reseed fast EMA on the first tick where the slow EMA becomes ready.

## Additional changes

- Added `require(symbol, name)` to `PyStreamingIndicatorGraph` so node callbacks can call `g.require(sym, dep)` with the same API as the batch graph.

## Test plan

- [x] `PYTHONPATH=build/python python3 python/tests/test_parity.py` — 62 passed, 0 failed
- [x] `PYTHONPATH=build/python python3 python/tests/test_bindings.py` — 75 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)