### PR TITLE
feat: HoldSide hint, BpsRangeBarPolicy, POST_ONLY rejection, tolerant binary log

### DIFF
--- a/include/flox/aggregator/bar.h
+++ b/include/flox/aggregator/bar.h
@@ -24,7 +24,8 @@ enum class BarType : uint8_t
   Volume,
   Renko,
   Range,
-  HeikinAshi
+  HeikinAshi,
+  BpsRange
 };
 
 enum class BarCloseReason : uint8_t

--- a/include/flox/aggregator/bar_aggregator.h
+++ b/include/flox/aggregator/bar_aggregator.h
@@ -13,6 +13,7 @@
 #include "flox/aggregator/bar.h"
 #include "flox/aggregator/bus/bar_bus.h"
 #include "flox/aggregator/events/bar_event.h"
+#include "flox/aggregator/policies/bps_range_bar_policy.h"
 #include "flox/aggregator/policies/heikin_ashi_bar_policy.h"
 #include "flox/aggregator/policies/range_bar_policy.h"
 #include "flox/aggregator/policies/renko_bar_policy.h"
@@ -117,6 +118,7 @@ using TickBarAggregator = BarAggregator<TickBarPolicy>;
 using VolumeBarAggregator = BarAggregator<VolumeBarPolicy>;
 using RenkoBarAggregator = BarAggregator<RenkoBarPolicy>;
 using RangeBarAggregator = BarAggregator<RangeBarPolicy>;
+using BpsRangeBarAggregator = BarAggregator<BpsRangeBarPolicy>;
 using HeikinAshiBarAggregator = BarAggregator<HeikinAshiBarPolicy>;
 
 }  // namespace flox

--- a/include/flox/aggregator/policies/bps_range_bar_policy.h
+++ b/include/flox/aggregator/policies/bps_range_bar_policy.h
@@ -1,0 +1,66 @@
+/*
+ * Flox Engine — local extension for flox-h6 project.
+ *
+ * BpsRangeBarPolicy: closes a bar when (high - low) / open >= bps_threshold.
+ *
+ * Same as RangeBarPolicy but the threshold is RELATIVE (basis points of bar
+ * open), so it works uniformly across symbols of any nominal price.
+ */
+
+#pragma once
+
+#include "flox/aggregator/aggregation_policy.h"
+
+namespace flox
+{
+
+class BpsRangeBarPolicy
+{
+ public:
+  static constexpr BarType kBarType = BarType::BpsRange;
+
+  // bpsThreshold = e.g. 20 means "close when (high - low) / open >= 20bps"
+  explicit constexpr BpsRangeBarPolicy(double bpsThreshold) noexcept
+      : _bps(bpsThreshold)
+  {
+  }
+
+  constexpr uint64_t param() const noexcept
+  {
+    // Encode bps × 100 to keep an int representation if anyone reads it back
+    return static_cast<uint64_t>(_bps * 100.0);
+  }
+
+  [[nodiscard]] bool shouldClose(const TradeEvent& trade, const Bar& bar) const noexcept
+  {
+    const auto newHigh = std::max(bar.high, trade.trade.price);
+    const auto newLow = std::min(bar.low, trade.trade.price);
+    if (bar.open.raw() <= 0)
+    {
+      return false;
+    }
+    // (high - low) / open in bps
+    const double range = static_cast<double>(newHigh.raw() - newLow.raw());
+    const double openD = static_cast<double>(bar.open.raw());
+    return (range / openD) * 1e4 >= _bps;
+  }
+
+  void update(const TradeEvent& trade, Bar& bar) noexcept
+  {
+    updateOHLCV(trade, bar);
+  }
+
+  void initBar(const TradeEvent& trade, Bar& bar) noexcept
+  {
+    initBarFromTrade(trade, bar);
+  }
+
+  double bps() const noexcept { return _bps; }
+
+ private:
+  double _bps;
+};
+
+static_assert(BarPolicy<BpsRangeBarPolicy>, "BpsRangeBarPolicy must satisfy BarPolicy concept");
+
+}  // namespace flox

--- a/include/flox/execution/order.h
+++ b/include/flox/execution/order.h
@@ -17,12 +17,24 @@
 namespace flox
 {
 
+// Hold-side hint for exchanges that operate in hedge / dual-position mode
+// (Bitget, Bybit, Binance hedge). 0 = unspecified (one-way mode), 1 = long
+// side, 2 = short side. Connectors serialise this to whatever field the
+// exchange expects (Bitget: posSide=long|short).
+enum class HoldSide : uint8_t
+{
+  Unspecified = 0,
+  Long = 1,
+  Short = 2
+};
+
 struct ExecutionFlags
 {
   uint8_t reduceOnly : 1 = 0;
   uint8_t closePosition : 1 = 0;
   uint8_t postOnly : 1 = 0;
-  uint8_t _reserved : 5 = 0;
+  uint8_t holdSide : 2 = 0;  // HoldSide; cast through static_cast<HoldSide>
+  uint8_t _reserved : 3 = 0;
 };
 
 struct Order

--- a/include/flox/replay/binary_format_v1.h
+++ b/include/flox/replay/binary_format_v1.h
@@ -59,7 +59,12 @@ struct alignas(8) SegmentHeader
 
   bool isValid() const noexcept { return magic == kMagic && version == kFormatVersion; }
   bool hasIndex() const noexcept { return (flags & SegmentFlags::HasIndex) && index_offset > 0; }
-  bool isCompressed() const noexcept { return (flags & SegmentFlags::Compressed) != 0; }
+  // Some older writers set `compression` field but forgot the Compressed flag.
+  // Treat either signal as compressed.
+  bool isCompressed() const noexcept
+  {
+    return ((flags & SegmentFlags::Compressed) != 0) || (compression != static_cast<uint8_t>(CompressionType::None));
+  }
   bool isSorted() const noexcept { return (flags & SegmentFlags::Sorted) != 0; }
   CompressionType compressionType() const noexcept { return static_cast<CompressionType>(compression); }
 };

--- a/src/backtest/simulated_executor.cpp
+++ b/src/backtest/simulated_executor.cpp
@@ -138,6 +138,24 @@ void SimulatedExecutor::submitOrder(const Order& order)
   emitEvent(OrderEventStatus::SUBMITTED, accepted);
   emitEvent(OrderEventStatus::ACCEPTED, accepted);
 
+  // POST_ONLY: reject any limit that would cross the book (taker semantics
+  // are not allowed for post-only). Real exchanges reject these on submit;
+  // the simulator must do the same so backtests don't silently fill them
+  // as makers via the queue tracker on subsequent ticks.
+  if (accepted.type == OrderType::LIMIT && accepted.timeInForce == TimeInForce::POST_ONLY)
+  {
+    const MarketState& state = getMarketState(accepted.symbol);
+    const int64_t orderPriceRaw = accepted.price.raw();
+    const bool crosses =
+        (accepted.side == Side::BUY && state.hasAsk && orderPriceRaw >= state.bestAskRaw) ||
+        (accepted.side == Side::SELL && state.hasBid && orderPriceRaw <= state.bestBidRaw);
+    if (crosses)
+    {
+      emitEvent(OrderEventStatus::REJECTED, accepted);
+      return;
+    }
+  }
+
   // Handle conditional orders (stop, TP, trailing)
   if (isConditionalOrder(accepted.type))
   {


### PR DESCRIPTION
## Summary

Three independent improvements that downstream connectors and aggregators need.

### 1. \`HoldSide\` hint for hedge-mode exchanges

Bitget, Bybit hedge mode, and Binance hedge mode require the connector to specify which side of the position an order targets (e.g. Bitget \`posSide=long|short\`). One-way mode ignores it.

Adds \`enum class HoldSide : uint8_t { Unspecified, Long, Short }\` and packs it into 2 bits of \`ExecutionFlags::holdSide\`, replacing 2 bits of the reserved space. Zero cost on the hot path; backwards-compatible default (\`Unspecified\`) for callers that don't set it.

### 2. \`BpsRangeBarPolicy\`

A new range-bar aggregator where the threshold is expressed in **basis points relative to bar open**, so the same policy works across symbols with different price scales (BTC \$70k vs SOL \$200 vs DOGE \$0.10) without per-symbol tuning.

- New \`BarType::BpsRange\` enum value
- New \`BpsRangeBarAggregator\` type alias
- Header-only policy in \`include/flox/aggregator/policies/bps_range_bar_policy.h\`

### 3. POST_ONLY rejection in \`SimulatedExecutor\`

Real exchanges reject POST_ONLY limits whose price would cross the book (taker semantics not allowed). The simulator was silently accepting them and filling them as makers via the queue tracker on subsequent ticks, which gave wrong fills in backtests of POST_ONLY strategies.

Now \`submitOrder\` rejects on submit any \`LIMIT + POST_ONLY\` whose price crosses \`best_ask\` (BUY) or \`best_bid\` (SELL) via \`OrderEventStatus::REJECTED\`. Pre-existing maker-fill correctness for non-POST_ONLY limits is unchanged — handled by \`OrderQueueTracker\`.

### 4. Tolerant binary log \`isCompressed()\`

\`SegmentHeader::isCompressed()\` now returns true when \`compression\` field is non-\`None\` even if the \`Compressed\` flag bit is unset. Older writers may forget to set the flag bit while still writing LZ4-compressed payloads — readers were silently treating those segments as uncompressed.

## Test plan

- [x] All existing tests pass (48/48)
- [x] clang-format applied
- [ ] CI green
- [ ] Reviewer can verify each change is self-contained and additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)