### PR TITLE
docs: publish llms.txt and llms-full.txt for AI agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           echo "Run: python3 scripts/gen_indicator_docs.py"
           exit 1
         fi
+    - name: Verify llms.txt and llms-full.txt are in sync with docs/
+      run: python3 scripts/gen_llms_txt.py --check
 
   linux-gcc:
     needs: format-check

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,0 +1,15258 @@
+# FLOX — full documentation bundle
+
+FLOX is a C++23 high-performance trading framework with first-class bindings for Python, Node.js, Codon, and embedded JavaScript. Use it to build strategies, backtest on historical data, and run live trading from any of these languages — the same C++ core powers all of them, so behavior is identical across runtimes.
+
+This file concatenates the curated documentation set listed in `llms.txt`. Each page is preceded by a `# Source: <path>` header and a horizontal rule so an agent can locate the original file.
+
+==============================================================================
+# Section: Overview
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/index.md
+# URL: https://flox-foundation.github.io/flox/
+------------------------------------------------------------------------------
+
+# FLOX
+
+**High-performance trading framework with bindings for Python, Node.js, Codon, and C++.**
+
+[![GitHub](https://img.shields.io/badge/GitHub-FLOX--Foundation%2Fflox-blue?logo=github)](https://github.com/FLOX-Foundation/flox)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/FLOX-Foundation/flox/blob/main/LICENSE)
+
+---
+
+## Getting started
+
+Pick your language:
+
+| | |
+|---|---|
+| [**Python quickstart**](tutorials/python-quickstart.md) | Indicators, strategies, and backtesting from Python |
+| [**Node.js quickstart**](tutorials/node-quickstart.md) | Same API from JavaScript/TypeScript |
+| [**C++ quickstart**](tutorials/quickstart.md) | Build FLOX and run the demo |
+| [**Architecture**](explanation/architecture.md) | How the components fit together |
+
+---
+
+## Quick example
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+
+    ema = flox.EMA(20)
+    rsi = flox.RSI(14)
+
+    for price in prices:
+        e = ema.update(price)
+        r = rsi.update(price)
+        if e is not None and r is not None:
+            print(f"EMA {e:.2f}  RSI {r:.1f}")
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const flox = require('./build/node');
+
+    const ema = new flox.EMA(20);
+    const rsi = new flox.RSI(14);
+
+    for (const price of prices) {
+        const e = ema.update(price);
+        const r = rsi.update(price);
+        if (e !== null && r !== null) {
+            console.log(`EMA ${e.toFixed(2)}  RSI ${r.toFixed(1)}`);
+        }
+    }
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/strategy/istrategy.h"
+    #include "flox/book/event/trade_event.h"
+
+    class MyStrategy : public flox::IStrategy {
+    public:
+        void onTrade(const flox::TradeEvent& event) override {
+            if (event.trade.symbol == _targetSymbol) {
+                processSignal(event.trade.price);
+            }
+        }
+
+        void start() override { _running = true; }
+        void stop() override  { _running = false; }
+
+    private:
+        flox::SymbolId _targetSymbol;
+        bool _running = false;
+    };
+    ```
+
+---
+
+## Language bindings
+
+| Language | Guide | Reference |
+|---|---|---|
+| Python | [Python](bindings/python.md) | [reference](reference/python/index.md) |
+| Node.js | [Node.js](bindings/node.md) | [reference](reference/node/index.md) |
+| Codon | [Codon](bindings/codon.md) | [reference](reference/codon/index.md) |
+| JavaScript (embedded) | [JavaScript](bindings/javascript.md) | [reference](reference/quickjs/index.md) |
+| C API | [C API](bindings/capi.md) | [reference](reference/api/capi/flox_capi.md) |
+
+---
+
+## Documentation
+
+| Section | Description |
+|---------|-------------|
+| [Tutorials](tutorials/README.md) | Step-by-step lessons for new users |
+| [How-To Guides](how-to/README.md) | Solutions for specific problems |
+| [Explanation](explanation/README.md) | Architecture and design concepts |
+| [Reference](reference/README.md) | API specifications |
+
+---
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| Lock-free event delivery | Disruptor-style ring buffers, busy-spin consumers |
+| Zero-allocation hot path | Pre-allocated pools, no heap allocation in market data callbacks |
+| CPU affinity support | Pin threads to isolated cores |
+| Multi-exchange trading | [CEX coordination](reference/api/cex/index.md) with aggregation and smart routing |
+| Binary replay system | Record live data, replay for backtesting |
+| Grid search optimization | Parallel parameter optimization with mmap-based bar storage |
+| Multi-language bindings | Python, Node.js, Codon, JavaScript, C API |
+| Type-safe primitives | Strong types for Price, Quantity, SymbolId |
+| Modular architecture | Use only what you need |
+
+---
+
+## Requirements
+
+Pick the row for your binding. The C++ engine itself only matters if you build from source.
+
+| If you use | You need |
+|---|---|
+| **Python** | Python 3.10+. `pip install flox-py` for prebuilt wheels (Linux / macOS). |
+| **Node.js** | Node 18+. `npm install @flox-foundation/flox`. |
+| **Codon** | Codon compiler + `flox` built with `-DFLOX_ENABLE_CAPI=ON`. |
+| **C++** | C++20 compiler (GCC 13+ / Clang 16+), CMake 3.22+, Linux or macOS. |
+
+Optional across all bindings: LZ4 for binary log compression.
+
+---
+
+## License
+
+MIT License
+
+------------------------------------------------------------------------------
+# Source: docs/bindings/README.md
+# URL: https://flox-foundation.github.io/flox/bindings/
+------------------------------------------------------------------------------
+
+# Language bindings
+
+All bindings expose the same core model: strategy callbacks, order emission, position queries. The API shape is the same across languages.
+
+| Language | Guide | Reference |
+|---|---|---|
+| Python | [Python](python.md) | [API reference](../reference/python/index.md) |
+| Node.js | [Node.js](node.md) | [API reference](../reference/node/index.md) |
+| Codon | [Codon](codon.md) | [API reference](../reference/codon/index.md) |
+| JavaScript (embedded) | [JavaScript](javascript.md) | [API reference](../reference/quickjs/index.md) |
+| C API | [C API](capi.md) | [reference](../reference/api/capi/flox_capi.md) |
+
+## Which one to use
+
+Python is the easiest starting point for backtesting — the `Engine` class runs signal batches in parallel C++ threads with the GIL released. Node.js makes more sense if your infrastructure is already JS.
+
+Codon has nearly identical syntax to Python but compiles to native code. Start with Python, switch to Codon if you need it.
+
+The embedded JS binding runs QuickJS inside the C++ process — no separate Node.js runtime. Useful for scripted rules and backtesting where spinning up an external runtime isn't practical.
+
+For other languages, use the C API.
+
+==============================================================================
+# Section: Bindings (language entry points)
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/bindings/python.md
+# URL: https://flox-foundation.github.io/flox/bindings/python/
+------------------------------------------------------------------------------
+
+# Python Bindings
+
+## Strategy API
+
+Event-driven live trading and backtesting using `Strategy`, `Runner`, and `BacktestRunner`.
+
+### Build
+
+```bash
+cmake -B build \
+  -DFLOX_ENABLE_PYTHON=ON \
+  -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build
+```
+
+Requires: Python 3.9+, pybind11 (`pip install pybind11`).
+
+The module builds at `build/python/flox_py.cpython-*.so`.
+
+### Symbols
+
+```python
+import flox_py as flox
+
+registry = flox.SymbolRegistry()
+btc = registry.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+# btc.id, btc.name, btc.exchange, btc.tick_size
+# int(btc) → 1 — works as int everywhere
+```
+
+### Writing a Strategy
+
+```python
+class SMAcross(flox.Strategy):
+    def __init__(self, symbols):
+        super().__init__(symbols)
+        self.fast = flox.SMA(10)
+        self.slow = flox.SMA(30)
+
+    def on_start(self): ...
+    def on_stop(self): ...
+
+    def on_trade(self, ctx, trade):
+        f = self.fast.update(trade.price)
+        s = self.slow.update(trade.price)
+        if f is None or s is None:
+            return
+        if f > s and ctx.is_flat():
+            self.market_buy(0.01)
+        elif f < s and ctx.is_long():
+            self.close_position()
+
+    def on_book_update(self, ctx): ...
+```
+
+Order methods: `market_buy(qty)`, `market_sell(qty)`, `limit_buy(price, qty)`, `limit_sell(price, qty)`, `stop_market(side, trigger, qty)`, `close_position()`. All accept an optional `symbol` argument; without it the first registered symbol is used.
+
+### Live Runner
+
+```python
+def on_signal(sig):
+    # sig.side, sig.order_type, sig.quantity, sig.price, sig.order_id
+    send_to_exchange(sig)
+
+runner = flox.Runner(registry, on_signal)                  # synchronous
+runner = flox.Runner(registry, on_signal, threaded=True)   # Disruptor background thread
+
+runner.add_strategy(SMAcross([btc]))
+runner.start()
+
+# Inject market data (from your feed):
+runner.on_trade(btc, price, qty, is_buy, ts_ns)
+runner.on_book_snapshot(btc, bid_prices, bid_qtys, ask_prices, ask_qtys, ts_ns)
+
+runner.stop()
+```
+
+### Backtest
+
+```python
+bt = flox.BacktestRunner(registry, fee_rate=0.0004, initial_capital=10_000)
+bt.set_strategy(SMAcross([btc]))
+
+stats = bt.run_csv("btcusdt_trades.csv")             # auto-detects symbol
+stats = bt.run_csv("btcusdt_trades.csv", "BTCUSDT")  # explicit
+print(stats["return_pct"], stats["sharpe"], stats["max_drawdown_pct"])
+```
+
+Stats dict keys: `return_pct`, `net_pnl`, `total_trades`, `win_rate`, `sharpe`, `max_drawdown_pct`.
+
+---
+
+## Batch Backtest Engine
+
+Run backtests against pre-computed signal arrays. Execution runs in C++ with the GIL released and multi-threaded batch support.
+
+### Build
+
+```bash
+cmake -B build \
+  -DFLOX_ENABLE_BACKTEST=ON \
+  -DFLOX_ENABLE_PYTHON=ON \
+  -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build
+```
+
+Requires: Python 3.9+, pybind11, numpy (`pip install pybind11 numpy`).
+
+### Quick Start
+
+```python
+import numpy as np
+import flox_py as flox
+
+engine = flox.Engine(initial_capital=100_000, fee_rate=0.0001)
+
+# Load OHLCV data
+engine.load_bars_df(timestamps, opens, highs, lows, closes, volumes)
+
+# Create signals (all market orders)
+signals = flox.make_signals(
+    timestamps=np.array([1704067200000, 1704068400000], dtype=np.int64),
+    sides=np.array([0, 1], dtype=np.uint8),  # 0=buy, 1=sell
+    quantities=np.array([0.5, 0.5]),
+)
+
+stats = engine.run(signals)
+print(f"PnL: {stats['net_pnl']:.2f}, Sharpe: {stats['sharpe']:.4f}")
+```
+
+### Loading Bar Data
+
+Two options:
+
+=== "From numpy arrays"
+
+    ```python
+    engine.load_bars_df(
+        timestamps,  # int64, unix ms or ns (auto-detected)
+        opens,       # float64
+        highs,       # float64
+        lows,        # float64
+        closes,      # float64
+        volumes,     # float64
+    )
+    ```
+
+=== "From structured array"
+
+    ```python
+    bars = np.zeros(n, dtype=flox.PyBar)
+    bars['timestamp_ns'] = ...
+    bars['open_raw'] = (opens * 1e8).astype(np.int64)
+    # ... etc
+    engine.load_bars(bars)
+    ```
+
+Load once, then run as many backtests as needed against the same data.
+
+### Creating Signals
+
+`make_signals()` converts numpy arrays into a packed struct array:
+
+```python
+signals = flox.make_signals(
+    timestamps,   # int64 — unix ms, us, or ns (auto-normalized)
+    sides,        # uint8 — 0=buy, 1=sell
+    quantities,   # float64 — position size
+    prices,       # float64 — limit price (optional, default: market)
+    types,        # uint8 — 0=market, 1=limit (optional, default: market)
+)
+```
+
+For market-only strategies, `prices` and `types` can be omitted.
+
+### Single Run
+
+```python
+stats = engine.run(signals, symbol=1)
+```
+
+Returns a dict with all backtest metrics:
+
+| Key | Description |
+|-----|-------------|
+| `total_trades` | Round-trip trade count |
+| `net_pnl` | Gross PnL minus all fees |
+| `total_fees` | Total execution fees |
+| `sharpe` | Annualized Sharpe ratio |
+| `sortino` | Annualized Sortino ratio |
+| `calmar` | Calmar ratio |
+| `max_drawdown` | Peak-to-trough drawdown |
+| `max_drawdown_pct` | Drawdown as percentage |
+| `win_rate` | Winning trade fraction |
+| `profit_factor` | Gross profit / gross loss |
+| `return_pct` | Net return percentage |
+
+### Batch Execution
+
+Run N backtests in parallel using C++ threads:
+
+```python
+all_stats = engine.run_batch(
+    [signals_1, signals_2, ..., signals_n],
+    threads=0,   # 0 = use all cores
+    symbol=1,
+)
+```
+
+GIL released. Threads run independent copies, nothing shared.
+
+#### Permutation Testing Example
+
+```python
+import flox_py as flox
+import numpy as np
+
+engine = flox.Engine(initial_capital=100_000, fee_rate=0.0001)
+engine.load_bars_df(timestamps, opens, highs, lows, closes, volumes)
+
+rng = np.random.default_rng(42)
+signal_sets = []
+
+for _ in range(1000):
+    rets = np.diff(np.log(closes))
+    rng.shuffle(rets)
+    shuffled = closes[0] * np.exp(np.cumsum(np.concatenate(([0], rets))))
+    sigs = my_strategy(shuffled, timestamps)
+    signal_sets.append(sigs)
+
+# 1000 backtests in ~50ms
+results = engine.run_batch(signal_sets)
+pnls = [r["net_pnl"] for r in results]
+p_value = np.mean([p >= results[0]["net_pnl"] for p in pnls])
+```
+
+### Performance
+
+Benchmarked on Apple M-series, 100K bars, MA cross strategy:
+
+| Mode | Time | vs Python |
+|------|------|-----------|
+| Single run | 0.6ms | 33x |
+| 1000 permutations | 53ms | 400x |
+| Bar loading | 0.5ms | — |
+
+## See Also
+
+- [Python API Reference](../reference/python/index.md) — complete Python API documentation
+- [Backtesting](../how-to/backtest.md) — C++ backtest guide
+- [Grid Search](../how-to/grid-search.md) — parameter optimization
+
+------------------------------------------------------------------------------
+# Source: docs/bindings/node.md
+# URL: https://flox-foundation.github.io/flox/bindings/node/
+------------------------------------------------------------------------------
+
+# Node.js Bindings
+
+Event-driven live trading and backtesting from Node.js using `@flox-foundation/flox`.
+
+## Install / Build
+
+```bash
+npm install @flox-foundation/flox
+# or build from source:
+cmake -B build -DFLOX_ENABLE_NODE=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+```javascript
+const flox = require('@flox-foundation/flox');
+// or, if building from source:
+const flox = require('../node');
+```
+
+## SymbolRegistry and Symbol
+
+```javascript
+const registry = new flox.SymbolRegistry();
+const btc = registry.addSymbol('binance', 'BTCUSDT', 0.01);
+
+btc.id        // 1
+btc.name      // "BTCUSDT"
+btc.exchange  // "binance"
+btc.tickSize  // 0.01
+
+Number(btc)   // 1
+btc.valueOf() // 1
+btc + 0       // 1
+btc.toString() // "Symbol(binance:BTCUSDT, id=1)"
+// btc works as a number wherever a symbol ID is expected
+```
+
+## Strategy
+
+A strategy is a plain JavaScript object with callback properties.
+
+```javascript
+const strategy = {
+    symbols: [btc],
+
+    onStart() {},
+    onStop() {},
+
+    onTrade(ctx, trade, emit) {
+        // ctx.position      — current position quantity
+        // ctx.symbolId      — symbol ID (int)
+        // ctx.lastTradePrice
+        // ctx.bestBid
+        // ctx.bestAsk
+        // ctx.midPrice
+
+        // trade.price
+        // trade.qty
+        // trade.isBuy       — boolean
+        // trade.side        — "buy" | "sell"
+        // trade.timestampNs — BigInt nanoseconds
+
+        if (ctx.position === 0) {
+            emit.marketBuy(0.01);
+        }
+    },
+
+    onBookUpdate(ctx, emit) {},
+};
+```
+
+### emit methods
+
+| Method | Description |
+|--------|-------------|
+| `emit.marketBuy(qty)` | Market buy |
+| `emit.marketSell(qty)` | Market sell |
+| `emit.limitBuy(price, qty)` | Limit buy |
+| `emit.limitSell(price, qty)` | Limit sell |
+| `emit.cancel(orderId)` | Cancel order |
+| `emit.closePosition()` | Close position (reduce-only) |
+
+## Runner
+
+```javascript
+function onSignal(sig) {
+    // sig.side       — "buy" | "sell"
+    // sig.quantity
+    // sig.price      — 0 for market orders
+    // sig.orderType  — "market" | "limit" | ...
+    // sig.orderId
+}
+
+const runner = new flox.Runner(registry, onSignal);        // synchronous
+const runner = new flox.Runner(registry, onSignal, true);  // Disruptor background thread
+
+runner.addStrategy(strategy);
+runner.start();
+
+// Inject market data from your feed:
+runner.onTrade(btc, price, qty, isBuy, tsNs);
+runner.onBookSnapshot(btc, bidPrices, bidQtys, askPrices, askQtys, tsNs);
+
+runner.stop();
+```
+
+`btc` in feed methods accepts a `Symbol` object or a raw number.
+
+## BacktestRunner
+
+```javascript
+const bt = new flox.BacktestRunner(registry, 0.0004, 10_000);
+bt.setStrategy(strategy);
+
+const stats = bt.runCsv('/path/to/data.csv', 'BTCUSDT');
+```
+
+### Stats object
+
+| Key | Description |
+|-----|-------------|
+| `returnPct` | Net return percentage |
+| `netPnl` | Net P&L after fees |
+| `totalTrades` | Round-trip trade count |
+| `winRate` | Winning trade fraction |
+| `sharpeRatio` | Annualized Sharpe ratio |
+| `maxDrawdownPct` | Peak-to-trough drawdown (%) |
+
+## Full Example — SMA Crossover
+
+```javascript
+const flox = require('@flox-foundation/flox');
+
+const registry = new flox.SymbolRegistry();
+const btc = registry.addSymbol('binance', 'BTCUSDT', 0.01);
+
+// Simple SMA helper
+function makeSMA(period) {
+    const buf = [];
+    return {
+        update(price) {
+            buf.push(price);
+            if (buf.length > period) buf.shift();
+            if (buf.length < period) return null;
+            return buf.reduce((a, b) => a + b, 0) / period;
+        },
+    };
+}
+
+const fast = makeSMA(10);
+const slow = makeSMA(30);
+
+const strategy = {
+    symbols: [btc],
+
+    onTrade(ctx, trade, emit) {
+        const f = fast.update(trade.price);
+        const s = slow.update(trade.price);
+        if (f === null || s === null) return;
+
+        if (f > s && ctx.position === 0) {
+            emit.marketBuy(0.01);
+        } else if (f < s && ctx.position > 0) {
+            emit.closePosition();
+        }
+    },
+};
+
+// --- Live ---
+function onSignal(sig) {
+    console.log(sig.side, sig.orderType, sig.quantity);
+    // forward to exchange
+}
+
+const runner = new flox.Runner(registry, onSignal);
+runner.addStrategy(strategy);
+runner.start();
+// runner.onTrade(btc, price, qty, isBuy, tsNs)  ← from your market data feed
+// runner.stop()
+
+// --- Backtest ---
+const bt = new flox.BacktestRunner(registry, 0.0004, 10_000);
+bt.setStrategy(strategy);
+const stats = bt.runCsv('./data/btcusdt_trades.csv', 'BTCUSDT');
+console.log(stats);
+```
+
+------------------------------------------------------------------------------
+# Source: docs/bindings/codon.md
+# URL: https://flox-foundation.github.io/flox/bindings/codon/
+------------------------------------------------------------------------------
+
+# Codon Bindings
+
+Codon is an ahead-of-time compiled Python-like language that produces native code.
+Flox provides Codon bindings via the C API, so strategies compile to binaries with no interpreter overhead.
+
+## Prerequisites
+
+- [Codon compiler](https://github.com/exaloop/codon) installed
+- Flox built with `-DFLOX_ENABLE_CAPI=ON`
+
+## Build
+
+```bash
+cmake -B build \
+  -DFLOX_ENABLE_BACKTEST=ON \
+  -DFLOX_ENABLE_CAPI=ON \
+  -DFLOX_ENABLE_CODON=ON \
+  -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build
+```
+
+Produces `build/src/capi/libflox_capi.so` and the example binaries in `build/codon/`.
+
+Compile a strategy:
+
+```bash
+codon build -exe \
+  -o my_strategy \
+  -L build/src/capi \
+  -lflox_capi \
+  my_strategy.codon
+```
+
+## Symbols
+
+```python
+from flox.runner import Runner, flox_registry_create, flox_registry_add_symbol
+
+reg = flox_registry_create()
+btc = flox_registry_add_symbol(reg, "binance".c_str(), "BTCUSDT".c_str(), 0.01)
+# btc is a u32 symbol ID — pass it anywhere a symbol is expected
+```
+
+## Writing a Strategy
+
+Subclass `Strategy` and override `on_trade`. Order methods default to the primary symbol.
+
+```python
+from flox.strategy import Strategy
+from flox.context import SymbolContext
+from flox.types import TradeData
+from flox.indicators import StreamingSMA
+
+class SMAcross(Strategy):
+    fast: StreamingSMA
+    slow: StreamingSMA
+
+    def __init__(self, symbols: List[int]):
+        super().__init__(symbols)
+        self.fast = StreamingSMA(10)
+        self.slow = StreamingSMA(30)
+
+    def on_start(self):
+        print("started")
+
+    def on_stop(self):
+        print("stopped")
+
+    def on_trade(self, ctx: SymbolContext, trade: TradeData):
+        f = self.fast.update(trade.price.to_double())
+        s = self.slow.update(trade.price.to_double())
+        if not self.slow.ready:
+            return
+        if f > s and self.position() == 0.0:
+            self.market_buy(0.01)
+        elif f < s and self.position() > 0.0:
+            self.close_position()
+```
+
+### Order methods
+
+| Method | Description |
+|--------|-------------|
+| `market_buy(qty)` | Market buy (primary symbol) |
+| `market_sell(qty)` | Market sell |
+| `limit_buy(price, qty)` | Limit buy (GTC) |
+| `limit_sell(price, qty)` | Limit sell (GTC) |
+| `stop_market(side, trigger, qty)` | Stop market. `side`: `"buy"` / `"sell"` |
+| `take_profit_market(side, trigger, qty)` | Take-profit market |
+| `trailing_stop(side, offset, qty)` | Trailing stop by offset |
+| `close_position()` | Reduce-only close |
+| `cancel_order(order_id)` | Cancel by ID |
+| `cancel_all_orders()` | Cancel all |
+
+All methods accept an optional `symbol` kwarg to target a specific symbol by name.
+
+### Context queries
+
+| Method | Description |
+|--------|-------------|
+| `position()` | Current position (float) |
+| `last_price()` | Last trade price |
+| `best_bid()` | Best bid |
+| `best_ask()` | Best ask |
+| `mid_price()` | Mid price |
+
+## Runner (live)
+
+```python
+from flox.runner import Runner
+
+def on_signal(sig):
+    # sig.side: "buy" | "sell"
+    # sig.order_type: "market" | "limit" | ...
+    # sig.quantity, sig.price
+    print(sig.side, sig.quantity, "@", sig.price)
+
+runner = Runner(reg, on_signal)           # synchronous
+# runner = Runner(reg, on_signal, True)   # Disruptor background thread
+
+runner.add_strategy(SMAcross([int(btc)]))
+runner.start()
+
+# Feed market data:
+runner.on_trade(int(btc), price, qty, True, ts_ns)
+runner.on_book_snapshot(int(btc), bid_prices, bid_qtys, ask_prices, ask_qtys, ts_ns)
+
+runner.stop()
+```
+
+## BacktestRunner
+
+```python
+from flox.runner import BacktestRunner
+
+bt = BacktestRunner(reg, fee_rate=0.0004, initial_capital=10_000.0)
+bt.set_strategy(SMAcross([int(btc)]))
+
+stats = bt.run_csv("/path/to/btcusdt_trades.csv", "BTCUSDT")
+print(stats.return_pct, stats.sharpe, stats.max_drawdown_pct)
+```
+
+Or pass raw arrays:
+
+```python
+stats = bt.run_ohlcv(timestamps_ns, closes, "BTCUSDT")
+```
+
+### BacktestStats fields
+
+| Field | Description |
+|-------|-------------|
+| `return_pct` | Net return percentage |
+| `net_pnl` | Net P&L after fees |
+| `total_trades` | Round-trip trade count |
+| `win_rate` | Winning trade fraction |
+| `sharpe` | Annualized Sharpe ratio |
+| `sortino` | Annualized Sortino ratio |
+| `calmar` | Calmar ratio |
+| `max_drawdown_pct` | Peak-to-trough drawdown (%) |
+| `profit_factor` | Gross profit / gross loss |
+| `final_capital` | Capital at end of backtest |
+
+## Indicators
+
+Streaming indicators with zero FFI overhead (pure Codon):
+
+```python
+from flox.indicators import StreamingSMA, StreamingEMA
+
+sma = StreamingSMA(20)
+val = sma.update(price)   # returns float; sma.ready is True once primed
+
+ema = StreamingEMA(12)
+val = ema.update(price)
+```
+
+Batch indicators via C API (`ema`, `sma`, `rsi`, `atr`, `macd`, `bollinger`) — see [Codon Indicators](../reference/codon/indicators.md).
+
+## Full Example
+
+```python
+from flox.runner import Runner, BacktestRunner, flox_registry_create, flox_registry_add_symbol
+from flox.strategy import Strategy
+from flox.context import SymbolContext
+from flox.types import TradeData
+from flox.indicators import StreamingSMA
+
+class SMAcross(Strategy):
+    fast: StreamingSMA
+    slow: StreamingSMA
+
+    def __init__(self, symbols: List[int]):
+        super().__init__(symbols)
+        self.fast = StreamingSMA(10)
+        self.slow = StreamingSMA(30)
+
+    def on_trade(self, ctx: SymbolContext, trade: TradeData):
+        f = self.fast.update(trade.price.to_double())
+        s = self.slow.update(trade.price.to_double())
+        if not self.slow.ready:
+            return
+        if f > s and self.position() == 0.0:
+            self.market_buy(0.01)
+        elif f < s and self.position() > 0.0:
+            self.close_position()
+
+def on_signal(sig):
+    print(f"signal  {sig.side}  qty={sig.quantity:.4f}  [{sig.order_type}]")
+
+def main():
+    reg = flox_registry_create()
+    btc = flox_registry_add_symbol(reg, "binance".c_str(), "BTCUSDT".c_str(), 0.01)
+    btc_id = int(btc)
+
+    # --- Backtest ---
+    bt = BacktestRunner(reg, fee_rate=0.0004, initial_capital=10_000.0)
+    bt.set_strategy(SMAcross([btc_id]))
+    stats = bt.run_csv("btcusdt_trades.csv", "BTCUSDT")
+    print(f"Return: {stats.return_pct:.2f}%  Sharpe: {stats.sharpe:.3f}")
+
+    # --- Live ---
+    runner = Runner(reg, on_signal)
+    runner.add_strategy(SMAcross([btc_id]))
+    runner.start()
+    # runner.on_trade(btc_id, 67000.0, 0.01, True, 0)
+    runner.stop()
+
+main()
+```
+
+------------------------------------------------------------------------------
+# Source: docs/bindings/javascript.md
+# URL: https://flox-foundation.github.io/flox/bindings/javascript/
+------------------------------------------------------------------------------
+
+# JavaScript Bindings (QuickJS)
+
+Flox embeds [QuickJS](https://bellard.org/quickjs/) to run trading strategies written in JavaScript.
+Strategies use string symbol names, options objects for orders, and get TypeScript declarations for IDE autocompletion.
+
+## Building
+
+```bash
+cmake -B build \
+  -DFLOX_ENABLE_CAPI=ON \
+  -DFLOX_ENABLE_QUICKJS=ON \
+  -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build
+```
+
+This produces:
+
+- `build/src/quickjs/flox_js_runner` -- CLI to load and run JS strategies
+- `build/src/quickjs/libflox_quickjs.a` -- static library for embedding
+
+## Writing a Strategy
+
+Create a `.js` file. Extend the `Strategy` base class, override `onTrade`, and call `flox.register`:
+
+```javascript
+class MyStrategy extends Strategy {
+    constructor() {
+        super({ exchange: "Binance", symbols: ["BTCUSDT"] });
+    }
+
+    onTrade(ctx, trade) {
+        // ctx.symbol === "BTCUSDT"
+        // trade.price, trade.qty, trade.side ("buy"/"sell")
+        if (trade.price > 50000) {
+            this.marketBuy({ qty: 0.1 });
+        }
+    }
+
+    onStart() { console.log("Started on", this.primarySymbol); }
+    onStop()  { console.log("Stopped"); }
+}
+
+flox.register(new MyStrategy());
+```
+
+Run it:
+
+```bash
+./build/src/quickjs/flox_js_runner my_strategy.js
+```
+
+## Symbol Configuration
+
+Specify exchange and symbols in the constructor:
+
+```javascript
+// Single exchange (most common):
+super({ exchange: "Binance", symbols: ["BTCUSDT", "ETHUSDT"] })
+
+// Multi-exchange (qualified format):
+super({ symbols: ["Binance:BTCUSDT", "Bybit:ETHUSDT"] })
+```
+
+Methods default to the primary symbol (first in the list) when symbol is omitted.
+
+## Order Methods
+
+Order methods accept an options object. Symbol defaults to primary when omitted.
+
+```javascript
+// Market
+this.marketBuy({ qty: 1.0 })
+this.marketSell({ symbol: "ETHUSDT", qty: 2.0 })
+
+// Limit (tif defaults to "GTC")
+this.limitBuy({ price: 50000, qty: 0.1 })
+this.limitSell({ price: 51000, qty: 0.1, tif: "IOC" })
+
+// Stop
+this.stopMarket({ side: "sell", trigger: 48000, qty: 0.1 })
+this.stopLimit({ side: "buy", trigger: 52000, price: 52100, qty: 0.1 })
+
+// Take profit
+this.takeProfitMarket({ side: "sell", trigger: 55000, qty: 0.1 })
+this.takeProfitLimit({ side: "sell", trigger: 55000, price: 54900, qty: 0.1 })
+
+// Trailing stop
+this.trailingStop({ side: "sell", offset: 100, qty: 0.1 })
+this.trailingStopPercent({ side: "sell", callbackBps: 50, qty: 0.1 })
+
+// Order management
+this.cancel(orderId)
+this.cancelAll()
+this.modify(orderId, { price: 50100, qty: 0.2 })
+this.closePosition()
+```
+
+## Context Queries
+
+```javascript
+this.position()             // current position (primary symbol)
+this.position("ETHUSDT")    // specific symbol
+this.bestBid()
+this.bestAsk()
+this.midPrice()
+this.lastPrice()
+this.orderStatus(orderId)
+this.hasPosition             // boolean
+this.primarySymbol           // "BTCUSDT"
+this.symbols                 // ["BTCUSDT", "ETHUSDT"]
+```
+
+## Callback Data
+
+`onTrade(ctx, trade)` receives:
+
+```javascript
+ctx.symbol        // "BTCUSDT" (string)
+ctx.symbolId      // 1 (numeric, for advanced use)
+ctx.position      // current position size
+ctx.avgEntryPrice // average entry price
+ctx.book.bidPrice // best bid
+ctx.book.askPrice // best ask
+
+trade.symbol      // "BTCUSDT"
+trade.price       // 50123.45
+trade.qty         // 1.5
+trade.side        // "buy" or "sell"
+trade.isBuy       // true/false
+trade.timestampNs // nanosecond timestamp
+```
+
+## Indicators
+
+Each indicator supports `.update()` for per-tick and `static compute()` for batch:
+
+| Single-value input | OHLC input | Volume input |
+|---|---|---|
+| SMA, EMA, RMA, DEMA, TEMA, KAMA, RSI, Slope | ATR, ADX, Stochastic, CCI, CHOP | OBV, VWAP, CVD |
+| MACD, Bollinger | | |
+
+```javascript
+// Per-tick
+var atr = new ATR(14);
+atr.update(high, low, close);
+
+var macd = new MACD(12, 26, 9);
+macd.update(price);
+console.log(macd.line, macd.signal, macd.histogram);
+
+// Batch
+var adxResult = ADX.compute(highArr, lowArr, closeArr, 14);
+// adxResult.adx, adxResult.plusDi, adxResult.minusDi
+```
+
+## Order Book
+
+```javascript
+var book = new OrderBook(0.01);  // tick size
+book.applySnapshot([50000, 49999], [1.5, 2.0], [50001, 50002], [0.5, 1.0]);
+book.bestBid();   // 50000
+book.bestAsk();   // 50001
+book.mid();       // 50000.5
+book.spread();    // 1.0
+book.getBids(5);  // [[50000, 1.5], [49999, 2.0]]
+book.getAsks(5);  // [[50001, 0.5], [50002, 1.0]]
+
+// L3 (order-level)
+var l3 = new L3Book();
+l3.addOrder(1, 50000, 1.5, "buy");
+l3.addOrder(2, 50001, 0.5, "sell");
+l3.bestBid();  // 50000
+l3.removeOrder(1);
+```
+
+## Backtesting
+
+```javascript
+var executor = new SimulatedExecutor();
+executor.submitOrder(1, "buy", 50000, 1.0, 0, 1);  // id, side, price, qty, type, symbol
+executor.onBar(1, 50100);   // symbol, close price
+executor.advanceClock(ts);
+executor.fillCount;         // number of fills
+```
+
+## Position Tracking
+
+```javascript
+var tracker = new PositionTracker();
+tracker.onFill(1, "buy", 50000, 1.0);
+tracker.onFill(1, "sell", 50100, 1.0);
+tracker.position(1);          // 0
+tracker.realizedPnl(1);       // 100
+tracker.totalRealizedPnl();   // 100
+
+// Group tracking
+var groups = new PositionGroupTracker();
+var pid = groups.openPosition(1, 1, "buy", 50000, 1.0);
+groups.closePosition(pid, 50500);
+groups.totalRealizedPnl();  // 500
+```
+
+## Profiling
+
+```javascript
+// Volume Profile
+var vp = new VolumeProfile(0.01);
+vp.addTrade(50000, 1.0, true);
+vp.poc();            // point of control
+vp.valueAreaHigh();
+vp.valueAreaLow();
+
+// Market Profile
+var mp = new MarketProfile(0.01, 30, 0);
+mp.addTrade(Date.now() * 1e6, 50000, 1.0, true);
+mp.poc();
+mp.initialBalanceHigh();
+mp.isPoorHigh();
+
+// Footprint
+var fp = new FootprintBar(0.01);
+fp.addTrade(50000, 1.0, true);
+fp.totalDelta();
+fp.totalVolume();
+```
+
+## Statistics
+
+```javascript
+flox.correlation([1,2,3], [1,2,3]);      // 1.0
+flox.profitFactor([100, -50, 200, -30]);  // gross_profit / gross_loss
+flox.winRate([100, -50, 200, -30]);       // 0.5
+
+flox.bootstrapCI([1,2,3,4,5], 0.95, 10000);
+// { lower: ..., median: ..., upper: ... }
+
+flox.permutationTest([1,2,3], [4,5,6], 10000);  // p-value
+```
+
+## Segment Operations
+
+```javascript
+flox.validateSegment("/path/to/segment.flx");
+flox.mergeSegments("/path/to/input_dir", "/path/to/output_dir");
+```
+
+## IDE Support
+
+Copy `quickjs/types/flox.d.ts` and `quickjs/jsconfig.json` into your project directory for VS Code autocompletion.
+
+## Error Handling
+
+JS exceptions in callbacks are caught, logged to stderr, and the strategy continues.
+Invalid symbol names or side values throw immediately with descriptive errors.
+
+## Memory Limit
+
+The JS runtime defaults to 32MB per strategy. When embedding via C++, pass a custom limit to the `FloxJsEngine` constructor:
+
+```cpp
+FloxJsEngine engine(64 * 1024 * 1024);  // 64MB
+FloxJsEngine engine(0);                  // unlimited
+```
+
+## Limitations
+
+- QuickJS is an interpreter — suitable for prototyping and backtesting, latency-sensitive production should use Codon or C++
+- Uses global eval, ES modules are planned for a future release
+
+------------------------------------------------------------------------------
+# Source: docs/bindings/capi.md
+# URL: https://flox-foundation.github.io/flox/bindings/capi/
+------------------------------------------------------------------------------
+
+# C API
+
+`flox_capi.h` is a C interface to the Flox engine. All existing bindings (Python, Node.js, Codon, embedded JS) use it. If you're adding support for a new language or embedding Flox in a C project, start here.
+
+## Build
+
+```bash
+cmake -B build \
+  -DFLOX_ENABLE_CAPI=ON \
+  -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build
+```
+
+Produces `build/src/capi/libflox_capi.so`.
+
+## Header
+
+```c
+#include "flox/capi/flox_capi.h"
+```
+
+## Minimal example
+
+```c
+#include "flox/capi/flox_capi.h"
+#include <stdio.h>
+
+static void on_trade(FloxStrategyHandle strat, FloxSymbolContext* ctx,
+                     FloxTradeData* trade, void* user_data) {
+    double price = flox_price_to_double(trade->price_raw);
+    printf("trade: %.2f\n", price);
+}
+
+static void on_signal(const FloxSignal* sig, void* user_data) {
+    printf("signal: %s qty=%.4f\n",
+           sig->side == 0 ? "buy" : "sell",
+           sig->quantity);
+}
+
+int main(void) {
+    FloxRegistryHandle reg = flox_registry_create();
+    uint32_t btc = flox_registry_add_symbol(reg, "binance", "BTCUSDT", 0.01);
+
+    FloxStrategyCallbacks cbs = {0};
+    cbs.on_trade = on_trade;
+
+    FloxStrategyHandle strat = flox_strategy_create(0, &btc, 1, &cbs, NULL);
+
+    FloxRunnerHandle runner = flox_runner_create(reg, on_signal, NULL);
+    flox_runner_add_strategy(runner, strat);
+    flox_runner_start(runner);
+
+    // inject a tick
+    flox_runner_on_trade(runner, btc, 67000.0, 0.01, 1, 0);
+
+    flox_runner_stop(runner);
+    flox_runner_destroy(runner);
+    flox_strategy_destroy(strat);
+    flox_registry_destroy(reg);
+    return 0;
+}
+```
+
+Compile:
+
+```bash
+gcc -o example example.c \
+  -I/path/to/flox/include \
+  -L/path/to/build/src/capi \
+  -lflox_capi \
+  -Wl,-rpath,/path/to/build/src/capi
+```
+
+## Full API reference
+
+See [C API Reference](../reference/api/capi/flox_capi.md) for all functions, structs, and callback signatures.
+
+==============================================================================
+# Section: Quickstart tutorials
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/tutorials/README.md
+# URL: https://flox-foundation.github.io/flox/tutorials/
+------------------------------------------------------------------------------
+
+# Tutorials
+
+Step-by-step lessons to get you productive with FLOX.
+
+## Pick your language
+
+Each language has its own quickstart. After that the tutorials are language-agnostic and use code tabs so you can pick what you read.
+
+| Quickstart | Audience |
+|------------|----------|
+| [Python quickstart](python-quickstart.md) | Quants and researchers — backtest in pandas-friendly Python |
+| [Node.js quickstart](node-quickstart.md) | JavaScript / TypeScript stacks — same API as Python |
+| [Codon quickstart](codon-strategy.md) | Python syntax compiled to native code |
+| [C++ quickstart](quickstart.md) | Direct access to the engine — lowest latency |
+
+## Core path
+
+After your language quickstart, work through these. They cover the same concepts; each page has tabs for Python / Node.js / C++ / Codon (where applicable).
+
+| Tutorial | What You'll Learn |
+|----------|-------------------|
+| [First Strategy](first-strategy.md) | Write a simple trading strategy |
+| [Multi-Timeframe Strategy](multi-timeframe-strategy.md) | Build strategies using multiple bar timeframes |
+| [Recording Data](recording-data.md) | Capture live market data to disk |
+| [Backtesting](backtesting.md) | Replay recorded data through your strategy |
+| [Run Demo](demo.md) | End-to-end demo runner |
+
+## Recommended order
+
+1. **Quickstart** for your language — verify your environment works
+2. **First Strategy** — understand the core programming model
+3. **Multi-Timeframe Strategy** — work with multiple bar timeframes
+4. **Recording Data** — set up market data capture
+5. **Backtesting** — test strategies against historical data
+
+After completing these tutorials, move on to [How-To Guides](../how-to/README.md) for specific tasks or [Explanation](../explanation/README.md) for deeper understanding.
+
+## Requirements per language
+
+=== "Python"
+    - Python 3.10+
+    - `pip install flox-py` or build from source
+
+=== "Node.js"
+    - Node.js 18+
+    - `npm install @flox-foundation/flox` or build from source
+
+=== "Codon"
+    - Codon compiler installed
+    - Flox built with `-DFLOX_ENABLE_CAPI=ON`
+
+=== "C++"
+    - C++20 compiler (GCC 13+ or Clang 16+)
+    - CMake 3.22+
+    - Linux (recommended) or macOS
+
+See the [Bindings](../bindings/README.md) page for full per-language build details.
+
+------------------------------------------------------------------------------
+# Source: docs/tutorials/python-quickstart.md
+# URL: https://flox-foundation.github.io/flox/tutorials/python-quickstart/
+------------------------------------------------------------------------------
+
+# Python quickstart
+
+## Requirements
+
+- Python 3.10+
+
+## 1. Install
+
+```bash
+pip install flox-py
+```
+
+## 2. First indicator
+
+```python
+import flox_py as flox
+
+ema = flox.EMA(20)
+
+prices = [100 + i * 0.1 for i in range(50)]
+for price in prices:
+    value = ema.update(price)
+    if value is not None:
+        print(f"EMA(20): {value:.4f}")
+```
+
+All streaming indicators return `None` during warmup and a float once ready. Check `.ready` to test without calling update.
+
+## 3. First strategy
+
+```python
+import flox_py as flox
+
+registry = flox.SymbolRegistry()
+btc = registry.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+
+class SMACross(flox.Strategy):
+    def __init__(self, symbols):
+        super().__init__(symbols)
+        self.fast = flox.SMA(10)
+        self.slow = flox.SMA(30)
+
+    def on_trade(self, ctx, trade):
+        f = self.fast.update(trade.price)
+        s = self.slow.update(trade.price)
+        if f is None or s is None:
+            return
+        if f > s and ctx.is_flat():
+            self.market_buy(0.01)
+        elif f < s and ctx.is_long():
+            self.close_position()
+
+def on_signal(sig):
+    print(sig.side, sig.order_type, sig.quantity)
+
+runner = flox.Runner(registry, on_signal)
+runner.add_strategy(SMACross([btc]))
+runner.start()
+
+# Feed market data from your source:
+# runner.on_trade(btc, price, qty, is_buy, ts_ns)
+
+runner.stop()
+```
+
+## 4. Backtest
+
+```python
+bt = flox.BacktestRunner(registry, fee_rate=0.0004, initial_capital=10_000)
+bt.set_strategy(SMACross([btc]))
+
+stats = bt.run_csv("btcusdt_trades.csv")
+print(stats["return_pct"], stats["sharpe"], stats["max_drawdown_pct"])
+```
+
+The CSV format is `timestamp,price,qty,is_buy` — one trade per row.
+
+---
+
+## Building from source
+
+Use this if you need the current `main` branch before a release is published.
+
+### Requirements
+
+- GCC 14+ or Clang 18+
+- CMake 3.22+
+- Python 3.10+
+
+```bash
+git clone https://github.com/FLOX-Foundation/flox.git
+cd flox
+pip install scikit-build-core pybind11 numpy
+pip install ./python
+```
+
+That's it — `scikit-build-core` handles the cmake build internally. The module installs into your environment the same way as the PyPI package.
+
+---
+
+## Next steps
+
+- [Indicators reference](../reference/python/indicators.md) — full indicator API
+- [Python bindings guide](../bindings/python.md) — batch backtest engine, grid search, live runner
+- [Backtesting how-to](../how-to/backtest.md)
+
+------------------------------------------------------------------------------
+# Source: docs/tutorials/node-quickstart.md
+# URL: https://flox-foundation.github.io/flox/tutorials/node-quickstart/
+------------------------------------------------------------------------------
+
+# Node.js quickstart
+
+## Requirements
+
+- Node.js 20+
+
+## 1. Install
+
+```bash
+npm install @flox-foundation/flox
+```
+
+## 2. First indicator
+
+```javascript
+const flox = require('@flox-foundation/flox');
+
+const ema = new flox.EMA(20);
+
+const prices = Array.from({ length: 50 }, (_, i) => 100 + i * 0.1);
+for (const price of prices) {
+    const value = ema.update(price);
+    if (value !== null) {
+        console.log(`EMA(20): ${value.toFixed(4)}`);
+    }
+}
+```
+
+All streaming indicators return `null` during warmup and the current value once ready. Use `.ready` to check without calling update.
+
+## 3. First strategy
+
+```javascript
+const flox = require('@flox-foundation/flox');
+
+const registry = new flox.SymbolRegistry();
+const btc = registry.addSymbol('binance', 'BTCUSDT', 0.01);
+
+const fast = new flox.SMA(10);
+const slow = new flox.SMA(30);
+
+const strategy = {
+    symbols: [btc],
+
+    onTrade(ctx, trade, emit) {
+        const f = fast.update(trade.price);
+        const s = slow.update(trade.price);
+        if (f === null || s === null) return;
+
+        if (f > s && ctx.position === 0) {
+            emit.marketBuy(0.01);
+        } else if (f < s && ctx.position > 0) {
+            emit.closePosition();
+        }
+    },
+};
+
+function onSignal(sig) {
+    console.log(sig.side, sig.orderType, sig.quantity);
+}
+
+const runner = new flox.Runner(registry, onSignal);
+runner.addStrategy(strategy);
+runner.start();
+
+// Feed market data from your source:
+// runner.onTrade(btc, price, qty, isBuy, tsNs)
+
+runner.stop();
+```
+
+## 4. Backtest
+
+```javascript
+const bt = new flox.BacktestRunner(registry, 0.0004, 10_000);
+bt.setStrategy(strategy);
+
+const stats = bt.runCsv('./data/btcusdt_trades.csv', 'BTCUSDT');
+console.log(stats.returnPct, stats.sharpeRatio, stats.maxDrawdownPct);
+```
+
+---
+
+## Building from source
+
+Use this if you need the current `main` branch before a release is published.
+
+### Requirements
+
+- GCC 14+ or Clang 18+
+- CMake 3.22+
+- Node.js 20+
+
+```bash
+git clone https://github.com/FLOX-Foundation/flox.git
+cd flox
+
+cmake -B build \
+  -DFLOX_ENABLE_CAPI=ON \
+  -DFLOX_ENABLE_BACKTEST=ON \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+
+cd node && npm install && npm run build
+```
+
+Then require the local build instead of the npm package:
+
+```javascript
+const flox = require('./node/build/Release/flox_node');
+```
+
+---
+
+## Next steps
+
+- [Indicators reference](../reference/node/indicators.md) — full indicator API
+- [Node.js bindings guide](../bindings/node.md) — runner, backtest runner, order types
+
+------------------------------------------------------------------------------
+# Source: docs/tutorials/codon-strategy.md
+# URL: https://flox-foundation.github.io/flox/tutorials/codon-strategy/
+------------------------------------------------------------------------------
+
+# Writing Your First Codon Strategy
+
+This tutorial walks through creating an SMA crossover strategy in Codon.
+The strategy buys when a fast SMA crosses above a slow SMA, and sells on the
+reverse crossover.
+
+## Prerequisites
+
+1. Flox built with C API enabled
+2. Codon compiler installed
+
+```bash
+cmake -B build -DFLOX_ENABLE_CAPI=ON -DFLOX_ENABLE_BACKTEST=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+## Step 1: Create the Strategy File
+
+Create `my_sma_strategy.codon`:
+
+```python
+from flox.strategy import Strategy
+from flox.context import SymbolContext
+from flox.types import TradeData
+from flox.indicators import StreamingSMA
+
+
+class SmaCrossover(Strategy):
+    fast_sma: StreamingSMA
+    slow_sma: StreamingSMA
+    order_size: float
+    long_position: bool
+
+    def __init__(self, symbols: List[int], fast: int = 10, slow: int = 30):
+        super().__init__(symbols)
+        self.fast_sma = StreamingSMA(fast)
+        self.slow_sma = StreamingSMA(slow)
+        self.order_size = 1.0
+        self.long_position = False
+
+    def on_trade(self, ctx: SymbolContext, trade: TradeData):
+        price = trade.price.to_double()
+        fast = self.fast_sma.update(price)
+        slow = self.slow_sma.update(price)
+
+        # Wait until both SMAs have enough data
+        if not self.slow_sma.ready:
+            return
+
+        sym = self.primary_symbol
+
+        # Golden cross: fast crosses above slow
+        if fast > slow and not self.long_position:
+            self.emit_market_buy(sym, self.order_size)
+            self.long_position = True
+
+        # Death cross: fast crosses below slow
+        elif fast < slow and self.long_position:
+            self.emit_market_sell(sym, self.order_size)
+            self.long_position = False
+
+    def on_start(self):
+        print("Strategy started!")
+
+    def on_stop(self):
+        pos = self.position()
+        print(f"Strategy stopped. Final position: {pos}")
+```
+
+## Step 2: Compile to Native Binary
+
+```bash
+codon build -exe \
+  -o my_sma_strategy \
+  -L build/src/capi \
+  -lflox_capi \
+  my_sma_strategy.codon
+```
+
+## Step 3: Understanding the Code
+
+### Imports
+
+- `Strategy` -- base class providing emit/query methods
+- `SymbolContext` -- per-symbol state (position, book, prices)
+- `TradeData` -- trade event with price, quantity, side
+- `StreamingSMA` -- O(1) streaming SMA (pure Codon, no FFI)
+
+### Key Patterns
+
+1. **Override `on_trade`** to receive trade events
+2. **Use streaming indicators** for per-tick computation
+3. **Call `emit_*` methods** to submit orders
+4. **Query `position()`** to check current state
+
+### Performance
+
+Because Codon compiles to native code:
+- `on_trade` is compiled to a native function, not interpreted
+- `StreamingSMA.update()` is a native function call
+- No GIL, no interpreter, no garbage collector pauses
+
+## Step 4: Compare with C++ and Python
+
+The same strategy in C++:
+
+```cpp
+void onSymbolTrade(SymbolContext& c, const TradeEvent& ev) override {
+    prices_.push_back(ev.trade.price.toDouble());
+    // ... SMA logic ...
+    if (fast_above && !long_position_)
+        emitMarketBuy(symbol(), orderSize_);
+}
+```
+
+And in Python:
+
+```python
+def on_trade(self, ctx, trade):
+    self.prices.append(trade.price)
+    # ... SMA logic ...
+    if fast > slow and not self.long_position:
+        self.emit_market_buy(ctx.symbol_id, 1.0)
+```
+
+All three produce identical trading behavior with the same API shape.
+
+## Next Steps
+
+
+- See [Indicators Reference](../reference/codon/indicators.md) for all available indicators
+- See [Strategy Classes](../how-to/strategy-classes.md) for the full API reference
+
+------------------------------------------------------------------------------
+# Source: docs/tutorials/quickstart.md
+# URL: https://flox-foundation.github.io/flox/tutorials/quickstart/
+------------------------------------------------------------------------------
+
+# Quickstart
+
+Build FLOX and run the demo application in 5 minutes.
+
+## 1. Clone and Build
+
+```bash
+git clone https://github.com/FLOX-Foundation/flox.git
+cd flox
+
+mkdir build && cd build
+cmake .. -DFLOX_ENABLE_DEMO=ON
+make -j$(nproc)
+```
+
+## 2. Run the Demo
+
+```bash
+./demo/flox_demo
+```
+
+The demo runs for 30 seconds, then prints latency statistics:
+
+```
+[demo] price spike starting
+[demo] price spike starting
+demo finished
+=== Latency Report ===
+BusPublish:       p50=123ns  p99=456ns  max=1.2µs
+StrategyOnTrade:  p50=89ns   p99=234ns  max=890ns
+```
+
+## 3. What the Demo Does
+
+The demo creates a complete trading system:
+
+```mermaid
+flowchart LR
+    subgraph Connector
+        DC[DemoConnector<br/>generates fake data]
+    end
+
+    subgraph Bus["Event Bus"]
+        TB[TradeBus]
+        BB[BookBus]
+    end
+
+    subgraph Strategy
+        DS[DemoStrategy<br/>reacts to trades]
+    end
+
+    subgraph Execution
+        EB[ExecutionBus]
+    end
+
+    DC --> TB
+    DC --> BB
+    TB --> DS
+    BB --> DS
+    DS --> EB
+```
+
+1. **DemoConnector** generates fake trades and order book updates
+2. Events flow through **TradeBus** and **BookUpdateBus** (Disruptor-style ring buffers)
+3. **DemoStrategy** receives events and submits orders
+4. Orders flow through **OrderExecutionBus** to an execution tracker
+
+## 4. Build Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `FLOX_ENABLE_DEMO` | OFF | Build the demo application |
+| `FLOX_ENABLE_TESTS` | OFF | Build unit tests |
+| `FLOX_ENABLE_BENCHMARKS` | OFF | Build performance benchmarks |
+| `FLOX_ENABLE_BACKTEST` | OFF | Build backtest module (simulated execution) |
+| `FLOX_ENABLE_LZ4` | OFF | Enable LZ4 compression for replay |
+| `FLOX_ENABLE_CPU_AFFINITY` | OFF | Enable CPU pinning (requires libnuma) |
+| `FLOX_ENABLE_TRACY` | OFF | Enable Tracy profiler integration |
+
+Example with multiple options:
+
+```bash
+cmake .. \
+  -DFLOX_ENABLE_DEMO=ON \
+  -DFLOX_ENABLE_TESTS=ON \
+  -DFLOX_ENABLE_LZ4=ON \
+  -DCMAKE_BUILD_TYPE=Release
+```
+
+## 5. Verify Installation
+
+Run the tests to verify everything works:
+
+```bash
+cmake .. -DFLOX_ENABLE_TESTS=ON
+make -j$(nproc)
+ctest --output-on-failure
+```
+
+## Next Steps
+
+- [First Strategy](first-strategy.md) — Write your own trading strategy
+- [Architecture Overview](../explanation/architecture.md) — Understand how components fit together
+
+------------------------------------------------------------------------------
+# Source: docs/tutorials/first-strategy.md
+# URL: https://flox-foundation.github.io/flox/tutorials/first-strategy/
+------------------------------------------------------------------------------
+
+# First Strategy
+
+Write a simple trading strategy that reacts to market data. After your [language quickstart](README.md) you should already have FLOX building. This tutorial introduces the callback model that every binding shares.
+
+## The model
+
+Every Strategy subclass gets four callbacks. You override the ones you need:
+
+| Callback | Fires when |
+|---|---|
+| `on_trade(ctx, trade)` | A trade tick arrives |
+| `on_book_update(ctx)` | Top-of-book moves (bid/ask change) |
+| `on_bar(ctx, bar)` | A closed OHLC bar is dispatched |
+| `on_start()` / `on_stop()` | Strategy lifecycle |
+
+Inside callbacks you query state via `ctx` and place orders with helpers like `market_buy(qty)` / `limit_sell(price, qty)`.
+
+## A printing strategy
+
+This strategy logs every trade and tracks the best bid / ask.
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+
+    class PrintingStrategy(flox.Strategy):
+        def __init__(self, symbols):
+            super().__init__(symbols)
+            self.trade_count = 0
+
+        def on_start(self):
+            print(f"PrintingStrategy started")
+
+        def on_stop(self):
+            print(f"PrintingStrategy stopped. Trades seen: {self.trade_count}")
+
+        def on_trade(self, ctx, trade):
+            self.trade_count += 1
+            side = "BUY" if trade.is_buy else "SELL"
+            print(f"Trade: {trade.price:.2f} x {trade.quantity:.4f} ({side})")
+
+        def on_book_update(self, ctx):
+            print(f"Book: {ctx.best_bid:.2f} / {ctx.best_ask:.2f}")
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    class PrintingStrategy {
+      constructor(symbols) {
+        this.symbols = symbols;
+        this.tradeCount = 0;
+      }
+      onStart() { console.log("PrintingStrategy started"); }
+      onStop()  { console.log(`PrintingStrategy stopped. Trades seen: ${this.tradeCount}`); }
+
+      onTrade(ctx, trade) {
+        this.tradeCount++;
+        const side = trade.isBuy ? "BUY" : "SELL";
+        console.log(`Trade: ${trade.price.toFixed(2)} x ${trade.qty.toFixed(4)} (${side})`);
+      }
+      onBookUpdate(ctx) {
+        console.log(`Book: ${ctx.bestBid.toFixed(2)} / ${ctx.bestAsk.toFixed(2)}`);
+      }
+    }
+    ```
+
+=== "Codon"
+
+    ```python
+    from flox.strategy import Strategy
+    from flox.context import SymbolContext
+    from flox.types import TradeData
+
+    class PrintingStrategy(Strategy):
+        trade_count: int = 0
+
+        def __init__(self, symbols: List[int]):
+            super().__init__(symbols)
+
+        def on_start(self):
+            print("PrintingStrategy started")
+
+        def on_trade(self, ctx: SymbolContext, trade: TradeData):
+            self.trade_count += 1
+            side = "BUY" if trade.is_buy else "SELL"
+            print(f"Trade: {trade.price.to_double():.2f} ({side})")
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/strategy/strategy.h"
+
+    using namespace flox;
+
+    class PrintingStrategy : public Strategy {
+    public:
+      PrintingStrategy(SymbolId symbol, const SymbolRegistry& reg)
+          : Strategy(/*id=*/1, symbol, reg) {}
+
+      void start() override { FLOX_LOG("PrintingStrategy started"); }
+      void stop()  override { FLOX_LOG("Trades seen: " << _tradeCount); }
+
+    protected:
+      void onSymbolTrade(SymbolContext& /*ctx*/, const TradeEvent& ev) override {
+        ++_tradeCount;
+        FLOX_LOG("Trade: " << ev.trade.price.toDouble()
+                 << " x " << ev.trade.quantity.toDouble()
+                 << " (" << (ev.trade.isBuy ? "BUY" : "SELL") << ")");
+      }
+
+      void onSymbolBook(SymbolContext& ctx, const BookUpdateEvent& /*ev*/) override {
+        FLOX_LOG("Book: " << ctx.book.bestBid()->toDouble()
+                 << " / " << ctx.book.bestAsk()->toDouble());
+      }
+
+    private:
+      uint64_t _tradeCount{0};
+    };
+    ```
+
+## A trading strategy
+
+Submit a buy after every 10th trade.
+
+=== "Python"
+
+    ```python
+    class TenthTradeBuyer(flox.Strategy):
+        def __init__(self, symbols):
+            super().__init__(symbols)
+            self.count = 0
+
+        def on_trade(self, ctx, trade):
+            self.count += 1
+            if self.count % 10 == 0:
+                self.limit_buy(price=trade.price - 0.01, qty=1.0)
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    class TenthTradeBuyer {
+      constructor(symbols) { this.symbols = symbols; this.count = 0; }
+      onTrade(ctx, trade, emit) {
+        this.count++;
+        if (this.count % 10 === 0) emit.limitBuy(trade.price - 0.01, 1.0);
+      }
+    }
+    ```
+
+=== "C++"
+
+    ```cpp
+    void onSymbolTrade(SymbolContext& /*ctx*/, const TradeEvent& ev) override {
+      if (++_tradeCount % 10 != 0) return;
+      auto px = Price::fromRaw(ev.trade.price.raw() - Price::fromDouble(0.01).raw());
+      emitLimitBuy(symbol(), px, Quantity::fromDouble(1.0));
+    }
+    ```
+
+## Wiring it up
+
+Each language has a small bit of boilerplate to register your symbols and run the strategy.
+
+=== "Python"
+
+    ```python
+    reg = flox.SymbolRegistry()
+    btc = reg.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+
+    strat = PrintingStrategy([btc])
+    bt = flox.BacktestRunner(reg, fee_rate=0.0004, initial_capital=10_000)
+    bt.set_strategy(strat)
+    bt.run_csv("data/btcusdt_1m.csv", "BTCUSDT")
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const reg = new flox.SymbolRegistry();
+    const btc = reg.addSymbol("binance", "BTCUSDT", 0.01);
+
+    const strat = new PrintingStrategy([btc]);
+    const bt = new flox.BacktestRunner(reg, 0.0004, 10_000);
+    bt.setStrategy(strat);
+    bt.runCsv("data/btcusdt_1m.csv", "BTCUSDT");
+    ```
+
+=== "C++"
+
+    ```cpp
+    auto tradeBus = std::make_unique<TradeBus>();
+    auto bookBus  = std::make_unique<BookUpdateBus>();
+
+    SymbolRegistry registry;
+    SymbolInfo info{ .exchange = "binance", .symbol = "BTCUSDT",
+                      .tickSize = Price::fromDouble(0.01) };
+    auto symId = registry.registerSymbol(info);
+
+    auto strat = std::make_unique<PrintingStrategy>(symId, registry);
+    tradeBus->subscribe(strat.get());
+    bookBus ->subscribe(strat.get());
+
+    std::vector<std::unique_ptr<ISubsystem>> subsystems;
+    subsystems.push_back(std::move(tradeBus));
+    subsystems.push_back(std::move(bookBus));
+    subsystems.push_back(std::move(strat));
+
+    EngineConfig config{};
+    Engine engine(config, std::move(subsystems), std::move(connectors));
+    engine.start();
+    ```
+
+## Best practices
+
+**Do**:
+
+- Keep callbacks fast and non-blocking
+- Filter or short-circuit on the first line if the event isn't relevant
+- Let `ctx.is_flat()` / `ctx.position` decide entries — don't track position state yourself
+- Use the strategy emit helpers (`market_buy(qty)`) — they wire fees, queue position, and reduce-only flags correctly
+
+**Don't**:
+
+- Block in callbacks (no I/O, no locks, no big allocations)
+- Hold references to event structs after the callback returns — they're recycled
+- Throw exceptions from callbacks
+
+## Next
+
+- [Multi-Timeframe Strategy](multi-timeframe-strategy.md) — work with multiple bar timeframes
+- [Recording Data](recording-data.md) — capture market data to disk
+- [Backtesting](backtesting.md) — replay recorded data
+- [Architecture overview](../explanation/architecture.md) — how events flow
+
+------------------------------------------------------------------------------
+# Source: docs/tutorials/multi-timeframe-strategy.md
+# URL: https://flox-foundation.github.io/flox/tutorials/multi-timeframe-strategy/
+------------------------------------------------------------------------------
+
+# Tutorial: Multi-Timeframe Strategy
+
+!!! info "C++ tutorial"
+    This walkthrough uses `BarMatrix<...>` and `MultiTimeframeAggregator<...>` — C++ template infrastructure that isn't yet exposed as a high-level Python/Node API. You can replicate the logic from those bindings by aggregating each timeframe yourself with `flox.aggregate_time_bars(...)` and indexing the result. The pattern below is the canonical C++ flow.
+
+This tutorial walks you through building a multi-timeframe momentum strategy from scratch. You'll learn how to:
+
+- Set up bar aggregation for multiple timeframes
+- Store bar history in a BarMatrix
+- Access bars from different timeframes in your strategy
+- Generate trading signals based on MTF analysis
+
+## Prerequisites
+
+- Completed [First Strategy](first-strategy.md) tutorial
+- Basic C++ knowledge — for Python users, see [Multi-symbol indicators](../how-to/multi-symbol-indicators.md) for the binding-friendly approach
+
+## What We're Building
+
+A momentum strategy that:
+
+1. Uses **H1** (hourly) bars to determine trend direction
+2. Uses **M5** (5-minute) bars to identify pullbacks
+3. Uses **M1** (1-minute) bars for entry timing
+
+**Entry logic**: Buy when H1 is bullish, M5 shows a pullback, and M1 prints a reversal bar.
+
+## Step 1: Project Setup
+
+Create a new file `my_mtf_strategy.cpp`:
+
+```cpp
+#include "flox/aggregator/bar_aggregator.h"
+#include "flox/aggregator/bar_matrix.h"
+#include "flox/aggregator/bus/bar_bus.h"
+#include "flox/aggregator/multi_timeframe_aggregator.h"
+#include "flox/aggregator/timeframe.h"
+#include "flox/book/events/trade_event.h"
+#include "flox/common.h"
+#include "flox/engine/abstract_market_data_subscriber.h"
+
+#include <iostream>
+
+using namespace flox;
+```
+
+## Step 2: Define the Strategy Class
+
+```cpp
+class MTFMomentumStrategy : public IMarketDataSubscriber
+{
+ public:
+  explicit MTFMomentumStrategy(SymbolId symbol, BarMatrix<256, 4, 64>* matrix)
+      : _symbol(symbol), _matrix(matrix)
+  {
+  }
+
+  SubscriberId id() const override
+  {
+    return reinterpret_cast<SubscriberId>(this);
+  }
+
+  void onBar(const BarEvent& ev) override
+  {
+    // We'll implement this next
+  }
+
+ private:
+  SymbolId _symbol;
+  BarMatrix<256, 4, 64>* _matrix;
+};
+```
+
+The strategy:
+- Takes a symbol ID and pointer to a BarMatrix
+- Implements `IMarketDataSubscriber` to receive bar events
+- Will analyze bars in `onBar()`
+
+## Step 3: Implement the Trading Logic
+
+Add the signal generation in `onBar()`:
+
+```cpp
+void onBar(const BarEvent& ev) override
+{
+  // Only process bars for our symbol
+  if (ev.symbol != _symbol)
+  {
+    return;
+  }
+
+  // Only act on M1 bars (fastest timeframe for entries)
+  if (ev.barType != BarType::Time || ev.barTypeParam != 60)
+  {
+    return;
+  }
+
+  // Get bars from different timeframes
+  const Bar* h1 = _matrix->bar(_symbol, timeframe::H1, 0);      // Latest H1
+  const Bar* h1_prev = _matrix->bar(_symbol, timeframe::H1, 1); // Previous H1
+  const Bar* m5 = _matrix->bar(_symbol, timeframe::M5, 0);      // Latest M5
+  const Bar* m1 = _matrix->bar(_symbol, timeframe::M1, 0);      // Latest M1
+
+  // Need all bars to generate signals
+  if (!h1 || !h1_prev || !m5 || !m1)
+  {
+    return;  // Not enough data yet
+  }
+
+  // 1. Check H1 trend
+  bool h1Bullish = h1->close > h1_prev->close;
+
+  // 2. Check M5 pullback (bearish bar in uptrend)
+  bool m5Pullback = m5->close < m5->open;
+
+  // 3. Check M1 reversal (bullish bar after pullback)
+  bool m1Reversal = m1->close > m1->open;
+
+  // Generate signal
+  if (h1Bullish && m5Pullback && m1Reversal)
+  {
+    std::cout << "[SIGNAL] BUY @ " << m1->close.toDouble()
+              << " | H1 bullish, M5 pullback, M1 reversal" << std::endl;
+  }
+}
+```
+
+**Key points:**
+
+- We filter for M1 bars to trigger entry logic on the fastest timeframe
+- `bar(symbol, timeframe, index)` gives us historical bars (0 = latest, 1 = previous)
+- We check conditions across all three timeframes
+
+## Step 4: Set Up the Infrastructure
+
+Now create `main()` to wire everything together:
+
+```cpp
+int main()
+{
+  constexpr SymbolId SYMBOL = 1;
+
+  // 1. Create the bar event bus
+  BarBus bus;
+
+  // 2. Create multi-timeframe aggregator
+  MultiTimeframeAggregator<4> aggregator(&bus);
+  aggregator.addTimeInterval(std::chrono::seconds(60));    // M1
+  aggregator.addTimeInterval(std::chrono::seconds(300));   // M5
+  aggregator.addTimeInterval(std::chrono::seconds(3600));  // H1
+
+  // 3. Create bar matrix for history storage
+  BarMatrix<256, 4, 64> matrix;
+  std::array<TimeframeId, 3> timeframes = {
+    timeframe::M1,
+    timeframe::M5,
+    timeframe::H1
+  };
+  matrix.configure(timeframes);
+
+  // 4. Create strategy
+  MTFMomentumStrategy strategy(SYMBOL, &matrix);
+
+  // 5. Subscribe to bar events
+  bus.subscribe(&matrix);    // Matrix stores bars
+  bus.subscribe(&strategy);  // Strategy receives bars
+
+  // 6. Start components
+  bus.start();
+  aggregator.start();
+
+  // 7. Feed trades (in real system, this comes from connector)
+  // aggregator.onTrade(tradeEvent);
+
+  // 8. Cleanup
+  aggregator.stop();
+  bus.stop();
+
+  return 0;
+}
+```
+
+## Step 5: Understanding the Data Flow
+
+```mermaid
+flowchart TB
+    TE[TradeEvent] --> MTA[MultiTimeframeAggregator]
+
+    MTA --> M1[M1 aggregator]
+    MTA --> M5[M5 aggregator]
+    MTA --> H1[H1 aggregator]
+
+    M1 --> BE1[BarEvent M1]
+    M5 --> BE5[BarEvent M5]
+    H1 --> BEH[BarEvent H1]
+
+    BE1 --> BB[BarBus]
+    BE5 --> BB
+    BEH --> BB
+
+    BB --> BM[BarMatrix<br/>stores bar history]
+    BB --> STR[MTFMomentumStrategy<br/>generates signals]
+```
+
+1. **Trades** come from your connector
+2. **MultiTimeframeAggregator** builds bars for all timeframes simultaneously
+3. **BarBus** distributes BarEvents to subscribers
+4. **BarMatrix** stores history for lookback
+5. **Strategy** accesses BarMatrix for multi-timeframe analysis
+
+## Step 6: Adding More Signal Logic
+
+Let's enhance the strategy with sell signals and tracking:
+
+```cpp
+class MTFMomentumStrategy : public IMarketDataSubscriber
+{
+ public:
+  // ... constructor ...
+
+  void onBar(const BarEvent& ev) override
+  {
+    if (ev.symbol != _symbol) return;
+    if (ev.barType != BarType::Time || ev.barTypeParam != 60) return;
+
+    const Bar* h1 = _matrix->bar(_symbol, timeframe::H1, 0);
+    const Bar* h1_prev = _matrix->bar(_symbol, timeframe::H1, 1);
+    const Bar* m5 = _matrix->bar(_symbol, timeframe::M5, 0);
+    const Bar* m1 = _matrix->bar(_symbol, timeframe::M1, 0);
+
+    if (!h1 || !h1_prev || !m5 || !m1) return;
+
+    // Trend detection
+    bool h1Bullish = h1->close > h1_prev->close;
+    bool h1Bearish = h1->close < h1_prev->close;
+
+    // Pullback detection
+    bool m5Pullback = m5->close < m5->open;   // Bearish M5 in uptrend
+    bool m5Rally = m5->close > m5->open;      // Bullish M5 in downtrend
+
+    // Entry bar
+    bool m1BullishReversal = m1->close > m1->open;
+    bool m1BearishReversal = m1->close < m1->open;
+
+    // BUY signal
+    if (h1Bullish && m5Pullback && m1BullishReversal)
+    {
+      std::cout << "[BUY] @ " << m1->close.toDouble() << std::endl;
+      ++_buySignals;
+    }
+    // SELL signal
+    else if (h1Bearish && m5Rally && m1BearishReversal)
+    {
+      std::cout << "[SELL] @ " << m1->close.toDouble() << std::endl;
+      ++_sellSignals;
+    }
+  }
+
+  void printStats() const
+  {
+    std::cout << "Buy signals:  " << _buySignals << std::endl;
+    std::cout << "Sell signals: " << _sellSignals << std::endl;
+  }
+
+ private:
+  SymbolId _symbol;
+  BarMatrix<256, 4, 64>* _matrix;
+  int _buySignals = 0;
+  int _sellSignals = 0;
+};
+```
+
+## Step 7: Adding Delta Confirmation
+
+Use buy/sell volume for confirmation:
+
+```cpp
+// In onBar(), after getting bars:
+
+// Check delta (buy pressure - sell pressure)
+Volume buyVol = m1->buyVolume;
+Volume sellVol = Volume::fromRaw(m1->volume.raw() - m1->buyVolume.raw());
+bool positiveDelta = buyVol.raw() > sellVol.raw();
+
+// Enhanced BUY signal with delta confirmation
+if (h1Bullish && m5Pullback && m1BullishReversal && positiveDelta)
+{
+  std::cout << "[BUY] @ " << m1->close.toDouble()
+            << " | Delta: +" << (buyVol.raw() - sellVol.raw()) << std::endl;
+}
+```
+
+## Complete Example
+
+See [multi_timeframe_demo.cpp](https://github.com/FLOX-Foundation/flox/blob/main/demo/src/multi_timeframe_demo.cpp) for a complete working example.
+
+## Next Steps
+
+- Add position management and risk controls
+- Implement stop-loss and take-profit logic
+- Add [Volume Profile](../reference/api/aggregator/volume_profile.md) for key level detection
+- Use [Footprint](../reference/api/aggregator/footprint_chart.md) for order flow confirmation
+
+------------------------------------------------------------------------------
+# Source: docs/tutorials/recording-data.md
+# URL: https://flox-foundation.github.io/flox/tutorials/recording-data/
+------------------------------------------------------------------------------
+
+# Recording Data
+
+Capture live market data to disk for later replay and backtesting. The same `.floxlog` binary format is produced by every binding — record from Python or Node.js and replay from C++ later, or vice versa.
+
+## Prerequisites
+
+- Completed [First Strategy](first-strategy.md)
+- Optional: LZ4 library for compression (`-DFLOX_ENABLE_LZ4=ON`)
+
+## What gets recorded
+
+FLOX writes a custom binary format optimised for sequential writes and fast sequential / indexed reads. Optional LZ4 compression. Automatic segment rotation.
+
+## Basic recording
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+
+    rec = flox.MarketDataRecorder(
+        output_dir="/data/btcusdt",
+        exchange_name="binance",
+        instrument_type="perpetual",
+        book_depth=20,
+        max_segment_bytes=256 << 20,
+    )
+    rec.add_symbol(1, "BTCUSDT", base="BTC", quote="USDT",
+                   price_precision=2, qty_precision=3)
+    rec.start()
+
+    # Feed events as they arrive — for example from a Runner subscription
+    rec.write_trade(symbol_id=1, price=10050.0, qty=0.5, is_buy=True,
+                     exchange_ts_ns=ts_ns)
+    rec.write_book_snapshot(symbol_id=1, bids=bids_arr, asks=asks_arr,
+                             exchange_ts_ns=ts_ns)
+
+    rec.stop()    # writes metadata.json
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const rec = new flox.MarketDataRecorder({
+      outputDir: "/data/btcusdt",
+      exchangeName: "binance",
+      instrumentType: "perpetual",
+      bookDepth: 20,
+      maxSegmentBytes: 256 << 20,
+    });
+    rec.addSymbol(1, "BTCUSDT", "BTC", "USDT", 2, 3);
+    rec.start();
+
+    rec.writeTrade(1, 10050.0, 0.5, /*isBuy=*/ true, tsNs);
+    rec.writeBookSnapshot(1, bidPrices, bidQtys, askPrices, askQtys, tsNs);
+
+    rec.stop();
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/replay/writers/binary_log_writer.h"
+    using namespace flox::replay;
+
+    WriterConfig config;
+    config.output_dir = "/data/market_data";
+    config.max_segment_bytes = 256 * 1024 * 1024;
+    config.create_index = true;
+    config.compression = CompressionType::None;       // or LZ4
+
+    BinaryLogWriter writer(config);
+
+    TradeRecord trade{ .symbol_id = 42, .price = 10050, .quantity = 100,
+                        .side = 1, .exchange_ts_ns = ts_ns };
+    writer.writeTrade(trade);
+
+    BookRecordHeader header{ .symbol_id = 42, .update_type = static_cast<uint8_t>(BookUpdateType::SNAPSHOT),
+                              .bid_count = 5, .ask_count = 5, .exchange_ts_ns = ts_ns };
+    writer.writeBook(header, bids, asks);
+
+    writer.flush();
+    writer.close();
+    ```
+
+## 3. Recording from Live Connectors
+
+Subscribe the writer to your market data buses:
+
+```cpp
+class MarketDataRecorder : public IMarketDataSubscriber
+{
+public:
+  MarketDataRecorder(const std::filesystem::path& output_dir)
+    : _writer(createConfig(output_dir)) {}
+
+  SubscriberId id() const override {
+    return reinterpret_cast<SubscriberId>(this);
+  }
+
+  void onTrade(const TradeEvent& ev) override {
+    TradeRecord record;
+    record.symbol_id = ev.trade.symbol;
+    record.price = ev.trade.price.raw();
+    record.quantity = ev.trade.quantity.raw();
+    record.side = ev.trade.isBuy ? 1 : 0;
+    record.exchange_ts_ns = ev.trade.exchangeTsNs;
+
+    _writer.writeTrade(record);
+  }
+
+  void onBookUpdate(const BookUpdateEvent& ev) override {
+    BookRecordHeader header;
+    header.symbol_id = ev.update.symbol;
+    header.update_type = static_cast<uint8_t>(ev.update.type);
+    header.bid_count = ev.update.bids.size();
+    header.ask_count = ev.update.asks.size();
+    header.exchange_ts_ns = ev.update.exchangeTsNs;
+
+    std::vector<BookLevel> bids, asks;
+    for (const auto& b : ev.update.bids) {
+      bids.push_back({b.price.raw(), b.quantity.raw()});
+    }
+    for (const auto& a : ev.update.asks) {
+      asks.push_back({a.price.raw(), a.quantity.raw()});
+    }
+
+    _writer.writeBook(header, bids, asks);
+  }
+
+  void flush() { _writer.flush(); }
+  void close() { _writer.close(); }
+  WriterStats stats() const { return _writer.stats(); }
+
+private:
+  static WriterConfig createConfig(const std::filesystem::path& dir) {
+    WriterConfig cfg;
+    cfg.output_dir = dir;
+    cfg.max_segment_bytes = 256 << 20;
+    cfg.create_index = true;
+    return cfg;
+  }
+
+  BinaryLogWriter _writer;
+};
+
+// Wire it up
+auto recorder = std::make_unique<MarketDataRecorder>("/data/live");
+tradeBus->subscribe(recorder.get());
+bookBus->subscribe(recorder.get());
+```
+
+## 4. Writer Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `output_dir` | Required | Directory for segment files |
+| `output_filename` | Auto | Override auto-generated filename |
+| `max_segment_bytes` | 256 MB | Rotate to new file at this size |
+| `buffer_size` | 64 KB | Write buffer size |
+| `sync_on_rotate` | true | fsync before starting new segment |
+| `create_index` | true | Write index for fast seeking |
+| `index_interval` | 1000 | Events between index entries |
+| `compression` | None | `None` or `LZ4` |
+
+## 5. File Format
+
+FLOX creates `.floxlog` segment files with embedded index:
+
+```
+/data/market_data/
+├── metadata.json                    # Recording metadata (exchange, symbols, etc.)
+├── 20250101_120000_000.floxlog      # First segment (index embedded at end)
+├── 20250101_121500_001.floxlog      # Second segment (after rotation)
+└── index.floxidx                    # Optional: global index across all segments
+```
+
+Segment structure:
+```
+┌──────────────────┐
+│  SegmentHeader   │  Magic, version, compression, timestamps, index_offset
+├──────────────────┤
+│  Event Frames    │  Trade and book update records
+│  ...             │
+├──────────────────┤
+│  SegmentIndex    │  Embedded: timestamp → offset mapping (if create_index=true)
+└──────────────────┘
+```
+
+The global index (`index.floxidx`) can be built separately using `GlobalIndexBuilder` to enable fast lookup across multiple segment files.
+
+## 6. Recording Metadata
+
+Each recording includes a `metadata.json` file with source information:
+
+```json
+{
+  "exchange": "binance",
+  "exchange_type": "cex",
+  "instrument_type": "perpetual",
+
+  "symbols": [
+    {
+      "symbol_id": 1,
+      "name": "BTCUSDT",
+      "base_asset": "BTC",
+      "quote_asset": "USDT",
+      "price_precision": 2,
+      "qty_precision": 3
+    }
+  ],
+
+  "has_trades": true,
+  "has_book_snapshots": true,
+  "has_book_deltas": true,
+  "book_depth": 20,
+
+  "recording_start": "2025-01-15T10:30:00.000Z",
+  "recording_end": "2025-01-15T18:45:00.000Z",
+
+  "price_scale": 100000000,
+  "qty_scale": 100000000
+}
+```
+
+### Using MarketDataRecorder
+
+The high-level `MarketDataRecorder` automatically creates metadata:
+
+```cpp
+#include "flox/replay/market_data_recorder.h"
+
+MarketDataRecorderConfig config;
+config.output_dir = "/data/btcusdt";
+config.exchange_name = "binance";
+config.exchange_type = "cex";
+config.instrument_type = "perpetual";
+config.book_depth = 20;
+
+MarketDataRecorder recorder(config);
+
+// Add symbol mappings
+recorder.addSymbol(1, "BTCUSDT", "BTC", "USDT", 2, 3);
+
+recorder.start();
+// ... subscribe to market data buses ...
+recorder.stop();  // Writes metadata.json automatically
+```
+
+### Manual Metadata with BinaryLogWriter
+
+```cpp
+#include "flox/replay/recording_metadata.h"
+
+RecordingMetadata meta;
+meta.exchange = "bybit";
+meta.instrument_type = "spot";
+meta.has_trades = true;
+
+WriterConfig config;
+config.output_dir = "/data/spot";
+config.metadata = meta;
+
+BinaryLogWriter writer(config);
+writer.addSymbol({.symbol_id = 1, .name = "ETHUSDT"});
+// ... write events ...
+writer.close();  // Saves metadata.json
+```
+
+## 7. Monitoring Recording
+
+```cpp
+// Periodically check stats
+WriterStats stats = writer.stats();
+std::cout << "Events: " << stats.events_written
+          << ", Trades: " << stats.trades_written
+          << ", Books: " << stats.book_updates_written
+          << ", Segments: " << stats.segments_created
+          << ", Bytes: " << stats.bytes_written << std::endl;
+```
+
+## 8. Compression
+
+Enable LZ4 for 3-5x size reduction:
+
+```bash
+cmake .. -DFLOX_ENABLE_LZ4=ON
+```
+
+```cpp
+WriterConfig config;
+config.compression = CompressionType::LZ4;
+// Everything else works the same
+```
+
+## Next Steps
+
+- [Backtesting](backtesting.md) — Replay recorded data through your strategy
+- [Binary Format](../reference/api/replay/binary_format.md) — Recording format specification
+
+------------------------------------------------------------------------------
+# Source: docs/tutorials/backtesting.md
+# URL: https://flox-foundation.github.io/flox/tutorials/backtesting/
+------------------------------------------------------------------------------
+
+# Backtesting
+
+Run your strategy against recorded market data. Each language exposes the same `BacktestRunner` model.
+
+## Prerequisites
+
+- Completed [Recording Data](recording-data.md) (or have a CSV / `.floxlog` file)
+- Build / install with backtest support — see [Bindings](../bindings/README.md) for per-language details
+
+## Pipeline
+
+```
+data file → BacktestRunner → Strategy → SimulatedExecutor → BacktestResult
+```
+
+## Minimal example
+
+A strategy that buys when price crosses above a 20-period SMA.
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+    from collections import deque
+
+    class CrossAboveSMA(flox.Strategy):
+        def __init__(self, symbols, period=20):
+            super().__init__(symbols)
+            self.window = deque(maxlen=period)
+
+        def on_trade(self, ctx, trade):
+            self.window.append(trade.price)
+            if len(self.window) < self.window.maxlen:
+                return
+            sma = sum(self.window) / len(self.window)
+            if trade.price > sma and ctx.is_flat():
+                self.market_buy(1.0)
+            elif trade.price < sma and ctx.is_long():
+                self.close_position()
+
+    reg = flox.SymbolRegistry()
+    btc = reg.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+
+    strat = CrossAboveSMA([btc])
+    bt = flox.BacktestRunner(reg, fee_rate=0.0004, initial_capital=10_000)
+    bt.set_strategy(strat)
+
+    stats = bt.run_csv("/data/btcusdt_1m.csv", "BTCUSDT")
+    print(f"Return {stats['return_pct']:.2f}%  Sharpe {stats['sharpe']:.2f}  "
+          f"DD {stats['max_drawdown_pct']:.2f}%  trades {stats['total_trades']}")
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const flox = require('@flox-foundation/flox');
+
+    class CrossAboveSMA {
+      constructor(symbols, period = 20) {
+        this.symbols = symbols;
+        this.period = period;
+        this.window = [];
+      }
+      onTrade(ctx, trade, emit) {
+        this.window.push(trade.price);
+        if (this.window.length > this.period) this.window.shift();
+        if (this.window.length < this.period) return;
+        const sma = this.window.reduce((a,b)=>a+b, 0) / this.period;
+        if (trade.price > sma && ctx.position === 0) emit.marketBuy(1.0);
+        else if (trade.price < sma && ctx.position > 0) emit.closePosition();
+      }
+    }
+
+    const reg = new flox.SymbolRegistry();
+    const btc = reg.addSymbol("binance", "BTCUSDT", 0.01);
+    const bt  = new flox.BacktestRunner(reg, 0.0004, 10_000);
+    bt.setStrategy(new CrossAboveSMA([btc]));
+
+    const stats = bt.runCsv("/data/btcusdt_1m.csv", "BTCUSDT");
+    console.log(`Return ${stats.returnPct.toFixed(2)}%  Sharpe ${stats.sharpeRatio.toFixed(2)}`);
+    ```
+
+=== "Codon"
+
+    ```python
+    from flox.runner import BacktestRunner
+    from flox.strategy import Strategy
+    from flox.context import SymbolContext
+    from flox.types import TradeData
+    from flox.indicators import StreamingSMA
+
+    class CrossAboveSMA(Strategy):
+        sma: StreamingSMA
+        def __init__(self, symbols: List[int], period: int = 20):
+            super().__init__(symbols)
+            self.sma = StreamingSMA(period)
+
+        def on_trade(self, ctx: SymbolContext, trade: TradeData):
+            v = self.sma.update(trade.price.to_double())
+            if not self.sma.ready:
+                return
+            if trade.price.to_double() > v and self.position() == 0.0:
+                self.market_buy(1.0)
+            elif trade.price.to_double() < v and self.position() > 0.0:
+                self.close_position()
+
+    bt = BacktestRunner(reg, fee_rate=0.0004, initial_capital=10_000.0)
+    bt.set_strategy(CrossAboveSMA([btc]))
+    stats = bt.run_csv("/data/btcusdt_1m.csv", "BTCUSDT")
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/backtest/backtest_runner.h"
+    #include "flox/replay/abstract_event_reader.h"
+
+    int main() {
+      replay::ReaderFilter filter;
+      filter.symbols = {1};
+      auto reader = replay::createMultiSegmentReader("/data/btcusdt", filter);
+
+      BacktestConfig config{ .initialCapital = 10000.0, .feeRate = 0.0004 };
+      BacktestRunner runner(config);
+
+      SymbolRegistry registry;
+      SymbolInfo info{ .exchange = "binance", .symbol = "BTCUSDT",
+                       .tickSize = Price::fromDouble(0.01) };
+      auto symId = registry.registerSymbol(info);
+
+      MyStrategy strat(symId, registry);
+      runner.setStrategy(&strat);
+
+      auto result = runner.run(*reader);
+      auto stats  = result.computeStats();
+      std::cout << "Return " << stats.returnPct << "%\n";
+    }
+    ```
+
+## What's in `stats`
+
+| Field | Description |
+|---|---|
+| `total_trades` / `totalTrades` | Number of closed trades |
+| `final_capital` / `finalCapital` | Ending capital |
+| `return_pct` / `returnPct` | Total return % |
+| `sharpe` / `sharpeRatio` | Annualised Sharpe |
+| `sortino` / `sortinoRatio` | Annualised Sortino |
+| `max_drawdown_pct` / `maxDrawdownPct` | Worst drawdown |
+| `win_rate` / `winRate` | Win rate (0–1) |
+| `profit_factor` / `profitFactor` | Gross profit / gross loss |
+
+## Time-range filtering
+
+=== "Python"
+
+    Use `pandas` to slice your CSV before passing in, or pass arrays to `run_bars(start_time_ns, end_time_ns, ...)` filtered to the window you want.
+
+=== "C++"
+
+    ```cpp
+    replay::ReaderFilter filter;
+    filter.from_ns = 1704067200000000000LL;   // 2024-01-01
+    filter.to_ns   = 1704153600000000000LL;   // 2024-01-02
+    filter.symbols = {1};
+    auto reader = replay::createMultiSegmentReader("/data", filter);
+    ```
+
+## Performance tips
+
+1. **Release build** — `cmake -DCMAKE_BUILD_TYPE=Release` (`pip install flox-py` already gives you Release)
+2. **Filter symbols** — only load what you need
+3. **Pre-aggregate** for repeated parameter sweeps; see [Bar aggregation](../how-to/bar-aggregation.md)
+4. **Avoid logging in callbacks** — measure first; logging in the inner loop dominates
+
+## Next
+
+- [Running a Backtest](../how-to/backtest.md) — fuller SMA crossover walkthrough
+- [Grid search](../how-to/grid-search.md) — sweep parameters
+- [Realistic fills](../how-to/backtest-realistic-fills.md) — slippage and queue position
+- [Bar aggregation](../how-to/bar-aggregation.md) — pre-aggregate offline for speed
+
+------------------------------------------------------------------------------
+# Source: docs/tutorials/demo.md
+# URL: https://flox-foundation.github.io/flox/tutorials/demo/
+------------------------------------------------------------------------------
+
+# Run the Demo
+
+The `demo` folder provides a minimal working example that wires FLOX components into a functioning system. It demonstrates the architecture, event flow, and subsystem lifecycle in a controlled, simulated environment.
+
+## Features
+
+| Component | Description |
+|-----------|-------------|
+| `DemoConnector` | Emits synthetic trades and book updates for testing |
+| `DemoStrategy` | Receives market data and generates mock orders |
+| `SimpleOrderExecutor` | Processes orders and triggers fills via `OrderExecutionBus` |
+| `SimplePnLTracker` | Tracks profit and loss |
+| `SimpleKillSwitch` | Emergency shutdown control |
+| `SimpleRiskManager` | Basic risk controls |
+| `DemoBuilder` | Constructs and wires all required subsystems and buses |
+
+## Build the Demo
+
+```bash
+cmake .. -DFLOX_ENABLE_DEMO=ON
+make -j$(nproc)
+```
+
+## Run the Demo
+
+```bash
+./demo/flox_demo
+```
+
+The demo will:
+
+1. Start two synthetic connectors
+2. Publish market data via `TradeBus` and `BookUpdateBus`
+3. Run the strategy and supporting systems for approximately five seconds
+4. Stop all components and exit cleanly
+
+## Expected Output
+
+```
+[INFO] Starting DemoConnector (exchange1)
+[INFO] Starting DemoConnector (exchange2)
+[INFO] DemoStrategy: received trade BTCUSDT @ 50000.00
+[INFO] DemoStrategy: received book update BTCUSDT (10 levels)
+[INFO] DemoStrategy: placing order BUY 0.1 BTCUSDT @ 49990.00
+[INFO] SimpleOrderExecutor: order filled
+...
+[INFO] Stopping all components
+[INFO] Demo completed
+```
+
+## Code Structure
+
+```
+demo/
+├── main.cpp              # Entry point
+├── demo_builder.h        # Wires all components
+├── demo_connector.h      # Synthetic market data
+├── demo_strategy.h       # Example strategy
+└── simple_*.h            # Simple implementations of interfaces
+```
+
+## Understanding the Demo
+
+### DemoBuilder
+
+The builder demonstrates how to wire FLOX components:
+
+```cpp
+// Create buses
+auto tradeBus = std::make_unique<TradeBus>();
+auto bookBus = std::make_unique<BookUpdateBus>();
+auto execBus = std::make_unique<OrderExecutionBus>();
+
+// Create connectors
+auto connector = std::make_shared<DemoConnector>(registry, tradeBus, bookBus);
+
+// Create strategy
+auto strategy = std::make_unique<DemoStrategy>();
+
+// Subscribe strategy to buses
+tradeBus->subscribe(strategy.get());
+bookBus->subscribe(strategy.get());
+
+// Wire execution
+strategy->setExecutor(executor.get());
+
+// Start engine
+engine.start();
+```
+
+### DemoConnector
+
+Generates synthetic market data at configurable rates:
+
+```cpp
+void DemoConnector::run() {
+    while (_running) {
+        TradeEvent trade;
+        trade.trade.symbol = _symbolId;
+        trade.trade.price = generatePrice();
+        trade.trade.quantity = generateQty();
+
+        _tradeBus.publish(trade);
+
+        std::this_thread::sleep_for(10ms);
+    }
+}
+```
+
+### DemoStrategy
+
+Shows how to consume events and place orders:
+
+```cpp
+void DemoStrategy::onTrade(const TradeEvent& event) {
+    // Process trade
+    if (shouldBuy(event)) {
+        Order order;
+        order.symbol = event.trade.symbol;
+        order.side = OrderSide::BUY;
+        order.price = event.trade.price - _tickSize;
+        order.quantity = _orderSize;
+
+        _executor->submit(order);
+    }
+}
+```
+
+## Notes
+
+- This demo is intended for integration testing and illustration only
+- Production deployments should define their own builder and execution harness
+- All demo components are isolated and can be replaced with real implementations
+
+## See Also
+
+- [Quickstart](quickstart.md) — Build FLOX from source
+- [First Strategy](first-strategy.md) — Write your own strategy
+- [Architecture](../explanation/architecture.md) — How components fit together
+
+==============================================================================
+# Section: Working examples
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/examples/index.md
+# URL: https://flox-foundation.github.io/flox/examples/
+------------------------------------------------------------------------------
+
+# Examples
+
+Source files and sample data are in [`docs/examples/`](https://github.com/FLOX-Foundation/flox/tree/main/docs/examples).
+
+| Example | Language | What it shows |
+|---------|----------|---------------|
+| [Backtest & live](python-backtest-vs-live.md) | Python | Same strategy class runs in backtest, sync live, and threaded live |
+| [Multi-symbol](python-multi-symbol.md) | Python | Two symbols, two timeframes, pairs spread strategy |
+| [Live via ccxt](python-ccxt-live.md) | Python | Binance WebSocket feed wired to a live strategy |
+| [Backtest & live](node-backtest-vs-live.md) | Node.js | Same strategy object runs in backtest, sync, and threaded modes |
+| [Backtest & live](codon-backtest-vs-live.md) | Codon | Same as Python example, compiled to native |
+| [Full API](codon-full-backtest.md) | Codon | Exercises indicators, order books, profiles, statistics, position tracking |
+| [SMA backtest](cpp-sma-backtest.md) | C++ | SMA crossover replayed through `BacktestRunner` |
+
+------------------------------------------------------------------------------
+# Source: docs/examples/python-backtest-vs-live.md
+# URL: https://flox-foundation.github.io/flox/examples/python-backtest-vs-live/
+------------------------------------------------------------------------------
+
+# Python — backtest & live
+
+The same `SMAStrategy` class runs unchanged in three modes:
+
+1. **BacktestRunner** — replays a CSV through the strategy; `SimulatedExecutor` handles fills
+2. **Runner** (sync) — push ticks from your connector; callbacks fire before the call returns
+3. **Runner(threaded=True)** — events go into a lock-free ring buffer; strategy runs in a background C++ thread
+
+```
+cd /path/to/flox
+PYTHONPATH=build/python python3 docs/examples/python_backtest_vs_live.py
+```
+
+```python
+--8<-- "examples/python_backtest_vs_live.py"
+```
+
+------------------------------------------------------------------------------
+# Source: docs/examples/python-multi-symbol.md
+# URL: https://flox-foundation.github.io/flox/examples/python-multi-symbol/
+------------------------------------------------------------------------------
+
+# Python — multi-symbol
+
+Loads BTC and ETH 1-minute data, resamples to 5-minute bars, then runs a pairs spread mean-reversion strategy across both symbols.
+
+```
+cd /path/to/flox
+PYTHONPATH=build/python python3 docs/examples/python_multi_symbol.py
+```
+
+```python
+--8<-- "examples/python_multi_symbol.py"
+```
+
+------------------------------------------------------------------------------
+# Source: docs/examples/python-ccxt-live.md
+# URL: https://flox-foundation.github.io/flox/examples/python-ccxt-live/
+------------------------------------------------------------------------------
+
+# Python — live via ccxt
+
+Connects to Binance public WebSocket via `ccxt.pro`, streams BTC/USDT trades in real time, and runs an SMA crossover strategy. No API key required.
+
+```
+pip install ccxt
+cd /path/to/flox
+PYTHONPATH=build/python python3 docs/examples/python_ccxt_live.py
+```
+
+Stop with `Ctrl+C`.
+
+```python
+--8<-- "examples/python_ccxt_live.py"
+```
+
+------------------------------------------------------------------------------
+# Source: docs/examples/node-backtest-vs-live.md
+# URL: https://flox-foundation.github.io/flox/examples/node-backtest-vs-live/
+------------------------------------------------------------------------------
+
+# Node.js — backtest & live
+
+The same strategy object runs unchanged in backtest, synchronous live, and threaded live modes.
+
+```
+node docs/examples/node_backtest_vs_live.js
+```
+
+```javascript
+--8<-- "examples/node_backtest_vs_live.js"
+```
+
+------------------------------------------------------------------------------
+# Source: docs/examples/codon-backtest-vs-live.md
+# URL: https://flox-foundation.github.io/flox/examples/codon-backtest-vs-live/
+------------------------------------------------------------------------------
+
+# Codon — backtest & live
+
+The same `SMAStrategy` class runs in backtest, synchronous live, and threaded live modes. Identical logic to the [Python example](python-backtest-vs-live.md), compiled to native.
+
+```bash
+codon build -exe -o build/codon/codon_backtest_vs_live \
+  -L build/src/capi -lflox_capi docs/examples/codon_backtest_vs_live.codon
+
+DYLD_LIBRARY_PATH=build/src/capi:~/.local/lib/codon \
+  ./build/codon/codon_backtest_vs_live
+```
+
+```python
+--8<-- "examples/codon_backtest_vs_live.codon"
+```
+
+------------------------------------------------------------------------------
+# Source: docs/examples/codon-full-backtest.md
+# URL: https://flox-foundation.github.io/flox/examples/codon-full-backtest/
+------------------------------------------------------------------------------
+
+# Codon — full API
+
+Exercises the Codon API end-to-end on synthetic data: streaming indicators, `SimulatedExecutor`, position tracking, order books, volume profile, footprint bars, statistics. No CSV required.
+
+```bash
+codon build -exe -o build/codon/codon_full_backtest \
+  -L build/src/capi -lflox_capi docs/examples/codon_full_backtest.codon
+
+DYLD_LIBRARY_PATH=build/src/capi:~/.local/lib/codon \
+  ./build/codon/codon_full_backtest
+```
+
+```python
+--8<-- "examples/codon_full_backtest.codon"
+```
+
+------------------------------------------------------------------------------
+# Source: docs/examples/cpp-sma-backtest.md
+# URL: https://flox-foundation.github.io/flox/examples/cpp-sma-backtest/
+------------------------------------------------------------------------------
+
+# C++ — SMA backtest
+
+A complete C++ backtest of an SMA(10/30) crossover. Same model as the [Python example](python-backtest-vs-live.md) — one Strategy subclass replayed through `BacktestRunner` against a CSV — but written against the C++ API directly.
+
+```bash
+cmake -B build -DFLOX_ENABLE_BACKTEST=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target cpp_sma_backtest
+./build/docs/examples/cpp_sma_backtest docs/examples/data/btcusdt_1m.csv
+```
+
+```cpp
+--8<-- "examples/cpp_sma_backtest.cpp"
+```
+
+## What it shows
+
+- Inheriting from `flox::Strategy` (not `IStrategy`) — `Strategy` exposes `emitMarketBuy/Sell` which `BacktestRunner` intercepts as signals.
+- Using `SymbolContext::position` indirectly via the `_long` / `_short` state — the bookkeeping `BacktestRunner` does in `BacktestResult::computeStats()`.
+- Loading a CSV via `replay::createCsvOhlcvReader(...)` — the same reader interface used for `.floxlog` segments.
+- Reading stats off `BacktestResult::computeStats()` — same fields exposed in Python and Node.js.
+
+## Compare to other languages
+
+The Python and Node.js versions of the same crossover live in:
+
+- [Python — backtest & live](python-backtest-vs-live.md) (also runs live via `Runner`)
+- [Node.js — backtest & live](node-backtest-vs-live.md)
+- [Codon — backtest & live](codon-backtest-vs-live.md)
+
+==============================================================================
+# Section: How-to: strategy and backtest
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/README.md
+# URL: https://flox-foundation.github.io/flox/how-to/
+------------------------------------------------------------------------------
+
+# How-To Guides
+
+Solve specific problems. Assumes you know the basics.
+
+## Available Guides
+
+| Guide | Problem |
+|-------|---------|
+| [Bar Aggregation](bar-aggregation.md) | Pre-aggregate bars for fast backtesting |
+| [Backtesting](backtest.md) | Run strategy backtests on historical data |
+| [Grid Search](grid-search.md) | Find optimal strategy parameters |
+| [CPU Affinity](cpu-affinity.md) | Pin threads to isolated cores for lower latency |
+| [Custom Connector](custom-connector.md) | Connect to a new exchange |
+| [Custom Bar Policy](custom-bar-policy.md) | Create custom bar aggregation policies |
+| [Advanced Orders](advanced-orders.md) | Use stop-loss, take-profit, brackets |
+| [Multi-Exchange Trading](multi-exchange-trading.md) | Trade across multiple exchanges with aggregation and routing |
+| [Optimize Performance](optimize-performance.md) | Tune for minimum latency |
+| [Configuration](configuration.md) | Runtime configuration options |
+| [CI Configuration](ci.md) | Understand the CI pipeline |
+| [Contributing](contributing.md) | Contribute to FLOX development |
+
+## Prerequisites
+
+These guides assume you've completed the [Tutorials](../tutorials/README.md) and understand basic FLOX concepts.
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/strategy-classes.md
+# URL: https://flox-foundation.github.io/flox/how-to/strategy-classes/
+------------------------------------------------------------------------------
+
+# Strategy classes
+
+FLOX exposes the same event-driven Strategy model in every language. Override callbacks (`on_trade`, `on_book_update`, `on_bar`), emit orders through the strategy's helper methods, and the C++ engine handles bus dispatch, fills, and bookkeeping.
+
+## Architecture
+
+```
+                   C++ Strategy (canonical)
+                            |
+                    C API (libflox_capi.so)
+              ____________ | ____________
+             |             |              |
+   Python Strategy   Node Strategy   Codon Strategy
+       (pybind11)        (N-API)      (C FFI, AOT)
+```
+
+All bindings dispatch through the same C++ `BridgeStrategy` callbacks, so behaviour is identical across languages.
+
+## A simple strategy
+
+10/30 SMA crossover, long-only.
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+
+    class SmaCrossover(flox.Strategy):
+        def __init__(self, symbols, fast=10, slow=30):
+            super().__init__(symbols)
+            self.prices = []
+            self.fast, self.slow = fast, slow
+
+        def on_trade(self, ctx, trade):
+            self.prices.append(trade.price)
+            if len(self.prices) < self.slow:
+                return
+            f = sum(self.prices[-self.fast:]) / self.fast
+            s = sum(self.prices[-self.slow:]) / self.slow
+            if f > s and ctx.is_flat():
+                self.market_buy(1.0)
+            elif f < s and ctx.is_long():
+                self.close_position()
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    class SmaCrossover {
+      constructor(symbols, fast = 10, slow = 30) {
+        this.symbols = symbols;
+        this.fast = fast; this.slow = slow;
+        this.prices = [];
+      }
+      onTrade(ctx, trade, emit) {
+        this.prices.push(trade.price);
+        if (this.prices.length < this.slow) return;
+        const f = this.prices.slice(-this.fast).reduce((a,b)=>a+b)/this.fast;
+        const s = this.prices.slice(-this.slow).reduce((a,b)=>a+b)/this.slow;
+        if (f > s && ctx.position === 0)        emit.marketBuy(1.0);
+        else if (f < s && ctx.position > 0)     emit.closePosition();
+      }
+    }
+    ```
+
+=== "Codon"
+
+    ```python
+    from flox.strategy import Strategy
+    from flox.context import SymbolContext
+    from flox.types import TradeData
+    from flox.indicators import StreamingSMA
+
+    class SmaCrossover(Strategy):
+        fast_sma: StreamingSMA
+        slow_sma: StreamingSMA
+
+        def __init__(self, symbols: List[int], fast: int = 10, slow: int = 30):
+            super().__init__(symbols)
+            self.fast_sma = StreamingSMA(fast)
+            self.slow_sma = StreamingSMA(slow)
+
+        def on_trade(self, ctx: SymbolContext, trade: TradeData):
+            price = trade.price.to_double()
+            f = self.fast_sma.update(price)
+            s = self.slow_sma.update(price)
+            if not self.slow_sma.ready:
+                return
+            if f > s and self.position() == 0.0:
+                self.market_buy(1.0)
+            elif f < s and self.position() > 0.0:
+                self.close_position()
+    ```
+
+=== "C++"
+
+    ```cpp
+    class SmaCrossover : public flox::Strategy {
+      // ... see docs/how-to/backtest.md for the full C++ class
+    };
+    ```
+
+## Overridable callbacks
+
+| Callback | When it fires | Available |
+|---|---|---|
+| `on_trade(ctx, trade)` | Tick-level trade event | All bindings |
+| `on_book_update(ctx)` | L2 book changed (bid/ask, mid) | All bindings |
+| `on_bar(ctx, bar)` | Closed OHLC bar | All bindings (since [#123](https://github.com/FLOX-Foundation/flox/pull/123)) |
+| `on_start()` / `on_stop()` | Lifecycle hooks | All bindings |
+
+## Order emission helpers
+
+Names differ slightly by language (snake_case vs camelCase) but the surface is the same.
+
+| Action | Python | Node.js | Codon | C++ |
+|---|---|---|---|---|
+| Market buy | `market_buy(qty)` | `emit.marketBuy(qty)` | `market_buy(qty)` | `emitMarketBuy(sym, qty)` |
+| Market sell | `market_sell(qty)` | `emit.marketSell(qty)` | `market_sell(qty)` | `emitMarketSell(sym, qty)` |
+| Limit buy | `limit_buy(price, qty)` | `emit.limitBuy(p, qty)` | `limit_buy(price, qty)` | `emitLimitBuy(sym, p, qty)` |
+| Limit sell | `limit_sell(price, qty)` | `emit.limitSell(p, qty)` | `limit_sell(price, qty)` | `emitLimitSell(sym, p, qty)` |
+| Cancel | `cancel_order(id)` | `emit.cancel(id)` | `cancel_order(id)` | `emitCancel(id)` |
+| Cancel all | `cancel_all_orders()` | `emit.cancelAll(sym)` | `cancel_all_orders()` | `emitCancelAll(sym)` |
+| Stop market | `stop_market(side, trigger, qty)` | — | `stop_market(side, trigger, qty)` | `emitStopMarket(sym, side, trigger, qty)` |
+| Take profit market | `take_profit_market(side, trigger, qty)` | — | `take_profit_market(side, trigger, qty)` | `emitTakeProfitMarket(sym, side, trigger, qty)` |
+| Trailing stop | `trailing_stop(side, offset, qty)` | — | `trailing_stop(side, offset, qty)` | `emitTrailingStop(sym, side, offset, qty)` |
+| Close position | `close_position()` | `emit.closePosition()` | `close_position()` | `emitClosePosition(sym)` |
+
+In Python / Node.js / Codon `symbol` defaults to the first registered symbol when omitted.
+
+## Context (`ctx`) properties
+
+| Property | Type | Description |
+|---|---|---|
+| `position` | float | Current position quantity (signed) |
+| `symbol_id` (Py/Codon) / `symbolId` (Node) | int | Numeric symbol id |
+| `last_trade_price` / `lastTradePrice` | float | Most recent trade price |
+| `best_bid` / `bestBid`, `best_ask` / `bestAsk` | float | Top-of-book |
+| `mid_price` / `midPrice` | float | `(best_bid + best_ask) / 2` |
+| `is_long()` / `is_short()` / `is_flat()` (Py/Codon) | bool | Position state |
+
+## C++ ↔ binding name map
+
+For the canonical reference of every callback and emit helper, see the per-language API references:
+
+- [Python reference](../reference/python/strategy.md)
+- [Node.js reference](../reference/node/strategy.md)
+- [Codon reference](../reference/codon/strategy.md)
+- [C++ Strategy](../reference/api/strategy/strategy.md)
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/backtest.md
+# URL: https://flox-foundation.github.io/flox/how-to/backtest/
+------------------------------------------------------------------------------
+
+# Running a Backtest
+
+Replay an SMA crossover strategy against historical data and read the stats out.
+
+## Build / install
+
+=== "Python"
+
+    ```bash
+    pip install flox-py
+    ```
+
+    Or build from source: `cmake -B build -DFLOX_ENABLE_PYTHON=ON -DFLOX_ENABLE_BACKTEST=ON && cmake --build build` and put `build/python` on `PYTHONPATH`.
+
+=== "Node.js"
+
+    ```bash
+    npm install @flox-foundation/flox
+    ```
+
+=== "Codon"
+
+    Build flox with `-DFLOX_ENABLE_CAPI=ON -DFLOX_ENABLE_BACKTEST=ON`, then point Codon at `codon/flox`.
+
+=== "C++"
+
+    ```bash
+    cmake -B build -DFLOX_ENABLE_BACKTEST=ON -DCMAKE_BUILD_TYPE=Release
+    cmake --build build -j
+    ```
+
+## Strategy
+
+A 10/20 SMA crossover. Buy when fast crosses above slow, sell on the reverse.
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+    from collections import deque
+
+    class SmaCrossover(flox.Strategy):
+        def __init__(self, symbols, fast=10, slow=20, size=1.0):
+            super().__init__(symbols)
+            self.fast, self.slow, self.size = fast, slow, size
+            self.prices = deque(maxlen=slow)
+            self.prev_above = False
+
+        def on_trade(self, ctx, trade):
+            self.prices.append(trade.price)
+            if len(self.prices) < self.slow:
+                return
+            fast_sma = sum(list(self.prices)[-self.fast:]) / self.fast
+            slow_sma = sum(self.prices) / self.slow
+            above = fast_sma > slow_sma
+            if above and not self.prev_above and ctx.is_flat():
+                self.market_buy(self.size)
+            elif not above and self.prev_above and ctx.is_long():
+                self.market_sell(self.size)
+            self.prev_above = above
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const flox = require('@flox-foundation/flox');
+
+    class SmaCrossover {
+      constructor(symbols, fast = 10, slow = 20, size = 1.0) {
+        this.symbols = symbols;
+        this.fast = fast; this.slow = slow; this.size = size;
+        this.prices = []; this.prevAbove = false;
+      }
+      onTrade(ctx, trade, emit) {
+        this.prices.push(trade.price);
+        if (this.prices.length > this.slow) this.prices.shift();
+        if (this.prices.length < this.slow) return;
+        const fastSma = this.prices.slice(-this.fast).reduce((a,b)=>a+b)/this.fast;
+        const slowSma = this.prices.reduce((a,b)=>a+b)/this.slow;
+        const above = fastSma > slowSma;
+        if (above && !this.prevAbove && ctx.position === 0) emit.marketBuy(this.size);
+        else if (!above && this.prevAbove && ctx.position > 0) emit.marketSell(this.size);
+        this.prevAbove = above;
+      }
+    }
+    ```
+
+=== "Codon"
+
+    ```python
+    from flox.strategy import Strategy
+    from flox.context import SymbolContext
+    from flox.types import TradeData
+    from flox.indicators import StreamingSMA
+
+    class SmaCrossover(Strategy):
+        fast: StreamingSMA
+        slow: StreamingSMA
+        size: float
+        prev_above: bool
+
+        def __init__(self, symbols: List[int], fast_n: int = 10, slow_n: int = 20, size: float = 1.0):
+            super().__init__(symbols)
+            self.fast = StreamingSMA(fast_n)
+            self.slow = StreamingSMA(slow_n)
+            self.size = size
+            self.prev_above = False
+
+        def on_trade(self, ctx: SymbolContext, trade: TradeData):
+            f = self.fast.update(trade.price.to_double())
+            s = self.slow.update(trade.price.to_double())
+            if f is None or s is None:
+                return
+            above = f > s
+            if above and not self.prev_above and self.position() == 0.0:
+                self.market_buy(self.size)
+            elif not above and self.prev_above and self.position() > 0.0:
+                self.market_sell(self.size)
+            self.prev_above = above
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/strategy/strategy.h"
+    #include <deque>
+
+    using namespace flox;
+
+    class SmaCrossover : public Strategy {
+    public:
+      SmaCrossover(SymbolId symbol, size_t fast, size_t slow, Quantity size,
+                   const SymbolRegistry& registry)
+          : Strategy(1, symbol, registry), _fast(fast), _slow(slow), _size(size) {}
+
+      void start() override { _running = true; }
+      void stop() override  { _running = false; }
+
+    protected:
+      void onSymbolTrade(SymbolContext& /*ctx*/, const TradeEvent& ev) override
+      {
+        if (!_running) return;
+        _prices.push_back(ev.trade.price.toDouble());
+        if (_prices.size() > _slow) _prices.pop_front();
+        if (_prices.size() < _slow) return;
+
+        double fast_sma = sma(_fast), slow_sma = sma(_slow);
+        bool above = fast_sma > slow_sma;
+        if (above && !_prev_above && !_long) { emitMarketBuy(symbol(), _size); _long = true; _short = false; }
+        else if (!above && _prev_above && !_short) { emitMarketSell(symbol(), _size); _short = true; _long = false; }
+        _prev_above = above;
+      }
+
+    private:
+      double sma(size_t n) const {
+        double sum = 0; auto it = _prices.end();
+        for (size_t i = 0; i < n; ++i) sum += *--it;
+        return sum / n;
+      }
+      size_t _fast, _slow;
+      Quantity _size;
+      std::deque<double> _prices;
+      bool _running{false}, _prev_above{false}, _long{false}, _short{false};
+    };
+    ```
+
+## Run the backtest
+
+=== "Python"
+
+    ```python
+    reg = flox.SymbolRegistry()
+    btc = reg.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+
+    strat = SmaCrossover([btc])
+    bt = flox.BacktestRunner(reg, fee_rate=0.0004, initial_capital=10_000)
+    bt.set_strategy(strat)
+
+    stats = bt.run_csv("data/btcusdt_1m.csv", "BTCUSDT")
+    print(f"Final ${stats['final_capital']:.2f}  return {stats['return_pct']:.2f}%  "
+          f"trades {stats['total_trades']}  Sharpe {stats['sharpe']:.2f}  "
+          f"DD {stats['max_drawdown_pct']:.2f}%")
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const reg = new flox.SymbolRegistry();
+    const btc = reg.addSymbol("binance", "BTCUSDT", 0.01);
+
+    const strat = new SmaCrossover([btc]);
+    const bt = new flox.BacktestRunner(reg, 0.0004, 10000);
+    bt.setStrategy(strat);
+
+    const stats = bt.runCsv("data/btcusdt_1m.csv", "BTCUSDT");
+    console.log(`Final $${stats.finalCapital.toFixed(2)}  return ${stats.returnPct.toFixed(2)}%  ` +
+                `trades ${stats.totalTrades}  Sharpe ${stats.sharpeRatio.toFixed(2)}  ` +
+                `DD ${stats.maxDrawdownPct.toFixed(2)}%`);
+    ```
+
+=== "Codon"
+
+    ```python
+    from flox.runner import BacktestRunner
+
+    reg = ...                                # see flox.engine in your runner code
+    btc = reg.add_symbol("binance", "BTCUSDT", 0.01)
+
+    strat = SmaCrossover([btc])
+    bt = BacktestRunner(reg, fee_rate=0.0004, initial_capital=10_000.0)
+    bt.set_strategy(strat)
+    stats = bt.run_csv("data/btcusdt_1m.csv", "BTCUSDT")
+    print(f"Final ${stats.final_capital:.2f}  return {stats.return_pct:.2f}%")
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/backtest/backtest_runner.h"
+    #include "flox/replay/abstract_event_reader.h"
+
+    int main() {
+      replay::ReaderFilter filter;
+      filter.symbols = {1};
+      auto reader = replay::createMultiSegmentReader("/data/btcusdt", filter);
+
+      BacktestConfig config{ .initialCapital = 10000.0, .feeRate = 0.0004 };
+      BacktestRunner runner(config);
+
+      SymbolRegistry registry;
+      SymbolInfo info{ .exchange = "binance", .symbol = "BTCUSDT",
+                        .tickSize = Price::fromDouble(0.01) };
+      registry.registerSymbol(info);
+
+      SmaCrossover strat(1, 10, 20, Quantity::fromDouble(1.0), registry);
+      runner.setStrategy(&strat);
+
+      auto result = runner.run(*reader);
+      auto stats = result.computeStats();
+      std::cout << "Final " << stats.finalCapital
+                << "  return " << stats.returnPct << "%\n";
+    }
+    ```
+
+## Output
+
+```
+Final $10245.30  return 2.45%  trades 47  Sharpe 1.23  DD 3.21%
+```
+
+## Pre-aggregated bars (faster replay)
+
+For repeated parameter sweeps over the same data, pre-aggregate bars once and replay them. The Python and Node.js bindings expose this via `BacktestRunner.run_bars(...)` (closed OHLC bars), and C++ has dedicated mmap storage.
+
+=== "Python"
+
+    ```python
+    import numpy as np
+    bt.run_bars(
+        start_time_ns = ts_start_arr.astype(np.int64),
+        end_time_ns   = ts_end_arr.astype(np.int64),
+        open  = opens,  high = highs, low = lows, close = closes, volume = vols,
+        symbol = "BTCUSDT",
+    )
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    bt.runBars(startNs, endNs, opens, highs, lows, closes, vols, "BTCUSDT");
+    ```
+
+=== "C++"
+
+    Pre-aggregate offline with the `preagg_bars` tool, then replay via `MmapBarReplaySource`:
+
+    ```cpp
+    MmapBarStorage storage("/data/BTCUSDT/bars");
+    MmapBarReplaySource source(storage, symbol_id);
+    source.replay([&](const BarEvent& ev) { strat.onBar(ev); });
+    ```
+
+## See Also
+
+- [Grid Search Optimization](grid-search.md) — parameter optimization
+- [Bar Aggregation Pipeline](bar-aggregation.md) — pre-aggregating bars
+- [Interactive Mode](interactive-backtest.md) — step-by-step execution
+- [Realistic fills](backtest-realistic-fills.md) — slippage and queue position
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/backtest-realistic-fills.md
+# URL: https://flox-foundation.github.io/flox/how-to/backtest-realistic-fills/
+------------------------------------------------------------------------------
+
+# Realistic backtest fills
+
+Configure a backtest with realistic execution: slippage on market orders, queue simulation for limit orders, and an exported equity curve. Same model in every binding.
+
+## 1. Configure the simulator
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+
+    ex = flox.SimulatedExecutor()
+    ex.set_default_slippage("fixed_bps", bps=1.0)   # 1 bps default
+    ex.set_queue_model("tob")                       # top-of-book queue
+    # Per-symbol override:
+    ex.set_symbol_slippage(eth_usd, "volume_impact", impact_coeff=0.01)
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const ex = new flox.SimulatedExecutor();
+    ex.setDefaultSlippage("fixed_bps", 0, 0, 1.0, 0);    // ticks, tickSize, bps, impactCoeff
+    ex.setQueueModel("tob", 1);
+    ```
+
+=== "Codon"
+
+    ```python
+    from flox.backtest import SimulatedExecutor, SLIPPAGE_FIXED_BPS, QUEUE_TOB
+
+    ex = SimulatedExecutor()
+    ex.set_default_slippage(SLIPPAGE_FIXED_BPS, 0, 0.0, 1.0, 0.0)
+    ex.set_queue_model(QUEUE_TOB, 1)
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/backtest/backtest_config.h"
+    #include "flox/backtest/backtest_runner.h"
+
+    flox::BacktestConfig cfg;
+    cfg.initialCapital = 100'000.0;
+    cfg.feeRate = 0.0002;                                                                 // 2 bps per fill
+    cfg.defaultSlippage = { flox::SlippageModel::FIXED_BPS, 0, flox::Price{}, 1.0, 0.0 };  // 1 bps default
+    cfg.queueModel = flox::QueueModel::TOB;
+    cfg.riskFreeRate = 0.0;
+    cfg.metricsAnnualizationFactor = 252.0;
+
+    flox::BacktestRunner runner(cfg);
+
+    cfg.perSymbolSlippage.emplace_back(
+        kEthUsd, flox::SlippageProfile{flox::SlippageModel::VOLUME_IMPACT, 0, 0.0, 0.01});
+    ```
+
+## 2. Run it
+
+=== "Python"
+
+    ```python
+    bt = flox.BacktestRunner(reg, fee_rate=0.0002, initial_capital=100_000)
+    bt.set_strategy(my_strategy)
+    stats = bt.run_csv("data.csv", "BTCUSDT")
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const bt = new flox.BacktestRunner(reg, 0.0002, 100_000);
+    bt.setStrategy(myStrategy);
+    const stats = bt.runCsv("data.csv", "BTCUSDT");
+    ```
+
+=== "C++"
+
+    ```cpp
+    runner.setStrategy(&yourStrategy);
+    auto result = runner.run(*reader);   // reader: replay::IMultiSegmentReader
+    auto stats  = result.computeStats();
+    ```
+
+## 3. Inspect stats
+
+The same fields are returned by every binding (snake_case in Python/Codon, camelCase in Node, `BacktestStats` struct in C++).
+
+| Field | Description |
+|---|---|
+| `total_trades` / `totalTrades` | Number of closed trades |
+| `net_pnl` / `netPnl` | Total P&L net of fees |
+| `return_pct` / `returnPct` | Total return % |
+| `sharpe` / `sharpeRatio` | Annualised Sharpe |
+| `sortino` / `sortinoRatio` | Annualised Sortino |
+| `max_drawdown_pct` / `maxDrawdownPct` | Worst drawdown |
+| `win_rate` / `winRate` | Win rate |
+| `profit_factor` / `profitFactor` | Gross profit / gross loss |
+
+## 4. Export the equity curve
+
+=== "Python"
+
+    ```python
+    curve = bt.equity_curve()                  # structured numpy array
+    bt.write_equity_curve_csv("equity.csv")
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const curve = bt.equityCurve();
+    bt.writeEquityCurveCsv("equity.csv");
+    ```
+
+=== "C++"
+
+    ```cpp
+    for (const auto& pt : result.equityCurve()) {
+      fmt::print("{},{:.2f},{:.2f}\n", pt.timestampNs, pt.equity, pt.drawdownPct);
+    }
+    result.writeEquityCurveCsv("equity.csv");
+    ```
+
+CSV header: `timestamp_ns,equity,drawdown_pct`. One row per closed trade.
+
+## See also
+
+- [Backtesting](backtest.md)
+- [Slippage reference](../reference/api/backtest/slippage.md)
+- [Queue simulation](../reference/api/backtest/queue_simulation.md)
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/interactive-backtest.md
+# URL: https://flox-foundation.github.io/flox/how-to/interactive-backtest/
+------------------------------------------------------------------------------
+
+# Interactive Backtest Mode
+
+!!! info "C++ only"
+    Interactive mode (pause, step, breakpoints) is currently exposed only through the C++ `BacktestRunner` API. The Python and Node bindings run backtests synchronously to completion — for step-by-step debugging from those languages, drive your own loop with `Runner.on_trade(...)` and inspect state between calls. See the [Backtesting how-to](backtest.md) for the synchronous flow.
+
+`BacktestRunner` supports an interactive mode with step-by-step execution, pause, breakpoints, and state inspection. This is useful for debugging strategies and understanding market dynamics at specific points in time.
+
+## Quick Start
+
+```cpp
+#include "flox/backtest/backtest_runner.h"
+
+BacktestRunner runner;
+runner.setStrategy(&myStrategy);
+
+// Set callbacks for debugging
+runner.setEventCallback([](const replay::ReplayEvent& ev, const BacktestState& state) {
+  std::cout << "Event " << state.eventCount << " at " << state.currentTimeNs << "\n";
+});
+
+runner.setPauseCallback([](const BacktestState& state) {
+  std::cout << "Paused at event " << state.eventCount << "\n";
+});
+
+// Start in background thread (starts paused)
+std::thread t([&]() { runner.start(reader); });
+
+// Step through events one by one
+runner.step();  // Process 1 event
+runner.step();  // Process another
+
+// Run until breakpoint or end
+runner.resume();
+
+t.join();
+```
+
+## Two Modes
+
+`BacktestRunner` supports two execution modes:
+
+### Non-Interactive Mode
+
+Synchronous execution from start to end:
+
+```cpp
+BacktestRunner runner;
+runner.setStrategy(&myStrategy);
+
+// Blocks until complete
+BacktestResult result = runner.run(reader);
+```
+
+### Interactive Mode
+
+Async execution with pause/step control:
+
+```cpp
+BacktestRunner runner;
+runner.setStrategy(&myStrategy);
+
+// Start in background (begins paused)
+std::thread t([&]() { runner.start(reader); });
+
+// Control execution
+runner.step();    // One event
+runner.resume();  // Run until breakpoint/end
+runner.pause();   // Pause execution
+runner.stop();    // Stop completely
+
+t.join();
+```
+
+## Execution Commands
+
+### step()
+
+Execute exactly one event:
+
+```cpp
+runner.step();
+```
+
+### stepUntil(mode)
+
+Skip events until condition:
+
+```cpp
+// Skip book updates, pause on next trade
+runner.stepUntil(BacktestMode::StepTrade);
+```
+
+### resume()
+
+Run continuously until breakpoint or end:
+
+```cpp
+runner.resume();
+```
+
+### pause()
+
+Pause execution (can resume later):
+
+```cpp
+runner.pause();
+```
+
+### stop()
+
+Stop execution completely:
+
+```cpp
+runner.stop();
+```
+
+## Breakpoints
+
+### Time-based
+
+Pause at specific timestamp:
+
+```cpp
+runner.addBreakpoint(Breakpoint::atTime(1609459200000000000));  // Unix ns
+```
+
+### Event Count
+
+Pause after N events:
+
+```cpp
+runner.addBreakpoint(Breakpoint::afterEvents(1000));
+```
+
+### Trade Count
+
+Pause after N trades:
+
+```cpp
+runner.addBreakpoint(Breakpoint::afterTrades(100));
+```
+
+### Signal Breakpoint
+
+Pause when strategy emits a signal:
+
+```cpp
+runner.setBreakOnSignal(true);
+```
+
+### Custom Breakpoint
+
+Pause on custom condition:
+
+```cpp
+runner.addBreakpoint(Breakpoint::when([](const replay::ReplayEvent& ev) {
+  return ev.type == replay::EventType::Trade && ev.trade.price_raw > 50000'00000000;
+}));
+```
+
+### Clear Breakpoints
+
+```cpp
+runner.clearBreakpoints();
+```
+
+## State Inspection
+
+Check current backtest state at any time:
+
+```cpp
+BacktestState state = runner.state();
+
+std::cout << "Time: " << state.currentTimeNs << "\n"
+          << "Events: " << state.eventCount << "\n"
+          << "Trades: " << state.tradeCount << "\n"
+          << "Book updates: " << state.bookUpdateCount << "\n"
+          << "Signals: " << state.signalCount << "\n"
+          << "Running: " << state.isRunning << "\n"
+          << "Paused: " << state.isPaused << "\n"
+          << "Finished: " << state.isFinished << "\n";
+```
+
+Convenience methods:
+
+```cpp
+bool paused = runner.isPaused();
+bool done = runner.isFinished();
+```
+
+## Control Flow
+
+```mermaid
+stateDiagram-v2
+    [*] --> Paused : start()
+    Paused --> Processing : step()
+    Processing --> Paused : event processed
+    Paused --> Running : resume()
+    Running --> Paused : breakpoint hit
+    Running --> Paused : pause()
+    Running --> Finished : end of data
+    Paused --> Finished : stop()
+    Finished --> [*]
+```
+
+## Example: Debug Strategy
+
+```cpp
+class DebugStrategy : public Strategy {
+  void onTrade(const TradeEvent& ev) override {
+    if (shouldBuy(ev)) {
+      emitMarketBuy(ev.trade.symbol, Quantity::fromDouble(1.0));
+    }
+  }
+};
+
+int main() {
+  auto reader = replay::createMultiSegmentReader("./data");
+
+  DebugStrategy strategy;
+  BacktestRunner runner;
+  runner.setStrategy(&strategy);
+
+  // Break when signal is emitted
+  runner.setBreakOnSignal(true);
+
+  std::thread t([&]() { runner.start(*reader); });
+
+  // Run until first signal
+  runner.resume();
+
+  // Inspect state when signal was emitted
+  auto state = runner.state();
+  std::cout << "Signal emitted at trade #" << state.tradeCount << "\n";
+  std::cout << "Time: " << state.currentTimeNs << "\n";
+
+  // Continue running
+  runner.resume();
+
+  t.join();
+
+  // Get results
+  auto result = runner.result();
+  auto stats = result.computeStats();
+  std::cout << "Total trades: " << stats.totalTrades << "\n";
+}
+```
+
+## Thread Safety
+
+- `start()` must be called from a separate thread (it blocks until completion)
+- `step()`, `resume()`, `pause()`, `stop()` can be called from any thread
+- `state()` returns a snapshot, safe to call anytime
+- Callbacks are invoked from the runner thread
+
+## See Also
+
+- [BacktestRunner](../reference/api/backtest/backtest_runner.md) — API reference
+- [SimulatedExecutor](../reference/api/backtest/simulated_executor.md) — Order execution simulation
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/grid-search.md
+# URL: https://flox-foundation.github.io/flox/how-to/grid-search/
+------------------------------------------------------------------------------
+
+# Parameter optimization with grid search
+
+Find good strategy parameters by sweeping a grid and ranking results. The pattern is the same in every binding: define a grid, run a backtest per combination, rank by your chosen metric.
+
+## Quick start
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+    import pandas as pd
+
+    def run_one(fast: int, slow: int) -> dict:
+        reg = flox.SymbolRegistry()
+        btc = reg.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+        strat = SmaCrossover([btc], fast=fast, slow=slow)
+        bt = flox.BacktestRunner(reg, fee_rate=0.0004, initial_capital=10_000)
+        bt.set_strategy(strat)
+        return bt.run_csv("data/btcusdt_1m.csv", "BTCUSDT")
+
+    rows = []
+    for fast in [5, 10, 15, 20]:
+        for slow in [20, 30, 40, 50]:
+            if fast >= slow:
+                continue
+            stats = run_one(fast, slow)
+            rows.append({"fast": fast, "slow": slow, **stats})
+
+    df = pd.DataFrame(rows).sort_values("sharpe", ascending=False)
+    print(df.head())
+    df.to_csv("grid_results.csv", index=False)
+    ```
+
+    For parallelism, wrap `run_one` in `multiprocessing.Pool` or `concurrent.futures.ProcessPoolExecutor`. FLOX releases the GIL during the C++ backtest, so threads work too.
+
+=== "Node.js"
+
+    ```javascript
+    const flox = require('@flox-foundation/flox');
+
+    function runOne(fast, slow) {
+      const reg = new flox.SymbolRegistry();
+      const btc = reg.addSymbol("binance", "BTCUSDT", 0.01);
+      const strat = new SmaCrossover([btc], fast, slow);
+      const bt = new flox.BacktestRunner(reg, 0.0004, 10_000);
+      bt.setStrategy(strat);
+      return bt.runCsv("data/btcusdt_1m.csv", "BTCUSDT");
+    }
+
+    const rows = [];
+    for (const fast of [5, 10, 15, 20]) {
+      for (const slow of [20, 30, 40, 50]) {
+        if (fast >= slow) continue;
+        rows.push({ fast, slow, ...runOne(fast, slow) });
+      }
+    }
+    rows.sort((a, b) => b.sharpeRatio - a.sharpeRatio);
+    console.log(rows.slice(0, 5));
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/backtest/backtest_optimizer.h"
+    #include "flox/backtest/optimization_stats.h"
+
+    struct MAParams {
+      int fastPeriod, slowPeriod;
+      std::string toString() const {
+        return "fast=" + std::to_string(fastPeriod) + ",slow=" + std::to_string(slowPeriod);
+      }
+    };
+
+    struct MAGrid {
+      std::vector<int> fastPeriods = {5, 10, 15, 20};
+      std::vector<int> slowPeriods = {20, 30, 40, 50};
+      size_t totalCombinations() const { return fastPeriods.size() * slowPeriods.size(); }
+      MAParams operator[](size_t i) const {
+        return { fastPeriods[i / slowPeriods.size()], slowPeriods[i % slowPeriods.size()] };
+      }
+    };
+
+    BacktestOptimizer<MAParams, MAGrid> optimizer;
+    optimizer.setParameterGrid(MAGrid{});
+    optimizer.setBacktestFactory([&](const MAParams& p) { return runBacktest(p); });
+    auto results = optimizer.runLocal();
+    auto ranked  = BacktestOptimizer<MAParams, MAGrid>::rankResults(results, RankMetric::SharpeRatio);
+    std::cout << "Best: " << ranked[0].parameters.toString() << "\n";
+    ```
+
+The C++ optimizer parallelises across threads automatically (`runLocal(numThreads)`).
+
+## Ranking metrics
+
+| Metric | Python (in stats dict) | C++ (`RankMetric::*`) |
+|---|---|---|
+| Sharpe | `sharpe` / `sharpeRatio` | `SharpeRatio` |
+| Sortino | `sortino` | `SortinoRatio` |
+| Calmar | n/a (compute as `return / max_dd`) | `CalmarRatio` |
+| Total return | `return_pct` | `TotalReturn` |
+| Max drawdown | `max_drawdown_pct` | `MaxDrawdown` |
+| Win rate | `win_rate` | `WinRate` |
+| Profit factor | `profit_factor` | `ProfitFactor` |
+
+## Filtering, stability, statistical tests
+
+The C++ `BacktestOptimizer` ships ranking, filtering, bootstrap CIs, and permutation tests as templated utilities (see [`optimization_stats.h`](../reference/api/backtest/optimization_stats.md)). From Python / Node.js you use `pandas` / `numpy` / `scipy` directly:
+
+=== "Python"
+
+    ```python
+    import numpy as np
+    from scipy import stats
+
+    sharpes = df["sharpe"].values
+    returns = df["return_pct"].values
+    print("mean Sharpe:", sharpes.mean(), " std:", sharpes.std())
+    print("corr(Sharpe, return):", np.corrcoef(sharpes, returns)[0, 1])
+
+    # Bootstrap 95% CI for mean Sharpe
+    boot = [np.random.choice(sharpes, size=len(sharpes), replace=True).mean() for _ in range(10_000)]
+    print("CI:", np.percentile(boot, [2.5, 97.5]))
+
+    # Permutation test: top-10 vs bottom-10
+    top, bot = np.sort(sharpes)[-10:], np.sort(sharpes)[:10]
+    perm = stats.permutation_test((top, bot), lambda a, b: a.mean() - b.mean(),
+                                    n_resamples=10_000, alternative="greater")
+    print("p =", perm.pvalue)
+    ```
+
+=== "C++"
+
+    ```cpp
+    using Stats = OptimizationStatistics<MAParams, MAGrid>;
+    Stats::printSummary(results);
+    auto sharpes = extractMetric(results, RankMetric::SharpeRatio);
+    auto ci      = Stats::bootstrapCI(sharpes, 0.95, 10000);     // .lower / .median / .upper
+    auto pValue  = Stats::permutationTest(group1, group2, 10000);
+    Stats::generateReport(results, "report.md");
+    ```
+
+## Best practices
+
+1. **Avoid overfitting** — every extra parameter increases overfit risk
+2. **Walk-forward** — optimise on train, validate on a held-out test slice
+3. **Parameter stability** — the best point should have good neighbours, not be an isolated peak
+4. **Realistic costs** — include slippage and exchange fees
+5. **Statistical significance** — bootstrap CI / permutation tests separate luck from edge
+
+## See also
+
+- [Backtesting](./backtest.md)
+- [Optimization stats reference (C++)](../reference/api/backtest/optimization_stats.md)
+- [Python optimizer reference](../reference/python/optimizer.md)
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/advanced-orders.md
+# URL: https://flox-foundation.github.io/flox/how-to/advanced-orders/
+------------------------------------------------------------------------------
+
+# Advanced orders
+
+Stop orders, take-profit, trailing stops, OCO, and execution flags. Every order type below is exposed through every binding — only the method name differs.
+
+## Order types
+
+| Type | Use case |
+|------|----------|
+| `STOP_MARKET` | Stop loss, breakout entry |
+| `STOP_LIMIT` | Stop with price control |
+| `TAKE_PROFIT_MARKET` | Lock in profits |
+| `TAKE_PROFIT_LIMIT` | Lock in profits with price control |
+| `TRAILING_STOP` | Dynamic stop that follows price |
+| `OCO` | One-cancels-other for breakouts |
+
+## Stop orders
+
+Stop trigger logic: SELL stop fires when `price <= trigger`; BUY stop fires when `price >= trigger`.
+
+=== "Python"
+
+    ```python
+    # Stop market: stop loss for a long
+    self.stop_market(side="sell", trigger=95.0, qty=qty)
+
+    # Stop limit
+    self.stop_limit(side="sell", trigger=95.0, limit_price=94.5, qty=qty)
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    emit.stopMarket("sell", 95.0, qty);
+    emit.stopLimit("sell", 95.0, 94.5, qty);
+    ```
+
+=== "Codon"
+
+    ```python
+    self.stop_market("sell", 95.0, qty)
+    self.stop_limit("sell", 95.0, 94.5, qty)
+    ```
+
+=== "C++"
+
+    ```cpp
+    emitStopMarket(symbol, Side::SELL, Price::fromDouble(95.0), qty);
+    emitStopLimit (symbol, Side::SELL, Price::fromDouble(95.0),
+                                       Price::fromDouble(94.5), qty);
+    ```
+
+## Take-profit orders
+
+SELL TP fires when `price >= trigger` (lock profit on a long); BUY TP fires when `price <= trigger`.
+
+=== "Python"
+
+    ```python
+    self.take_profit_market(side="sell", trigger=110.0, qty=qty)
+    self.take_profit_limit (side="sell", trigger=110.0, limit_price=109.5, qty=qty)
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    emit.takeProfitMarket("sell", 110.0, qty);
+    emit.takeProfitLimit ("sell", 110.0, 109.5, qty);
+    ```
+
+=== "Codon"
+
+    ```python
+    self.take_profit_market("sell", 110.0, qty)
+    self.take_profit_limit ("sell", 110.0, 109.5, qty)
+    ```
+
+=== "C++"
+
+    ```cpp
+    emitTakeProfitMarket(symbol, Side::SELL, Price::fromDouble(110.0), qty);
+    emitTakeProfitLimit (symbol, Side::SELL,
+                          Price::fromDouble(110.0), Price::fromDouble(109.5), qty);
+    ```
+
+## Trailing stops
+
+SELL trailing trigger follows price up; when price drops to trigger, the order executes.
+
+=== "Python"
+
+    ```python
+    # Fixed-offset trailing stop (5.0 below price)
+    self.trailing_stop(side="sell", offset=5.0, qty=qty)
+
+    # Percentage trailing stop (2% = 200 bps)
+    self.trailing_stop_percent(side="sell", callback_bps=200, qty=qty)
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    emit.trailingStop("sell", 5.0, qty);
+    emit.trailingStopPercent("sell", 200, qty);   // 200 bps = 2%
+    ```
+
+=== "Codon"
+
+    ```python
+    self.trailing_stop("sell", 5.0, qty)
+    self.trailing_stop_percent("sell", 200, qty)
+    ```
+
+=== "C++"
+
+    ```cpp
+    emitTrailingStop       (symbol, Side::SELL, Price::fromDouble(5.0), qty);
+    emitTrailingStopPercent(symbol, Side::SELL, /*callback_bps=*/200,   qty);
+    ```
+
+## Time-in-force
+
+`IOC` (immediate-or-cancel), `FOK` (fill-or-kill), `POST_ONLY` (maker-only — reject if would cross spread).
+
+=== "Python"
+
+    ```python
+    self.limit_buy(price, qty, tif="ioc")
+    self.limit_buy(price, qty, tif="fok")
+    self.limit_buy(price, qty, tif="post_only")
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    emit.limitBuy(price, qty, /*tif=*/ "IOC");
+    emit.limitBuy(price, qty, /*tif=*/ "FOK");
+    emit.limitBuy(price, qty, /*tif=*/ "POST_ONLY");
+    ```
+
+=== "Codon"
+
+    ```python
+    self.limit_buy(price, qty, tif="ioc")
+    self.limit_buy(price, qty, tif="fok")
+    self.limit_buy(price, qty, tif="post_only")
+    ```
+
+=== "C++"
+
+    ```cpp
+    emitLimitBuy(symbol, price, qty, TimeInForce::IOC);
+    emitLimitBuy(symbol, price, qty, TimeInForce::FOK);
+    emitLimitBuy(symbol, price, qty, TimeInForce::POST_ONLY);
+    ```
+
+`POST_ONLY` orders that would cross the book are rejected at submit time (matches real-exchange behaviour, including in `BacktestRunner` since [#124](https://github.com/FLOX-Foundation/flox/pull/124)).
+
+## Close current position
+
+`close_position` issues a reduce-only market order sized to flatten the existing position.
+
+=== "Python"
+
+    ```python
+    self.close_position()         # primary symbol
+    self.close_position("BTCUSDT")
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    emit.closePosition();
+    emit.closePosition("BTCUSDT");
+    ```
+
+=== "Codon"
+
+    ```python
+    self.close_position()
+    ```
+
+=== "C++"
+
+    ```cpp
+    emitClosePosition(symbol);
+    ```
+
+## Manual TP/SL bracket
+
+A common pattern: on entry-fill, place TP and SL; cancel one when the other fills.
+
+=== "Python"
+
+    ```python
+    def on_order_filled(self, order):
+        if order.id == self.entry_id:
+            entry = order.price
+            self.tp_id = self.take_profit_market("sell", trigger=entry * 1.06, qty=order.quantity)
+            self.sl_id = self.stop_market       ("sell", trigger=entry * 0.98, qty=order.quantity)
+        elif order.id == self.tp_id:
+            self.cancel_order(self.sl_id)
+        elif order.id == self.sl_id:
+            self.cancel_order(self.tp_id)
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    onOrderFilled(order, emit) {
+      if (order.id === this.entryId) {
+        const entry = order.price;
+        this.tpId = emit.takeProfitMarket("sell", entry * 1.06, order.quantity);
+        this.slId = emit.stopMarket       ("sell", entry * 0.98, order.quantity);
+      } else if (order.id === this.tpId) {
+        emit.cancel(this.slId);
+      } else if (order.id === this.slId) {
+        emit.cancel(this.tpId);
+      }
+    }
+    ```
+
+=== "C++"
+
+    ```cpp
+    void onOrderFilled(const Order& order) {
+      if (order.id == _entryId) {
+        auto entry = order.price.toDouble();
+        _tpId = emitTakeProfitMarket(order.symbol, Side::SELL,
+                                      Price::fromDouble(entry * 1.06), order.quantity);
+        _slId = emitStopMarket      (order.symbol, Side::SELL,
+                                      Price::fromDouble(entry * 0.98), order.quantity);
+      } else if (order.id == _tpId) {
+        emitCancel(_slId);
+      } else if (order.id == _slId) {
+        emitCancel(_tpId);
+      }
+    }
+    ```
+
+## Checking exchange capabilities
+
+Real exchanges support different subsets of order types. Before using an advanced feature in live trading, ask the executor what it supports.
+
+=== "C++"
+
+    ```cpp
+    auto caps = engine().executor().capabilities();
+    bool hasTrailing = caps.supports(OrderType::TRAILING_STOP);
+    bool hasOCO      = caps.supportsOCO;
+    ```
+
+=== "Python / Node.js / Codon"
+
+    Capabilities introspection isn't yet exposed in the binding APIs — check the [exchange's connector source](../bindings/README.md) or fall back to manual TP/SL.
+
+## See also
+
+- [Order Types reference](../reference/api/common.md)
+- [Time-In-Force](../reference/api/common.md)
+- [Order structure](../reference/api/execution/order.md)
+- [Exchange capabilities](../reference/api/execution/exchange_capabilities.md)
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/multi-exchange-trading.md
+# URL: https://flox-foundation.github.io/flox/how-to/multi-exchange-trading/
+------------------------------------------------------------------------------
+
+# Multi-Exchange Trading
+
+!!! info "C++ CEX layer"
+    Multi-exchange aggregation, clock sync, and smart routing live in the C++ CEX coordination layer (`CompositeBookMatrix`, `ExchangeClockSync`, `OrderRouter`). Bindings can subscribe to a single exchange today; cross-venue routing is built in the C++ engine. See [CEX reference](../reference/api/cex/index.md).
+
+Set up trading across multiple exchanges with position aggregation and smart routing.
+
+## Prerequisites
+
+- Multiple exchange connectors configured
+- SymbolRegistry with registered exchanges
+
+## 1. Register Exchanges and Symbols
+
+```cpp
+#include "flox/engine/symbol_registry.h"
+
+SymbolRegistry registry;
+
+// Register exchanges
+ExchangeId binance = registry.registerExchange("Binance");
+ExchangeId bybit = registry.registerExchange("Bybit");
+ExchangeId kraken = registry.registerExchange("Kraken");
+
+// Register symbols per exchange
+SymbolId btcBinance = registry.registerSymbol(binance, "BTCUSDT");
+SymbolId btcBybit = registry.registerSymbol(bybit, "BTCUSDT");
+SymbolId btcKraken = registry.registerSymbol(kraken, "XBTUSDT");
+
+// Map equivalent symbols
+std::array<SymbolId, 3> btcSymbols = {btcBinance, btcBybit, btcKraken};
+registry.mapEquivalentSymbols(btcSymbols);
+```
+
+## 2. Set Up Clock Synchronization
+
+```cpp
+#include "flox/util/sync/exchange_clock_sync.h"
+
+ExchangeClockSync<8> clockSync;
+
+// Record timing samples from API calls
+void onApiResponse(ExchangeId ex, int64_t localSend, int64_t serverTime, int64_t localRecv)
+{
+  clockSync.recordSample(ex, localSend, serverTime, localRecv);
+}
+
+// Convert exchange timestamp to local time
+int64_t localTs = clockSync.toLocalTimeNs(binance, exchangeTimestamp);
+
+// Check sync quality
+if (clockSync.hasReliableSync(binance)) {
+  auto est = clockSync.estimate(binance);
+  // est.offsetNs, est.latencyNs, est.confidenceNs
+}
+```
+
+## 3. Aggregate Order Books
+
+```cpp
+#include "flox/book/composite_book_matrix.h"
+
+CompositeBookMatrix<4> books;
+
+// Subscribe to BookUpdateEvents from all exchanges
+// The matrix updates atomically on each event
+
+// Query best prices (thread-safe, lock-free)
+auto bestBid = books.bestBid(btcBinance);  // Best bid across all exchanges
+auto bestAsk = books.bestAsk(btcBinance);  // Best ask across all exchanges
+
+if (bestBid.valid && bestAsk.valid) {
+  int64_t spread = bestAsk.priceRaw - bestBid.priceRaw;
+  // bestBid.exchange, bestAsk.exchange tell you where
+}
+
+// Check for arbitrage
+if (books.hasArbitrageOpportunity(btcBinance)) {
+  // bestBid.priceRaw > bestAsk.priceRaw across different exchanges
+}
+```
+
+## 4. Track Positions
+
+```cpp
+#include "flox/position/aggregated_position_tracker.h"
+
+AggregatedPositionTracker<8> positions;
+
+// Update on fills (writer thread)
+positions.onFill(binance, btcBinance,
+    Quantity::fromDouble(1.0).raw(),      // Buy 1 BTC
+    Price::fromDouble(50000.0).raw());    // @ $50,000
+
+positions.onFill(bybit, btcBybit,
+    Quantity::fromDouble(-0.3).raw(),     // Sell 0.3 BTC
+    Price::fromDouble(50100.0).raw());    // @ $50,100
+
+// Query positions (reader thread, lock-free)
+auto binancePos = positions.position(binance, btcBinance);
+auto totalPos = positions.totalPosition(btcBinance);  // Aggregated across exchanges
+
+Price currentPrice = Price::fromDouble(50200.0);
+int64_t pnlRaw = positions.unrealizedPnlRaw(btcBinance, currentPrice.raw());
+double pnl = Price::fromRaw(pnlRaw).toDouble();  // Convert to readable value
+```
+
+## 5. Configure Order Routing
+
+```cpp
+#include "flox/execution/order_router.h"
+
+OrderRouter<4> router;
+
+// Register executors
+router.registerExecutor(binance, &binanceExecutor);
+router.registerExecutor(bybit, &bybitExecutor);
+router.registerExecutor(kraken, &krakenExecutor);
+
+// Configure strategy
+router.setCompositeBook(&books);
+router.setClockSync(&clockSync);
+router.setRoutingStrategy(RoutingStrategy::BestPrice);
+router.setFailoverPolicy(FailoverPolicy::FailoverToBest);
+
+// Route orders
+ExchangeId routed;
+auto err = router.route(btcBinance, Side::BUY, priceRaw, qtyRaw, orderId, &routed);
+
+if (err == RoutingError::Success) {
+  // Order sent to 'routed' exchange
+}
+
+// Or route explicitly
+router.routeTo(binance, btcBinance, Side::BUY, priceRaw, qtyRaw, orderId);
+```
+
+## 6. Track Split Orders
+
+```cpp
+#include "flox/execution/split_order_tracker.h"
+
+SplitOrderTracker tracker;
+
+// Split parent order across exchanges
+OrderId parentId = 1000;
+std::array<OrderId, 3> childIds = {1001, 1002, 1003};
+Quantity totalQty = Quantity::fromDouble(10.0);  // 10 BTC total
+
+tracker.registerSplit(parentId, childIds, totalQty.raw(), nowNs);
+
+// Update on child events
+tracker.onChildFill(1001, Quantity::fromDouble(4.0).raw());  // 4 BTC filled
+tracker.onChildComplete(1001, true);
+
+// Check status
+auto* state = tracker.getState(parentId);
+double fillRatio = state->fillRatio();  // 0.4
+bool done = state->allDone();
+```
+
+## Routing Strategies
+
+| Strategy | Description | Use Case |
+|----------|-------------|----------|
+| `BestPrice` | Route to exchange with best price | Default, maximize fill price |
+| `LowestLatency` | Route to exchange with lowest RTT | Time-sensitive orders |
+| `LargestSize` | Route to exchange with most liquidity | Large orders |
+| `RoundRobin` | Distribute evenly | Load balancing |
+| `Explicit` | Use order's target exchange | Manual control |
+
+## Error Handling
+
+```cpp
+auto err = router.route(symbol, side, price, qty, orderId);
+
+switch (err) {
+  case RoutingError::Success:
+    break;
+  case RoutingError::NoExecutor:
+    // No executor registered or all disabled
+    break;
+  case RoutingError::ExchangeDisabled:
+    // Target exchange temporarily disabled
+    break;
+  case RoutingError::InvalidSymbol:
+    // Symbol not found
+    break;
+}
+```
+
+## See Also
+
+- [CEX Components](../reference/api/cex/index.md)
+- [Custom Connector](custom-connector.md)
+- [Backtest Guide](backtest.md)
+
+==============================================================================
+# Section: How-to: indicators and aggregation
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/indicator-graph.md
+# URL: https://flox-foundation.github.io/flox/how-to/indicator-graph/
+------------------------------------------------------------------------------
+
+# Indicator graph
+
+When multiple strategies use the same indicator (e.g. ATR used by both ADX and a normalised slope), `IndicatorGraph` computes it once and caches the result. Available in C++, Python, and Node.js.
+
+## Concept
+
+You define **nodes** by name. Each node has a list of upstream dependencies and a compute function. `require()` resolves the DAG, computes only what's needed, and caches the result. `invalidate()` clears the cache when new data arrives.
+
+The graph is per-symbol; different symbols have independent caches.
+
+## Setup
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+
+    g = flox.IndicatorGraph()
+    g.set_bars(symbol_id, bars)   # bars is a structured numpy array
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const flox = require('@flox-foundation/flox');
+    const g = new flox.IndicatorGraph();
+    g.setBars(symbolId, bars);
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/indicator/indicator_pipeline.h"
+    #include "flox/indicator/{ema,atr,slope}.h"
+
+    using namespace flox::indicator;
+    IndicatorGraph g;
+    g.setBars(symbolId, bars);
+    ```
+
+## Registering nodes
+
+=== "Python"
+
+    ```python
+    g.add_node("atr14", deps=[],
+               factory=lambda: flox.ATR(14))            # uses bar high/low/close
+
+    g.add_node("ema50", deps=[],
+               factory=lambda: flox.EMA(50))            # uses bar close
+
+    # Compute "norm_slope" from ema50 and atr14
+    def norm_slope(ema, atr):
+        slope = flox.Slope(1).compute(ema)
+        out = slope / atr            # numpy element-wise; NaN-safe
+        out[atr <= 0] = 0
+        return out
+
+    g.add_node("norm_slope", deps=["ema50", "atr14"], factory=norm_slope)
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    g.addNode("atr14", { source: "ohlc" }, () => new flox.ATR(14));
+    g.addNode("ema50", { source: "close" }, () => new flox.EMA(50));
+    g.addNode("normSlope", { deps: ["ema50", "atr14"] }, ({ ema50, atr14 }) => {
+      const slope = new flox.Slope(1).compute(ema50);
+      return slope.map((s, i) => (atr14[i] > 0 ? s / atr14[i] : 0));
+    });
+    ```
+
+=== "C++"
+
+    ```cpp
+    g.addNode("atr14", {}, [](IndicatorGraph& g, SymbolId sym) {
+        return ATR(14).compute(g.high(sym), g.low(sym), g.close(sym));
+    });
+
+    g.addNode("ema50", {}, [](IndicatorGraph& g, SymbolId sym) {
+        return EMA(50).compute(g.close(sym));
+    });
+
+    g.addNode("norm_slope", {"ema50", "atr14"}, [](IndicatorGraph& g, SymbolId sym) {
+        auto& ema = *g.get(sym, "ema50");
+        auto& atr = *g.get(sym, "atr14");
+        auto slope = Slope(1).compute(ema);
+        std::vector<double> out(slope.size());
+        for (size_t i = 0; i < slope.size(); ++i)
+          out[i] = (atr[i] > 0 && !std::isnan(slope[i])) ? slope[i] / atr[i] : 0.0;
+        return out;
+    });
+    ```
+
+## Computing
+
+`require()` resolves dependencies recursively and only computes what's needed. Already-computed nodes are returned from cache. Circular dependencies are detected and raise an error.
+
+=== "Python"
+
+    ```python
+    out = g.require(symbol_id, "norm_slope")    # ema50 + atr14 computed first
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const out = g.require(symbolId, "normSlope");
+    ```
+
+=== "C++"
+
+    ```cpp
+    auto& result = g.require(symbolId, "norm_slope");
+    ```
+
+## Invalidation
+
+When new data arrives, call `set_bars` (or `invalidate`) and the next `require()` recomputes from scratch.
+
+=== "Python"
+
+    ```python
+    g.set_bars(symbol_id, new_bars)
+    ```
+
+=== "C++"
+
+    ```cpp
+    g.setBars(symbolId, newBars);
+    ```
+
+## Multi-symbol
+
+The graph is per-symbol. Each symbol has its own cache; different symbols are independent.
+
+=== "Python"
+
+    ```python
+    g.set_bars(0, btc_bars)
+    g.set_bars(1, eth_bars)
+    btc_slope = g.require(0, "norm_slope")
+    eth_slope = g.require(1, "norm_slope")
+    ```
+
+=== "C++"
+
+    ```cpp
+    g.setBars(0, btcBars);
+    g.setBars(1, ethBars);
+    auto& btcSlope = g.require(0, "norm_slope");
+    auto& ethSlope = g.require(1, "norm_slope");
+    ```
+
+See also: [Multi-symbol indicators](multi-symbol-indicators.md).
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/multi-symbol-indicators.md
+# URL: https://flox-foundation.github.io/flox/how-to/multi-symbol-indicators/
+------------------------------------------------------------------------------
+
+# Multi-symbol indicators
+
+Run the same indicator pipeline across multiple symbols. The C++ engine ships a built-in helper for parallel execution; from Python and Node.js, group your data per symbol and either iterate or use a process pool.
+
+## Partition by symbol
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+
+    # Either group manually...
+    by_sym = {}
+    for ev in bar_events:
+        by_sym.setdefault(ev.symbol, []).append(ev)
+
+    # ...or rely on numpy structured arrays already grouped
+    btc_bars = bars[bars["symbol"] == 1]
+    eth_bars = bars[bars["symbol"] == 2]
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const bySym = new Map();
+    for (const ev of barEvents) {
+      if (!bySym.has(ev.symbol)) bySym.set(ev.symbol, []);
+      bySym.get(ev.symbol).push(ev);
+    }
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/indicator/multi_symbol.h"
+    using namespace flox::indicator;
+
+    // from BarEvents (each carries a symbol ID)
+    auto data = partitionBySymbol(barEvents);
+
+    // or from parallel arrays
+    auto data = partitionBySymbol(bars, symbolIds);
+    ```
+
+## Sequential iteration
+
+=== "Python"
+
+    ```python
+    for sym_id, bars in by_sym.items():
+        ema = flox.EMA(50).compute(np.array([b.close for b in bars]))
+        # ...
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    for (const [sym, bars] of bySym) {
+      const closes = Float64Array.from(bars.map(b => b.close));
+      const ema = new flox.EMA(50).compute(closes);
+      // ...
+    }
+    ```
+
+=== "C++"
+
+    ```cpp
+    forEachSymbol(data, [](SymbolId sym, std::span<const Bar> bars) {
+        auto ema = EMA(50).compute(indicator::close(bars));
+        // ...
+    });
+    ```
+
+## Parallel execution
+
+Indicator compute releases the GIL in Python, so threads/processes give real speedup.
+
+=== "Python"
+
+    ```python
+    from concurrent.futures import ProcessPoolExecutor
+
+    def compute_one(sym_id_and_bars):
+        sym_id, bars = sym_id_and_bars
+        return sym_id, flox.EMA(50).compute(np.array([b.close for b in bars]))
+
+    with ProcessPoolExecutor() as pool:
+        results = dict(pool.map(compute_one, by_sym.items()))
+    ```
+
+=== "Node.js"
+
+    Use [`worker_threads`](https://nodejs.org/api/worker_threads.html) or a tool like `piscina` to fan-out per symbol.
+
+=== "C++"
+
+    ```cpp
+    forEachSymbolParallel(data,
+        [](SymbolId sym, std::span<const Bar> bars) {
+            auto ema = EMA(50).compute(indicator::close(bars));
+            // ...
+        },
+        /*threads=*/0);   // 0 = all cores
+    ```
+
+The function passed in must be thread-safe (no shared mutable state). C++ uses an internal pool; Python uses processes (real parallelism without the GIL).
+
+## See also
+
+- [Indicator graph](indicator-graph.md) — caching shared computations across nodes
+- [Bar aggregation](bar-aggregation.md) — preparing the bars themselves
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/bar-aggregation.md
+# URL: https://flox-foundation.github.io/flox/how-to/bar-aggregation/
+------------------------------------------------------------------------------
+
+# Bar aggregation pipeline
+
+Get from raw market data to bars you can backtest against. The pipeline has three stages — record, aggregate, replay — and each is reachable from every binding.
+
+```mermaid
+flowchart TB
+    subgraph Recording
+        RD[Raw data<br/>trades / books] --> BLW[Binary log writer]
+        BLW --> FLX[.floxlog files]
+    end
+
+    subgraph Aggregation
+        FLX --> BA[Bar aggregator<br/>+ preagg_bars tool]
+        BA --> MBW[Mmap bar writer]
+        MBW --> MBS[Mmap bar storage]
+    end
+
+    subgraph Backtesting
+        MBS --> MBRS[Bar replay source]
+        MBRS --> STR[Your strategy]
+    end
+```
+
+## 1. Record raw data
+
+Most users record from a live connector. The Python recorder writes the same `.floxlog` format as the C++ writer.
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+
+    rec = flox.MarketDataRecorder(output_dir="/data/bybit/BTCUSDT",
+                                   max_segment_bytes=256 << 20)
+    # Feed trades / book updates from your connector
+    rec.write_trade(trade_record)
+    rec.write_book(book_header, bids, asks)
+    rec.close()
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const rec = new flox.MarketDataRecorder({
+      outputDir: "/data/bybit/BTCUSDT",
+      maxSegmentBytes: 256 << 20,
+    });
+    rec.writeTrade(tradeRecord);
+    rec.writeBook(bookHeader, bids, asks);
+    rec.close();
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/replay/writers/binary_log_writer.h"
+
+    replay::WriterConfig config;
+    config.output_dir = "/data/bybit/BTCUSDT";
+    config.max_segment_bytes = 256 << 20;
+    replay::BinaryLogWriter writer(config);
+
+    writer.writeTrade(tradeRecord);
+    writer.writeBook(bookHeader, bids, asks);
+    writer.close();
+    ```
+
+## 2. Pre-aggregate bars (offline)
+
+Run `preagg_bars` once per dataset; it writes one bar file per timeframe.
+
+```bash
+cmake -B build -DFLOX_ENABLE_TOOLS=ON -DFLOX_ENABLE_BACKTEST=ON
+cmake --build build
+
+./build/tools/preagg_bars /data/bybit/BTCUSDT /data/bybit/BTCUSDT/bars 60 300 900 3600
+# bars_60s.bin   (1m)
+# bars_300s.bin  (5m)
+# bars_900s.bin  (15m)
+# bars_3600s.bin (1h)
+```
+
+Same tool for every binding — it's a standalone CLI binary.
+
+## 3. Load bars for backtesting
+
+=== "Python"
+
+    Bars come back as a structured numpy array. Pass directly to `BacktestRunner.run_bars(...)`:
+
+    ```python
+    storage = flox.MmapBarStorage("/data/bybit/BTCUSDT/bars")
+    bars = storage.bars(timeframe_ns=60 * 1_000_000_000)   # 1-minute bars
+
+    bt.run_bars(
+        start_time_ns = bars["start_time_ns"],
+        end_time_ns   = bars["end_time_ns"],
+        open  = bars["open"],   high = bars["high"],
+        low   = bars["low"],    close = bars["close"],
+        volume = bars["volume"],
+        symbol = "BTCUSDT",
+    )
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const storage = new flox.MmapBarStorage("/data/bybit/BTCUSDT/bars");
+    const bars = storage.bars(60n * 1_000_000_000n);
+    bt.runBars(bars.startTimeNs, bars.endTimeNs,
+                bars.open, bars.high, bars.low, bars.close, bars.volume,
+                "BTCUSDT");
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/backtest/mmap_bar_storage.h"
+    #include "flox/backtest/mmap_bar_replay_source.h"
+
+    MmapBarStorage storage("/data/bybit/BTCUSDT/bars");
+    auto tf = TimeframeId::time(std::chrono::seconds(60));
+    auto bars = storage.getBars(tf);                    // std::span<const Bar>
+
+    MmapBarReplaySource replay(storage, symbolId);
+    replay.replay([&](const BarEvent& ev) { strat.onBar(ev); });
+    ```
+
+## Live aggregation (no offline step)
+
+For real-time bar generation while you trade, configure the aggregator with the timeframes you want and connect it to your strategy.
+
+=== "C++"
+
+    ```cpp
+    BarBus bus;
+    MultiTimeframeAggregator<4> aggregator(&bus);
+    aggregator.addTimeInterval(std::chrono::seconds(60));    // 1m
+    aggregator.addTimeInterval(std::chrono::seconds(300));   // 5m
+    aggregator.addTimeInterval(std::chrono::seconds(900));   // 15m
+    aggregator.addTimeInterval(std::chrono::seconds(3600));  // 1h
+
+    MmapBarWriter writer("/data/bybit/BTCUSDT/bars");
+    bus.subscribe(&writer);
+
+    aggregator.start();
+    aggregator.onTrade(tradeEvent);
+    ```
+
+=== "Python / Node.js"
+
+    Live bar aggregation isn't yet exposed as an idiomatic Python/Node.js API — drive your strategy from `Runner.on_trade(...)` and accumulate bars yourself, or pre-aggregate with `preagg_bars` and replay.
+
+## Bar types
+
+| Type | Parameter | Description |
+|---|---|---|
+| Time | interval (seconds) | Close every N seconds |
+| Tick | count | Close after N trades |
+| Volume | threshold | Close when cumulative volume crosses threshold |
+| Renko | brick size | Fixed price-move bars |
+| Range | range | Close when high − low > range |
+| BpsRange | bps | Range in basis points relative to bar open (works across price scales) |
+| HeikinAshi | interval | Heikin-Ashi smoothed |
+
+```cpp
+aggregator.addTickInterval(100);          // 100-trade bars
+aggregator.addVolumeInterval(1'000'000);  // 1M-volume bars
+```
+
+## File format
+
+```
+[uint64_t]  bar_count
+[Bar × N]   bar data
+```
+
+Each `Bar` carries `open / high / low / close / volume / buyVolume / tradeCount / startTime / endTime / reason`. File naming: `bars_<seconds>s.bin`.
+
+## Performance tips
+
+1. **mmap for big data** — `MmapBarStorage` lets the OS manage paging
+2. **Pre-aggregate offline** for repeated parameter sweeps
+3. **Pick coarser timeframes** for faster iteration; smaller bars = more events
+4. **Batch flushes** — `MmapBarWriter` buffers; call `flush()` periodically for durability
+
+## See also
+
+- [Custom bar policy](custom-bar-policy.md) — write your own aggregator
+- [Bar types explained](../explanation/bar-types.md)
+- [Backtesting](backtest.md)
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/custom-bar-policy.md
+# URL: https://flox-foundation.github.io/flox/how-to/custom-bar-policy/
+------------------------------------------------------------------------------
+
+# How to Create a Custom Bar Policy
+
+!!! info "C++ extension point"
+    A bar policy is a small C++ class plugged into `BarAggregator<T>` via a template parameter. Once written, the new bar type is available everywhere — Python, Node.js, Codon — through the standard aggregator API. If you only need the built-in bar types (Time, Tick, Volume, Renko, Range, BpsRange, HeikinAshi), see [Bar aggregation](bar-aggregation.md).
+
+This guide shows how to create your own bar closing policy for the BarAggregator.
+
+## When to Use
+
+Create a custom policy when built-in types (Time, Tick, Volume, Renko, Range) don't fit your needs:
+
+- Dollar bars (close after fixed dollar volume)
+- Volatility bars (close based on ATR)
+- Session bars (close at specific times)
+- Hybrid bars (combine multiple conditions)
+
+## The BarPolicy Concept
+
+Your policy must satisfy this interface:
+
+```cpp
+template <typename T>
+concept BarPolicy = requires(T& p, const TradeEvent& t, Bar& b) {
+  { p.shouldClose(t, b) } noexcept -> std::same_as<bool>;
+  { p.update(t, b) } noexcept -> std::same_as<void>;
+  { p.initBar(t, b) } noexcept -> std::same_as<void>;
+  { T::kBarType } -> std::convertible_to<BarType>;
+};
+```
+
+## Example: Dollar Bar Policy
+
+Closes when notional volume reaches a threshold:
+
+```cpp
+#include "flox/aggregator/aggregation_policy.h"
+#include "flox/aggregator/bar.h"
+#include "flox/book/events/trade_event.h"
+
+namespace flox
+{
+
+class DollarBarPolicy
+{
+ public:
+  static constexpr BarType kBarType = BarType::Volume;
+
+  explicit DollarBarPolicy(Volume threshold) : _threshold(threshold) {}
+
+  static DollarBarPolicy fromDouble(double dollars)
+  {
+    return DollarBarPolicy(Volume::fromDouble(dollars));
+  }
+
+  bool shouldClose(const TradeEvent& trade, const Bar& bar) noexcept
+  {
+    return bar.volume.raw() >= _threshold.raw();
+  }
+
+  void update(const TradeEvent& trade, Bar& bar) noexcept
+  {
+    updateOHLCV(trade, bar);  // Use built-in helper
+  }
+
+  void initBar(const TradeEvent& trade, Bar& bar) noexcept
+  {
+    initializeBar(trade, bar);  // Use built-in helper
+  }
+
+ private:
+  Volume _threshold;
+};
+
+}  // namespace flox
+```
+
+### Usage
+
+```cpp
+BarAggregator<DollarBarPolicy> aggregator(
+  DollarBarPolicy::fromDouble(1000000.0),  // $1M bars
+  &bus
+);
+```
+
+## Example: Session Bar Policy
+
+Closes at specific session boundaries:
+
+```cpp
+class SessionBarPolicy
+{
+ public:
+  static constexpr BarType kBarType = BarType::Time;
+
+  explicit SessionBarPolicy(std::vector<uint64_t> closeTimesNs)
+      : _closeTimes(std::move(closeTimesNs))
+  {
+    std::sort(_closeTimes.begin(), _closeTimes.end());
+  }
+
+  bool shouldClose(const TradeEvent& trade, const Bar& bar) noexcept
+  {
+    uint64_t tradeNs = trade.trade.exchangeTsNs;
+    uint64_t barStartNs = bar.startTime.time_since_epoch().count();
+
+    for (uint64_t closeTime : _closeTimes)
+    {
+      if (tradeNs >= closeTime && barStartNs < closeTime)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void update(const TradeEvent& trade, Bar& bar) noexcept
+  {
+    updateOHLCV(trade, bar);
+  }
+
+  void initBar(const TradeEvent& trade, Bar& bar) noexcept
+  {
+    initializeBar(trade, bar);
+  }
+
+ private:
+  std::vector<uint64_t> _closeTimes;
+};
+```
+
+## Example: Volatility Bar Policy
+
+Closes when price range exceeds N times recent average:
+
+```cpp
+class VolatilityBarPolicy
+{
+ public:
+  static constexpr BarType kBarType = BarType::Range;
+
+  explicit VolatilityBarPolicy(double multiplier, Price baseRange)
+      : _multiplier(multiplier), _threshold(baseRange)
+  {
+  }
+
+  bool shouldClose(const TradeEvent& trade, const Bar& bar) noexcept
+  {
+    Price range = Price::fromRaw(bar.high.raw() - bar.low.raw());
+    Price dynamicThreshold = Price::fromRaw(
+      static_cast<int64_t>(_threshold.raw() * _multiplier)
+    );
+    return range.raw() >= dynamicThreshold.raw();
+  }
+
+  void update(const TradeEvent& trade, Bar& bar) noexcept
+  {
+    updateOHLCV(trade, bar);
+
+    // Update rolling average for next bar
+    Price range = Price::fromRaw(bar.high.raw() - bar.low.raw());
+    _threshold = Price::fromRaw(
+      (_threshold.raw() * 9 + range.raw()) / 10  // EMA-like
+    );
+  }
+
+  void initBar(const TradeEvent& trade, Bar& bar) noexcept
+  {
+    initializeBar(trade, bar);
+  }
+
+ private:
+  double _multiplier;
+  Price _threshold;
+};
+```
+
+## Helper Functions
+
+Use these built-in helpers in your policy:
+
+### updateOHLCV
+
+Updates high, low, close, volume, tradeCount, buyVolume, endTime:
+
+```cpp
+void update(const TradeEvent& trade, Bar& bar) noexcept
+{
+  updateOHLCV(trade, bar);
+  // Add custom logic here
+}
+```
+
+### initializeBar
+
+Initializes a new bar from the first trade:
+
+```cpp
+void initBar(const TradeEvent& trade, Bar& bar) noexcept
+{
+  initializeBar(trade, bar);
+  // Add custom initialization here
+}
+```
+
+## Adding Custom State
+
+Store additional state in your policy:
+
+```cpp
+class ImbalanceBarPolicy
+{
+ public:
+  static constexpr BarType kBarType = BarType::Volume;
+
+  explicit ImbalanceBarPolicy(double imbalanceThreshold)
+      : _threshold(imbalanceThreshold)
+  {
+  }
+
+  bool shouldClose(const TradeEvent& trade, const Bar& bar) noexcept
+  {
+    if (bar.volume.raw() == 0) return false;
+
+    double buyRatio = static_cast<double>(bar.buyVolume.raw()) /
+                      static_cast<double>(bar.volume.raw());
+
+    // Close when buy/sell imbalance exceeds threshold
+    return buyRatio > _threshold || buyRatio < (1.0 - _threshold);
+  }
+
+  void update(const TradeEvent& trade, Bar& bar) noexcept
+  {
+    updateOHLCV(trade, bar);
+  }
+
+  void initBar(const TradeEvent& trade, Bar& bar) noexcept
+  {
+    initializeBar(trade, bar);
+  }
+
+ private:
+  double _threshold;  // e.g., 0.7 = 70% imbalance
+};
+```
+
+## Using with MultiTimeframeAggregator
+
+Custom policies work with `MultiTimeframeAggregator` via the variant-based interface:
+
+```cpp
+// Currently supports Time, Tick, Volume via addXxxInterval()
+// For custom policies, use separate BarAggregator instances:
+
+BarAggregator<DollarBarPolicy> dollarAgg(
+  DollarBarPolicy::fromDouble(1000000.0), &bus
+);
+
+BarAggregator<ImbalanceBarPolicy> imbalanceAgg(
+  ImbalanceBarPolicy(0.7), &bus
+);
+
+// Feed trades to both
+void onTrade(const TradeEvent& trade) {
+  dollarAgg.onTrade(trade);
+  imbalanceAgg.onTrade(trade);
+}
+```
+
+## Testing Your Policy
+
+```cpp
+TEST(MyPolicyTest, ClosesAtThreshold)
+{
+  BarBus bus;
+  bus.enableDrainOnStop();
+
+  std::vector<Bar> bars;
+  // ... set up test subscriber ...
+
+  BarAggregator<MyPolicy> agg(MyPolicy(...), &bus);
+  bus.subscribe(&subscriber);
+  bus.start();
+  agg.start();
+
+  // Feed test trades
+  agg.onTrade(makeTrade(...));
+
+  agg.stop();
+  bus.stop();
+
+  EXPECT_EQ(bars.size(), expectedCount);
+}
+```
+
+## See Also
+
+- [Bar Aggregator Reference](../reference/api/aggregator/bar_aggregator.md)
+- [Bar Types Explained](../explanation/bar-types.md)
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/use-volume-profile.md
+# URL: https://flox-foundation.github.io/flox/how-to/use-volume-profile/
+------------------------------------------------------------------------------
+
+# How to Use Volume Profile
+
+Volume Profile aggregates traded volume by price level over a session, exposing point-of-control (POC), value area, and high/low volume nodes. Available in C++, Python, and Node.js. The advanced pattern examples below are written in C++ but the same logic ports directly to the Python/Node API.
+
+## Basic setup
+
+=== "Python"
+
+    ```python
+    import flox_py as flox
+
+    vp = flox.VolumeProfile(tick_size=0.50)   # aggregate to $0.50 levels
+
+    # On every trade
+    vp.add_trade(price, qty, is_buy=trade.is_buy)
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const vp = new flox.VolumeProfile(0.50);
+    vp.addTrade(price, qty, /*isBuy=*/ true);
+    ```
+
+=== "C++"
+
+    ```cpp
+    #include "flox/aggregator/custom/volume_profile.h"
+
+    VolumeProfile<256> profile;
+    profile.setTickSize(Price::fromDouble(0.50));
+    ```
+
+## Reading key levels
+
+=== "Python"
+
+    ```python
+    poc      = vp.poc()
+    va_low   = vp.value_area_low()
+    va_high  = vp.value_area_high()
+    total    = vp.total_volume()
+    delta    = vp.total_delta()        # buy − sell
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const poc     = vp.poc();
+    const vaLow   = vp.valueAreaLow();
+    const vaHigh  = vp.valueAreaHigh();
+    ```
+
+=== "C++"
+
+    ```cpp
+    Price poc    = profile.poc();
+    Price vaLow  = profile.valueAreaLow();
+    Price vaHigh = profile.valueAreaHigh();
+    ```
+
+## Trading patterns (C++)
+
+The following examples show common patterns. They use the C++ API but the calls are 1:1 with Python (`vp.poc()`) and Node (`vp.poc()`).
+
+## Building a Session Profile
+
+Reset at session start, build throughout the day:
+
+```cpp
+class SessionProfileStrategy : public IMarketDataSubscriber
+{
+ public:
+  void onSessionStart()
+  {
+    _profile.clear();
+  }
+
+  void onTrade(const TradeEvent& ev) override
+  {
+    _profile.addTrade(ev);
+  }
+
+ private:
+  VolumeProfile<256> _profile;
+};
+```
+
+## Finding Key Levels
+
+### Point of Control (POC)
+
+The price with highest volume - acts as a magnet:
+
+```cpp
+Price poc = profile.poc();
+
+// Trade toward POC
+if (currentPrice < poc) {
+  // Expect price to rise toward POC
+} else if (currentPrice > poc) {
+  // Expect price to fall toward POC
+}
+```
+
+### Value Area
+
+Where 70% of volume traded - represents "fair value":
+
+```cpp
+Price vaLow = profile.valueAreaLow();
+Price vaHigh = profile.valueAreaHigh();
+
+// Fade extremes
+if (currentPrice < vaLow) {
+  // Below value = potential long
+} else if (currentPrice > vaHigh) {
+  // Above value = potential short
+}
+```
+
+## Trading Strategies
+
+### Mean Reversion to POC
+
+```cpp
+void onTrade(const TradeEvent& ev) override
+{
+  _profile.addTrade(ev);
+
+  Price poc = _profile.poc();
+  Price price = ev.trade.price;
+
+  // Entry: 0.5% away from POC
+  Price distance = Price::fromRaw(std::abs(price.raw() - poc.raw()));
+  Price threshold = Price::fromRaw(poc.raw() / 200);  // 0.5%
+
+  if (distance > threshold) {
+    if (price < poc) {
+      // BUY - expect reversion to POC
+      std::cout << "BUY @ " << price.toDouble()
+                << " target POC @ " << poc.toDouble() << std::endl;
+    } else {
+      // SELL - expect reversion to POC
+      std::cout << "SELL @ " << price.toDouble()
+                << " target POC @ " << poc.toDouble() << std::endl;
+    }
+  }
+}
+```
+
+### Value Area Breakout
+
+```cpp
+void onBar(const BarEvent& ev) override
+{
+  Price vaLow = _profile.valueAreaLow();
+  Price vaHigh = _profile.valueAreaHigh();
+  Price close = ev.bar.close;
+
+  // Breakout above value area
+  if (_prevClose <= vaHigh && close > vaHigh) {
+    std::cout << "BREAKOUT LONG @ " << close.toDouble() << std::endl;
+  }
+
+  // Breakdown below value area
+  if (_prevClose >= vaLow && close < vaLow) {
+    std::cout << "BREAKDOWN SHORT @ " << close.toDouble() << std::endl;
+  }
+
+  _prevClose = close;
+}
+```
+
+### Delta Confirmation
+
+Use delta to confirm direction:
+
+```cpp
+void analyzeProfile()
+{
+  Volume delta = _profile.totalDelta();
+  Price poc = _profile.poc();
+
+  if (delta.raw() > 0) {
+    // Net buying - bullish bias
+    std::cout << "Bullish bias, buy pullbacks to POC @ "
+              << poc.toDouble() << std::endl;
+  } else {
+    // Net selling - bearish bias
+    std::cout << "Bearish bias, sell rallies to POC @ "
+              << poc.toDouble() << std::endl;
+  }
+}
+```
+
+## Multi-Session Analysis
+
+Combine profiles from multiple days:
+
+```cpp
+class CompositeProfile
+{
+ public:
+  void addSession(const VolumeProfile<256>& session)
+  {
+    // Merge session POC into composite
+    Price poc = session.poc();
+    _pocLevels.push_back(poc);
+
+    // Track recurring high-volume levels
+    for (size_t i = 0; i < session.numLevels(); ++i) {
+      const auto* lvl = session.level(i);
+      if (lvl && lvl->volume.raw() > _minVolume) {
+        _significantLevels[lvl->price.raw()]++;
+      }
+    }
+  }
+
+  std::vector<Price> getKeyLevels() const
+  {
+    std::vector<Price> result;
+    for (const auto& [priceRaw, count] : _significantLevels) {
+      if (count >= 3) {  // Appeared in 3+ sessions
+        result.push_back(Price::fromRaw(priceRaw));
+      }
+    }
+    return result;
+  }
+
+ private:
+  std::vector<Price> _pocLevels;
+  std::map<int64_t, int> _significantLevels;
+  int64_t _minVolume = Volume::fromDouble(100000).raw();
+};
+```
+
+## Volume at Price Queries
+
+Check volume at specific levels:
+
+```cpp
+// Check if current price is at high volume node
+Volume volAtPrice = profile.volumeAt(currentPrice);
+Volume avgVol = Volume::fromRaw(profile.totalVolume().raw() / profile.numLevels());
+
+if (volAtPrice.raw() > avgVol.raw() * 2) {
+  // High Volume Node (HVN) - expect consolidation
+} else if (volAtPrice.raw() < avgVol.raw() / 2) {
+  // Low Volume Node (LVN) - expect fast move through
+}
+```
+
+## Combining with Other Tools
+
+### With Footprint
+
+```cpp
+VolumeProfile<256> profile;
+FootprintBar<64> footprint;
+
+void onTrade(const TradeEvent& ev) override
+{
+  profile.addTrade(ev);
+  footprint.addTrade(ev);
+}
+
+void analyze()
+{
+  Price poc = profile.poc();
+
+  // Check order flow at POC
+  const auto* lvl = footprint.levelAt(poc);
+  if (lvl) {
+    if (lvl->imbalanceRatio() > 0.7) {
+      // Strong buying at POC - support confirmed
+    } else if (lvl->imbalanceRatio() < 0.3) {
+      // Strong selling at POC - resistance forming
+    }
+  }
+}
+```
+
+### With Bar Data
+
+```cpp
+void onBar(const BarEvent& ev) override
+{
+  Price poc = _profile.poc();
+  Price vaLow = _profile.valueAreaLow();
+  Price vaHigh = _profile.valueAreaHigh();
+
+  // Bar closes at POC
+  if (std::abs(ev.bar.close.raw() - poc.raw()) < _tickSize.raw()) {
+    // Consolidation expected
+  }
+
+  // Bar closes outside value
+  if (ev.bar.close < vaLow || ev.bar.close > vaHigh) {
+    // Trend move or potential reversal
+  }
+}
+```
+
+## Performance Tips
+
+1. **Tick size**: Larger tick = fewer levels = faster lookups
+2. **MaxLevels**: Size appropriately (128-256 typical for crypto)
+3. **Clear regularly**: Reset at session boundaries to avoid stale data
+
+```cpp
+// Appropriate sizing
+VolumeProfile<128> cryptoProfile;   // Volatile, fewer levels
+VolumeProfile<256> stockProfile;    // More granular
+VolumeProfile<512> futuresProfile;  // High precision needed
+```
+
+## See Also
+
+- [Volume Profile Reference](../reference/api/aggregator/volume_profile.md)
+- [Footprint Chart](../reference/api/aggregator/footprint_chart.md)
+- [Bar Types Explained](../explanation/bar-types.md)
+
+==============================================================================
+# Section: How-to: performance and extension (C++)
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/optimize-performance.md
+# URL: https://flox-foundation.github.io/flox/how-to/optimize-performance/
+------------------------------------------------------------------------------
+
+# Optimize Performance
+
+!!! info "System-level (C++)"
+    These tuning knobs live in the C++ engine. Every binding inherits them automatically; there's nothing per-language to configure. If you only run Python or Node.js the relevant tuning is "use a Release build of FLOX" — the rest is for advanced low-latency setups.
+
+Tune FLOX for minimum latency.
+
+## Build Optimization
+
+### Release Build
+
+```bash
+cmake .. \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_FLAGS="-O3 -march=native -flto"
+```
+
+Default release flags in FLOX:
+```cmake
+$<$<CONFIG:Release>:-O3 -march=native -flto -funroll-loops>
+```
+
+### Link-Time Optimization
+
+Already enabled by default with `-flto`. Ensure your compiler supports it:
+```bash
+g++ --version  # GCC 13+ recommended
+```
+
+## Event Bus Tuning
+
+### Capacity
+
+Default: 4096 events. For high-frequency feeds, increase:
+
+```bash
+cmake .. -DFLOX_DEFAULT_EVENTBUS_CAPACITY=16384
+```
+
+Or per-bus:
+```cpp
+using HighCapacityBus = EventBus<TradeEvent, 16384>;
+```
+
+Capacity must be power of 2.
+
+### Consumer Limit
+
+Default: 128 consumers. Adjust if needed:
+
+```bash
+cmake .. -DFLOX_DEFAULT_EVENTBUS_MAX_CONSUMERS=256
+```
+
+## Memory Optimization
+
+### Pre-allocate Pools
+
+Size pools to handle peak load without exhaustion:
+
+```cpp
+// For 3 consumers at 10ms processing, 1000 events/sec:
+// In-flight ≈ 3 × 10ms × 1000/sec = 30 events
+// Add headroom: 64-128
+
+pool::Pool<BookUpdateEvent, 128> bookPool;
+```
+
+Monitor pool usage:
+```cpp
+size_t inUse = bookPool.inUse();
+if (inUse > threshold) {
+  FLOX_LOG("Warning: pool usage high: " << inUse);
+}
+```
+
+### Avoid Allocations in Hot Path
+
+**Don't:**
+```cpp
+void onTrade(const TradeEvent& ev) {
+  auto data = std::make_unique<Data>();  // BAD: allocation
+  std::string s = std::to_string(ev.trade.price.toDouble());  // BAD
+}
+```
+
+**Do:**
+```cpp
+class MyStrategy : public IStrategy {
+  Data _data;  // Pre-allocated member
+  char _buffer[128];  // Pre-allocated buffer
+
+  void onTrade(const TradeEvent& ev) {
+    _data.process(ev);  // Use pre-allocated
+    snprintf(_buffer, sizeof(_buffer), "%.2f", ev.trade.price.toDouble());
+  }
+};
+```
+
+## CPU Optimization
+
+### CPU Affinity
+
+See [Configure CPU Affinity](cpu-affinity.md) for details.
+
+Quick setup:
+```cpp
+#if FLOX_CPU_AFFINITY_ENABLED
+tradeBus.setupOptimalConfiguration(TradeBus::ComponentType::MARKET_DATA, true);
+#endif
+```
+
+### Disable Frequency Scaling
+
+```bash
+echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+```
+
+### Isolate CPUs
+
+Kernel parameters:
+```
+isolcpus=2,3,4,5 nohz_full=2,3,4,5 rcu_nocbs=2,3,4,5
+```
+
+## Strategy Optimization
+
+### Filter Early
+
+```cpp
+void onTrade(const TradeEvent& ev) {
+  // Filter first line — reject early
+  if (ev.trade.symbol != _symbol) return;
+  if (ev.trade.price < _minPrice) return;
+
+  // Expensive processing only for relevant events
+  processSignal(ev);
+}
+```
+
+### Avoid Branches in Hot Path
+
+```cpp
+// BAD: Branch in tight loop
+for (const auto& level : book.bids) {
+  if (level.price > threshold) {
+    total += level.quantity;
+  }
+}
+
+// BETTER: Branchless or predictable branch
+// (compiler may optimize, but be aware)
+```
+
+### Cache Friendly Access
+
+```cpp
+// BAD: Random access
+for (int i : randomIndices) {
+  process(data[i]);
+}
+
+// GOOD: Sequential access
+for (const auto& item : data) {
+  process(item);
+}
+```
+
+## Logging Optimization
+
+Disable logging during performance-critical sections:
+
+```cpp
+FLOX_LOG_OFF();
+
+// Hot path - no logging overhead
+
+FLOX_LOG_ON();
+```
+
+Or disable at build time for production:
+
+```bash
+cmake .. -DFLOX_DISABLE_LOGGING=ON
+```
+
+## Profiling
+
+### Enable Tracy
+
+```bash
+cmake .. -DFLOX_ENABLE_TRACY=ON
+```
+
+Use profiling macros:
+```cpp
+void onTrade(const TradeEvent& ev) {
+  FLOX_PROFILE_SCOPE("Strategy::onTrade");
+
+  // Your code...
+}
+```
+
+### Measure Latency
+
+```cpp
+class LatencyTracker {
+  std::vector<int64_t> _samples;
+
+public:
+  void record(int64_t latency_ns) {
+    _samples.push_back(latency_ns);
+  }
+
+  void report() {
+    std::sort(_samples.begin(), _samples.end());
+    size_t n = _samples.size();
+
+    std::cout << "p50: " << _samples[n * 0.50] << " ns\n";
+    std::cout << "p99: " << _samples[n * 0.99] << " ns\n";
+    std::cout << "max: " << _samples.back() << " ns\n";
+  }
+};
+```
+
+## Compression Trade-offs
+
+For replay:
+
+- **No compression:** Fastest read, largest files
+- **LZ4:** ~3-5x compression, small CPU overhead
+
+For recording, LZ4 is usually worth it:
+```cpp
+WriterConfig config;
+config.compression = CompressionType::LZ4;  // Good default
+```
+
+## Network Optimization
+
+### Socket Tuning
+
+```bash
+# Increase receive buffer
+sudo sysctl -w net.core.rmem_max=16777216
+sudo sysctl -w net.core.rmem_default=16777216
+```
+
+### Busy-poll
+
+For lowest latency with kernel 4.11+:
+```bash
+sudo sysctl -w net.core.busy_poll=50
+sudo sysctl -w net.core.busy_read=50
+```
+
+## Checklist
+
+- [ ] Release build with `-O3 -march=native -flto`
+- [ ] EventBus capacity sized for peak load
+- [ ] Object pools pre-allocated
+- [ ] No allocations in callbacks
+- [ ] CPU affinity configured (if dedicated hardware)
+- [ ] CPU frequency scaling disabled
+- [ ] Logging disabled during benchmarks
+- [ ] Profiling enabled during tuning
+- [ ] Socket buffers increased
+- [ ] Kernel parameters tuned (isolated CPUs, etc.)
+
+## Benchmarking
+
+Run included benchmarks:
+```bash
+cmake .. -DFLOX_ENABLE_BENCHMARKS=ON
+make -j
+./benchmarks/binary_log_benchmark
+./benchmarks/nlevel_order_book_benchmark
+```
+
+Run your own latency measurements to establish baseline for your hardware.
+
+## See Also
+
+- [Configure CPU Affinity](cpu-affinity.md) — Thread pinning
+- [The Disruptor Pattern](../explanation/disruptor.md) — Understanding latency
+- [Memory Model](../explanation/memory-model.md) — Zero-allocation design
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/cpu-affinity.md
+# URL: https://flox-foundation.github.io/flox/how-to/cpu-affinity/
+------------------------------------------------------------------------------
+
+# Configure CPU Affinity
+
+!!! info "System-level (C++)"
+    Thread pinning is configured in the C++ engine layer. Bindings (Python, Node.js, Codon) inherit whatever the host engine is configured with — there is no per-language API for this.
+
+Pin threads to isolated CPU cores for lower, more predictable latency.
+
+## When to Use
+
+CPU affinity is useful when:
+- You have dedicated hardware for trading
+- You've isolated CPU cores from the OS scheduler
+- You need sub-microsecond latency consistency
+
+**Warning:** CPU affinity can *decrease* performance on shared or busy systems. Only use it when you control the entire system workload.
+
+## 1. Enable at Build Time
+
+```bash
+cmake .. -DFLOX_ENABLE_CPU_AFFINITY=ON
+```
+
+This requires the NUMA library on Linux:
+```bash
+sudo apt install libnuma-dev  # Debian/Ubuntu
+```
+
+## 2. Isolate CPU Cores (System Setup)
+
+Edit your kernel command line (e.g., `/etc/default/grub`):
+
+```
+GRUB_CMDLINE_LINUX="isolcpus=2,3,4,5 nohz_full=2,3,4,5 rcu_nocbs=2,3,4,5"
+```
+
+Then:
+```bash
+sudo update-grub
+sudo reboot
+```
+
+Verify isolation:
+```bash
+cat /sys/devices/system/cpu/isolated
+# Should show: 2-5
+```
+
+## 3. Configure EventBus Affinity
+
+### Automatic Configuration
+
+```cpp
+#include "flox/book/bus/trade_bus.h"
+
+TradeBus tradeBus;
+
+// Auto-configure for market data workload
+tradeBus.setupOptimalConfiguration(
+    TradeBus::ComponentType::MARKET_DATA,
+    /*enablePerformanceOptimizations=*/true
+);
+```
+
+**Component types and their priority:**
+
+| Type | Priority | Description |
+|------|----------|-------------|
+| `MARKET_DATA` | 90 | Market data buses (TradeBus, BookUpdateBus) |
+| `EXECUTION` | 85 | Order execution bus |
+| `STRATEGY` | 80 | Strategy processing threads |
+| `RISK` | 75 | Risk management |
+| `GENERAL` | 70 | Non-critical threads |
+
+Higher priority components get first choice of isolated cores.
+
+### Manual Configuration
+
+```cpp
+#include "flox/util/performance/cpu_affinity.h"
+
+using namespace flox::performance;
+
+// Create affinity manager
+auto cpuAffinity = createCpuAffinity();
+
+// Get recommended core assignment
+CriticalComponentConfig config;
+config.preferIsolatedCores = true;
+config.exclusiveIsolatedCores = true;
+
+auto assignment = cpuAffinity->getNumaAwareCoreAssignment(config);
+
+// Apply to bus
+tradeBus.setCoreAssignment(assignment);
+
+// Verify configuration
+if (tradeBus.verifyIsolatedCoreConfiguration()) {
+    std::cout << "CPU affinity configured correctly" << std::endl;
+}
+```
+
+### Per-Bus Configuration
+
+```cpp
+// Different buses can use different core types
+TradeBus::AffinityConfig tradeCfg;
+tradeCfg.componentType = TradeBus::ComponentType::MARKET_DATA;
+tradeCfg.enableRealTimePriority = true;
+tradeCfg.realTimePriority = 90;
+tradeCfg.enableNumaAwareness = true;
+tradeCfg.preferIsolatedCores = true;
+
+tradeBus.setAffinityConfig(tradeCfg);
+
+OrderExecutionBus::AffinityConfig execCfg;
+execCfg.componentType = OrderExecutionBus::ComponentType::EXECUTION;
+execCfg.enableRealTimePriority = true;
+execCfg.realTimePriority = 85;
+
+execBus.setAffinityConfig(execCfg);
+```
+
+## 4. Core Assignment Structure
+
+```cpp
+struct CoreAssignment
+{
+  std::vector<int> marketDataCores;  // For market data processing
+  std::vector<int> executionCores;   // For order execution
+  std::vector<int> strategyCores;    // For strategy threads
+  std::vector<int> riskCores;        // For risk management
+  std::vector<int> generalCores;     // For non-critical threads
+  std::vector<int> allIsolatedCores; // All isolated cores
+  bool hasIsolatedCores{false};      // True if system has isolated cores
+};
+```
+
+## 5. NUMA Awareness
+
+For multi-socket systems, use NUMA-aware assignment:
+
+```cpp
+auto assignment = cpuAffinity->getNumaAwareCoreAssignment(config);
+```
+
+This ensures:
+- Threads run on cores near their memory
+- Cross-socket memory access is minimized
+- Cache coherency traffic is reduced
+
+## 6. Disable Frequency Scaling
+
+For consistent performance, disable CPU frequency scaling:
+
+```cpp
+cpuAffinity->disableCpuFrequencyScaling();
+```
+
+Or via system settings:
+```bash
+echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+```
+
+## 7. Verify Configuration
+
+```cpp
+// Check if isolated cores are properly configured
+if (tradeBus.verifyIsolatedCoreConfiguration()) {
+    std::cout << "Verified: running on isolated cores" << std::endl;
+} else {
+    std::cerr << "Warning: not running on isolated cores" << std::endl;
+}
+
+// Print assignment
+auto assignment = tradeBus.getCoreAssignment();
+if (assignment) {
+    std::cout << "Market data cores: ";
+    for (int c : assignment->marketDataCores) std::cout << c << " ";
+    std::cout << std::endl;
+}
+```
+
+## 8. Full Example
+
+```cpp
+#include "flox/book/bus/trade_bus.h"
+#include "flox/book/bus/book_update_bus.h"
+#include "flox/execution/bus/order_execution_bus.h"
+
+int main()
+{
+    flox::init_timebase_mapping();
+
+#if FLOX_CPU_AFFINITY_ENABLED
+    auto cpuAffinity = flox::performance::createCpuAffinity();
+
+    flox::performance::CriticalComponentConfig config;
+    config.preferIsolatedCores = true;
+    config.exclusiveIsolatedCores = true;
+
+    auto assignment = cpuAffinity->getNumaAwareCoreAssignment(config);
+
+    if (assignment.hasIsolatedCores) {
+        std::cout << "Using isolated cores for critical components" << std::endl;
+    }
+#endif
+
+    auto tradeBus = std::make_unique<TradeBus>();
+    auto bookBus = std::make_unique<BookUpdateBus>();
+    auto execBus = std::make_unique<OrderExecutionBus>();
+
+#if FLOX_CPU_AFFINITY_ENABLED
+    tradeBus->setupOptimalConfiguration(TradeBus::ComponentType::MARKET_DATA);
+    bookBus->setupOptimalConfiguration(BookUpdateBus::ComponentType::MARKET_DATA);
+    execBus->setupOptimalConfiguration(OrderExecutionBus::ComponentType::EXECUTION);
+#endif
+
+    // ... rest of setup and run
+}
+```
+
+## Troubleshooting
+
+### "NUMA library not found"
+
+Install libnuma:
+```bash
+sudo apt install libnuma-dev  # Debian/Ubuntu
+sudo yum install numactl-devel  # RHEL/CentOS
+```
+
+### Performance is worse with affinity
+
+- Ensure cores are properly isolated (`cat /sys/devices/system/cpu/isolated`)
+- Disable frequency scaling
+- Verify you have enough isolated cores for all critical threads
+- Check for IRQ affinity conflicts (`cat /proc/interrupts`)
+
+### "Permission denied" setting real-time priority
+
+Run as root or add capability:
+```bash
+sudo setcap cap_sys_nice+ep ./your_binary
+```
+
+Or run with:
+```bash
+sudo nice -n -20 ./your_binary
+```
+
+## See Also
+
+- [Optimize Performance](optimize-performance.md) — More tuning options
+- [Architecture Overview](../explanation/architecture.md) — Threading model
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/add-an-indicator.md
+# URL: https://flox-foundation.github.io/flox/how-to/add-an-indicator/
+------------------------------------------------------------------------------
+
+# Add a new indicator
+
+!!! info "C++ extension point"
+    Indicators are defined once in C++ and surface automatically in every binding. Most users don't need this guide — the [built-in indicators](../reference/python/indicators.md) cover the standard set.
+
+The framework is designed so that adding a new indicator is **one C++ class
+plus one line in a registry**. After those two changes it appears in C++,
+Python, every binding, in `flox.list_indicators()` discovery, in the parity
+tests, and in the docs site, all automatically.
+
+## 1. Write the C++ class
+
+Create `include/flox/indicator/my_indicator.h`. Implement the canonical
+`compute()` for your indicator — that's the single source of truth for the
+math. Inherit from the matching streaming mixin to get
+`update()`/`value()`/`ready()`/`reset()` on the same class for free:
+
+```cpp
+#pragma once
+
+#include "flox/indicator/streaming.h"
+
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace flox::indicator
+{
+
+class MyIndicator : public StreamingSingle<MyIndicator>
+{
+ public:
+  explicit MyIndicator(size_t period) noexcept : _period(period) {}
+
+  std::vector<double> compute(std::span<const double> input) const
+  {
+    std::vector<double> out(input.size(), std::nan(""));
+    // ... your logic ...
+    return out;
+  }
+
+  size_t period() const noexcept { return _period; }
+
+ private:
+  size_t _period;
+};
+
+}  // namespace flox::indicator
+
+#include "flox/indicator/indicator.h"
+static_assert(flox::indicator::SingleIndicator<flox::indicator::MyIndicator>);
+```
+
+The streaming mixin you choose depends on the input shape:
+
+| Input | Mixin |
+|---|---|
+| Single series (`compute(span)`) | `StreamingSingle<T>` |
+| `compute(high, low, close)` | `StreamingBar<T>` |
+| `compute(high, low)` | `StreamingHighLow<T>` |
+| `compute(open, high, low, close)` | `StreamingOhlc<T>` |
+| `compute(x, y)` | `StreamingPair<T>` |
+| Multi-output result struct | hand-written streaming methods (see `MACD`, `Bollinger`, `Stochastic`) |
+
+## 2. Register it
+
+Add **one line** to `include/flox/indicator/registry.def`:
+
+```c
+FLOX_INDICATOR(MyIndicator, my_indicator, SingleInput, (size_t period))
+```
+
+The `Kind` matches the mixin you used (`SingleInput`, `BarInput`,
+`HighLowInput`, `OhlcInput`, `PairInput`, or `MultiOutput`).
+
+## 3. Build, regenerate docs, run tests
+
+```sh
+cmake --build build
+python3 scripts/gen_indicator_docs.py
+ctest --test-dir build
+```
+
+You now have:
+
+- `flox::indicator::MyIndicator` in C++ with `compute()` (batch) and
+  `update()`/`value()`/`ready()`/`reset()` (streaming) on the same instance.
+- `flox.MyIndicator(...)` in Python with `compute(arr)` and
+  `update(v)` / `value` / `ready` / `reset()` on the same instance.
+- `flox.MyIndicator(...)` in **Node.js** — same surface, same semantics
+  (thin N-API wrapper around the same C++ class).
+- `MyIndicator` in **QuickJS** (`quickjs/flox/indicators.js`) — accumulates
+  history and re-runs the batch C-API; same `update`/`value`/`ready`/`reset`.
+  Add a 3-line class to that file using one of the `_Stream*` helper bases.
+- `MyIndicator` in **Codon** (`codon/flox/indicators.codon`) — same pattern
+  as QuickJS, history + batch call.
+- The streaming-vs-batch parity test
+  (`tests/test_streaming_parity.cpp`) automatically covers it once you add
+  one line to the registry-driven test list.
+- `flox.list_indicators()` returns it (Python and Node).
+- The docs site lists it on every per-binding page (run
+  `python3 scripts/gen_indicator_docs.py`).
+
+The parity is **by construction** — `update()` calls your `compute()`
+internally, so there is no separate streaming logic to drift. No ring
+buffer, no warmup logic, no seeding to debug.
+
+## 4. Reading the existing 22 indicators
+
+Every indicator listed in `registry.def` (EMA, SMA, RSI, ATR, MACD, ...)
+follows exactly this pattern. Look at any `include/flox/indicator/<name>.h`
+for a working example.
+
+## When NOT to use the streaming mixin
+
+The mixin re-runs `compute()` on the accumulated history each
+`update()` — O(N) per tick. Acceptable for research, UI, and
+moderate-throughput live trading. For a production-critical hot path you
+can specialize `update()` to do O(1) state-keeping, but you **must** keep
+the observable behaviour identical to `compute().back()` so the parity
+test continues to pass.
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/custom-connector.md
+# URL: https://flox-foundation.github.io/flox/how-to/custom-connector/
+------------------------------------------------------------------------------
+
+# Write a Custom Connector
+
+!!! info "C++ extension point"
+    Connectors are written against the C++ engine. Once a connector is built into FLOX, every binding (Python, Node.js, Codon, embedded JS) gets access to it automatically — no further work per language. If you just want to *use* an existing connector from Python or Node.js, see the [Python](../bindings/python.md) / [Node.js](../bindings/node.md) bindings docs instead.
+
+Connect FLOX to a new exchange or data source.
+
+## Overview
+
+A connector:
+
+1. Connects to an exchange API (WebSocket, REST, FIX, etc.)
+2. Parses incoming messages
+3. Converts to FLOX event types
+4. Emits events to the engine
+
+## 1. Implement IExchangeConnector
+
+**Header:** `flox/connector/abstract_exchange_connector.h`
+
+```cpp
+#include "flox/connector/abstract_exchange_connector.h"
+#include "flox/book/events/trade_event.h"
+#include "flox/book/events/book_update_event.h"
+
+class MyExchangeConnector : public flox::IExchangeConnector
+{
+public:
+  MyExchangeConnector(const std::string& symbol, flox::SymbolId symbolId)
+    : _symbol(symbol), _symbolId(symbolId) {}
+
+  std::string exchangeId() const override {
+    return "myexchange";
+  }
+
+  void start() override {
+    _running = true;
+    _thread = std::thread(&MyExchangeConnector::run, this);
+  }
+
+  void stop() override {
+    _running = false;
+    if (_thread.joinable()) {
+      _thread.join();
+    }
+  }
+
+private:
+  void run() {
+    // Connect to exchange
+    connect();
+
+    while (_running) {
+      // Receive and parse messages
+      auto msg = receiveMessage();
+      handleMessage(msg);
+    }
+
+    disconnect();
+  }
+
+  void handleMessage(const Message& msg) {
+    if (msg.type == MessageType::Trade) {
+      handleTrade(msg);
+    } else if (msg.type == MessageType::BookUpdate) {
+      handleBookUpdate(msg);
+    }
+  }
+
+  void handleTrade(const Message& msg) {
+    flox::TradeEvent ev;
+    ev.trade.symbol = _symbolId;
+    ev.trade.price = flox::Price::fromDouble(msg.price);
+    ev.trade.quantity = flox::Quantity::fromDouble(msg.qty);
+    ev.trade.isBuy = msg.side == "buy";
+    ev.trade.exchangeTsNs = msg.timestamp;
+    ev.recvNs = flox::nowNsMonotonic();
+
+    // Emit via base class method
+    emitTrade(ev);
+  }
+
+  void handleBookUpdate(const Message& msg) {
+    // For book updates, create event directly (simplified)
+    // In practice, you might use a pool for large events
+
+    flox::BookUpdateEvent ev(/* pmr allocator */);
+    ev.update.symbol = _symbolId;
+    ev.update.type = flox::BookUpdateType::SNAPSHOT;
+
+    for (const auto& bid : msg.bids) {
+      ev.update.bids.push_back({
+        flox::Price::fromDouble(bid.price),
+        flox::Quantity::fromDouble(bid.qty)
+      });
+    }
+    for (const auto& ask : msg.asks) {
+      ev.update.asks.push_back({
+        flox::Price::fromDouble(ask.price),
+        flox::Quantity::fromDouble(ask.qty)
+      });
+    }
+
+    ev.recvNs = flox::nowNsMonotonic();
+
+    emitBookUpdate(ev);
+  }
+
+  std::string _symbol;
+  flox::SymbolId _symbolId;
+  std::atomic<bool> _running{false};
+  std::thread _thread;
+};
+```
+
+## 2. Wire Callbacks
+
+Connect the connector to your buses:
+
+```cpp
+#include "flox/book/bus/trade_bus.h"
+#include "flox/book/bus/book_update_bus.h"
+#include "flox/util/memory/pool.h"
+
+// Create buses
+auto tradeBus = std::make_unique<TradeBus>();
+auto bookBus = std::make_unique<BookUpdateBus>();
+
+// Create pool for book events
+pool::Pool<BookUpdateEvent, 128> bookPool;
+
+// Create connector
+auto connector = std::make_shared<MyExchangeConnector>("BTCUSD", symbolId);
+
+// Wire callbacks
+connector->setCallbacks(
+  // Book update callback
+  [&bookBus, &bookPool](const BookUpdateEvent& ev) {
+    // Acquire from pool for variable-size events
+    if (auto handle = bookPool.acquire()) {
+      (*handle)->update = ev.update;
+      (*handle)->recvNs = ev.recvNs;
+      bookBus->publish(std::move(handle));
+    }
+  },
+  // Trade callback
+  [&tradeBus](const TradeEvent& ev) {
+    tradeBus->publish(ev);
+  }
+);
+```
+
+## 3. Register with Engine
+
+```cpp
+std::vector<std::shared_ptr<IExchangeConnector>> connectors;
+connectors.push_back(connector);
+
+std::vector<std::unique_ptr<ISubsystem>> subsystems;
+subsystems.push_back(std::move(tradeBus));
+subsystems.push_back(std::move(bookBus));
+// ... add strategies, etc.
+
+EngineConfig config{};
+Engine engine(config, std::move(subsystems), std::move(connectors));
+engine.start();
+```
+
+## 4. Use ConnectorFactory (Optional)
+
+For dynamic connector creation:
+
+```cpp
+#include "flox/connector/connector_factory.h"
+
+// Register factory
+ConnectorFactory::instance().registerConnector("myexchange",
+  [registry](const std::string& symbol) {
+    auto symbolId = registry->getSymbolId("myexchange", symbol);
+    return std::make_shared<MyExchangeConnector>(symbol, *symbolId);
+  }
+);
+
+// Create connector
+auto conn = ConnectorFactory::instance().createConnector("myexchange", "BTCUSD");
+```
+
+## 5. Best Practices
+
+### Thread Safety
+
+- Connector runs its own thread(s)
+- `emitTrade()` and `emitBookUpdate()` are thread-safe
+- Callbacks may execute on connector thread
+
+### Timestamps
+
+Capture timestamps at the right points:
+```cpp
+void handleMessage(const RawMessage& raw) {
+  MonoNanos recvNs = nowNsMonotonic();  // Capture immediately
+
+  // Parse message...
+  auto parsed = parse(raw);
+
+  TradeEvent ev;
+  ev.trade.exchangeTsNs = parsed.exchangeTimestamp;  // From exchange
+  ev.recvNs = recvNs;                                 // When we received it
+  ev.publishTsNs = nowNsMonotonic();                  // Right before emit
+
+  emitTrade(ev);
+}
+```
+
+### Error Handling
+
+```cpp
+void run() {
+  while (_running) {
+    try {
+      if (!_connected) {
+        connect();
+      }
+      auto msg = receiveMessage();
+      handleMessage(msg);
+    } catch (const ConnectionError& e) {
+      FLOX_LOG("Connection lost: " << e.what());
+      _connected = false;
+      reconnect();
+    }
+  }
+}
+```
+
+### Sequence Numbers
+
+Track exchange sequence numbers for gap detection:
+
+```cpp
+void handleBookUpdate(const Message& msg) {
+  if (_lastSeq > 0 && msg.seq != _lastSeq + 1) {
+    FLOX_LOG("Gap detected: " << _lastSeq << " -> " << msg.seq);
+    requestSnapshot();  // Request full book snapshot
+  }
+  _lastSeq = msg.seq;
+
+  // ... create and emit event
+}
+```
+
+### Pooled Book Events
+
+For high-frequency book updates, use pooled events:
+
+```cpp
+class MyExchangeConnector : public IExchangeConnector
+{
+  pool::Pool<BookUpdateEvent, 64> _bookPool;
+
+  void handleBookUpdate(const Message& msg) {
+    auto evOpt = _bookPool.acquire();
+    if (!evOpt) {
+      FLOX_LOG("Pool exhausted, dropping book update");
+      return;
+    }
+
+    auto& ev = *evOpt;
+    // ... populate ev
+
+    emitBookUpdate(*ev);
+    // Handle is moved to bus, returns to pool when all consumers done
+  }
+};
+```
+
+## 6. Complete Example
+
+```cpp
+#include "flox/connector/abstract_exchange_connector.h"
+#include "flox/book/events/trade_event.h"
+#include "flox/book/events/book_update_event.h"
+#include "flox/util/memory/pool.h"
+#include "flox/util/base/time.h"
+#include "flox/log/log.h"
+
+#include <thread>
+#include <atomic>
+
+namespace myexchange
+{
+
+using namespace flox;
+
+class MyConnector : public IExchangeConnector
+{
+public:
+  MyConnector(SymbolId symbol, TradeBus& tradeBus, BookUpdateBus& bookBus)
+    : _symbol(symbol)
+    , _tradeBus(tradeBus)
+    , _bookBus(bookBus)
+  {}
+
+  std::string exchangeId() const override { return "myexchange"; }
+
+  void start() override {
+    if (_running.exchange(true)) return;
+    _thread = std::thread(&MyConnector::run, this);
+  }
+
+  void stop() override {
+    if (!_running.exchange(false)) return;
+    if (_thread.joinable()) _thread.join();
+  }
+
+private:
+  void run() {
+    FLOX_LOG("[myexchange] Connecting...");
+    // ... connect to exchange
+
+    while (_running) {
+      // ... receive and process messages
+    }
+
+    FLOX_LOG("[myexchange] Disconnected");
+  }
+
+  void onTradeMessage(/* ... */) {
+    TradeEvent ev;
+    ev.trade.symbol = _symbol;
+    ev.trade.price = Price::fromDouble(/* ... */);
+    ev.trade.quantity = Quantity::fromDouble(/* ... */);
+    ev.trade.isBuy = /* ... */;
+    ev.trade.exchangeTsNs = /* ... */;
+    ev.recvNs = nowNsMonotonic();
+
+    _tradeBus.publish(ev);
+  }
+
+  void onBookMessage(/* ... */) {
+    auto evOpt = _bookPool.acquire();
+    if (!evOpt) return;
+
+    auto& ev = *evOpt;
+    ev->update.symbol = _symbol;
+    ev->update.type = BookUpdateType::SNAPSHOT;
+    // ... populate bids/asks
+
+    ev->recvNs = nowNsMonotonic();
+    _bookBus.publish(std::move(ev));
+  }
+
+  SymbolId _symbol;
+  TradeBus& _tradeBus;
+  BookUpdateBus& _bookBus;
+
+  pool::Pool<BookUpdateEvent, 64> _bookPool;
+
+  std::atomic<bool> _running{false};
+  std::thread _thread;
+};
+
+}  // namespace myexchange
+```
+
+## See Also
+
+- [Architecture Overview](../explanation/architecture.md) — How connectors fit
+- [First Strategy Tutorial](../tutorials/first-strategy.md) — Consuming events
+
+==============================================================================
+# Section: How-to: project ops
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/configuration.md
+# URL: https://flox-foundation.github.io/flox/how-to/configuration/
+------------------------------------------------------------------------------
+
+# Configuration
+
+!!! info "C++ engine setup"
+    `EngineConfig` is how the **C++ engine** wires up exchanges, symbols, and the kill switch on startup. Python, Node.js, and Codon users build the equivalent imperatively (`flox.SymbolRegistry`, `flox.Runner`, etc.) — see the [Bindings](../bindings/README.md) page. This guide is for the C++ entrypoint.
+
+FLOX is configured via the `EngineConfig` structure, typically loaded from a JSON file or embedded configuration source.
+
+## Example Configuration
+
+```json
+{
+  "logLevel": "debug",
+  "exchanges": [
+    {
+      "name": "bybit",
+      "type": "mock",
+      "symbols": [
+        { "symbol": "DOTUSDT", "tickSize": 0.001, "expectedDeviation": 0.5 }
+      ]
+    }
+  ],
+  "killSwitchConfig": {
+    "maxOrderQty": 10000,
+    "maxLoss": -5000,
+    "maxOrdersPerSecond": 100
+  }
+}
+```
+
+## Configuration Fields
+
+### `logLevel`
+
+Controls runtime logging verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `debug` | All messages including debug info |
+| `info` | Informational messages and above |
+| `warn` | Warnings and errors only |
+| `error` | Errors only |
+
+### `exchanges[]`
+
+Defines which exchange connectors to start and which symbols to subscribe to.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Display label or unique ID for internal routing |
+| `type` | string | Used by `ConnectorFactory` to instantiate the appropriate connector |
+| `symbols[]` | array | List of symbol configs |
+
+#### Symbol Configuration
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `symbol` | string | Trading pair (e.g., "BTCUSDT") |
+| `tickSize` | number | Minimum price increment |
+| `expectedDeviation` | number | Allowed price deviation for validation |
+
+### `killSwitchConfig`
+
+Defines runtime shutdown thresholds:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `maxOrderQty` | number | 10000 | Maximum order size allowed per submission |
+| `maxLoss` | number | -1000000 | Hard limit on realized/unrealized loss (negative) |
+| `maxOrdersPerSecond` | number | -1 | Rate limit for outbound orders (`-1` disables) |
+
+### `logFile`
+
+Optional path to log file. If not set, logs go to stdout only.
+
+```json
+{
+  "logFile": "/var/log/flox/engine.log"
+}
+```
+
+### `drainTimeoutMs`
+
+Timeout in milliseconds for draining in-flight orders on shutdown. Default: `5000`.
+
+## Loading Configuration
+
+### From JSON File
+
+```cpp
+#include "flox/engine/engine_config.h"
+#include <fstream>
+
+EngineConfig loadConfig(const std::string& path) {
+    std::ifstream file(path);
+    nlohmann::json j;
+    file >> j;
+    return j.get<EngineConfig>();
+}
+
+int main() {
+    auto config = loadConfig("config.json");
+    Engine engine(config, subsystems, connectors);
+    engine.start();
+}
+```
+
+### Programmatic Configuration
+
+```cpp
+EngineConfig config;
+config.logLevel = LogLevel::INFO;
+
+ExchangeConfig exchange;
+exchange.name = "binance";
+exchange.type = "binance_futures";
+
+SymbolConfig symbol;
+symbol.symbol = "BTCUSDT";
+symbol.tickSize = 0.1;
+config.exchanges.push_back(exchange);
+
+config.killSwitchConfig.maxOrderQty = 10000;
+config.killSwitchConfig.maxLoss = -5000;
+config.killSwitchConfig.maxOrdersPerSecond = 100;
+```
+
+## Symbol Registration
+
+`SymbolId` is derived automatically from `(exchange, symbol)` during engine startup:
+
+```cpp
+// During startup, the engine registers symbols
+for (const auto& exchange : config.exchanges) {
+    for (const auto& sym : exchange.symbols) {
+        auto symbolId = registry.registerSymbol(exchange.name, sym.symbol);
+        // symbolId is now available for use throughout the system
+    }
+}
+```
+
+## Environment Variables
+
+Some settings can be overridden via environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `FLOX_LOG_LEVEL` | Override log level |
+| `FLOX_CONFIG_PATH` | Default config file path |
+
+## Validation
+
+Configuration is validated at startup:
+
+```cpp
+void validateConfig(const EngineConfig& config) {
+    if (config.exchanges.empty()) {
+        throw std::invalid_argument("At least one exchange required");
+    }
+
+    for (const auto& ex : config.exchanges) {
+        if (ex.symbols.empty()) {
+            throw std::invalid_argument("Exchange must have symbols");
+        }
+        for (const auto& sym : ex.symbols) {
+            if (sym.tickSize <= 0) {
+                throw std::invalid_argument("tickSize must be positive");
+            }
+        }
+    }
+}
+```
+
+## Notes
+
+- Tick size and deviation are used by validators and order book alignment
+- All configuration is immutable after startup for safety and determinism
+- Use different config files for development, testing, and production
+
+## See Also
+
+- [Quickstart](../tutorials/quickstart.md) — Build and run FLOX
+- [Run the Demo](../tutorials/demo.md) — See configuration in action
+- [Architecture](../explanation/architecture.md) — How config affects components
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/ci.md
+# URL: https://flox-foundation.github.io/flox/how-to/ci/
+------------------------------------------------------------------------------
+
+# Continuous Integration
+
+FLOX uses GitHub Actions for continuous integration. The CI pipeline runs on every push and pull request to ensure code quality and cross-platform compatibility.
+
+## CI Matrix
+
+| Job | Platform | Compiler | Build Type | Description |
+|-----|----------|----------|------------|-------------|
+| `format-check` | Ubuntu | - | - | Validates code formatting with clang-format |
+| `linux-gcc` | Ubuntu 24.04 | GCC 14 | Release | Main Linux build |
+| `linux-clang` | Ubuntu 24.04 | Clang 18 + libc++ | Release | Clang with libc++ standard library |
+| `sanitizers` | Ubuntu 24.04 | GCC 14 | Debug | ASan and UBSan for memory/UB detection |
+| `macos` | macOS latest | Apple Clang | Release | macOS compatibility |
+| `windows-msvc` | Windows latest | MSVC | Release | Windows with MSVC toolchain |
+| `windows-clang-cl` | Windows latest | Clang-CL | Release | Windows with Clang frontend |
+| `affinity-tests` | Ubuntu 24.04 | GCC 14 | Release | Weekly CPU affinity tests (scheduled) |
+
+## Build Configuration
+
+All builds use **Release mode only**. Debug builds are intentionally excluded because:
+
+1. Sanitizers (ASan, UBSan) catch memory and undefined behavior issues better than Debug assertions
+2. Release mode tests the actual production code path
+3. Reduces CI time and resource usage
+
+## Sanitizers
+
+The `sanitizers` job runs with both AddressSanitizer and UndefinedBehaviorSanitizer:
+
+```yaml
+matrix:
+  sanitizer: [address, undefined]
+```
+
+| Sanitizer | Detects |
+|-----------|---------|
+| AddressSanitizer | Buffer overflows, use-after-free, memory leaks |
+| UndefinedBehaviorSanitizer | Signed overflow, null pointer dereference, alignment issues |
+
+Sanitizer options:
+
+```
+ASAN_OPTIONS: detect_leaks=1:abort_on_error=1
+UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+```
+
+## Weekly Affinity Tests
+
+CPU affinity tests run weekly (Sunday 3:00 UTC) because:
+
+- Require `libnuma-dev` which isn't available on all platforms
+- GitHub runners don't have isolated cores for reliable affinity testing
+- Tests verify the affinity API works, not that it improves performance
+
+## Running CI Locally
+
+### Format Check
+
+```bash
+./scripts/check-format.sh
+```
+
+### Build with GCC
+
+```bash
+cmake -B build -G Ninja \
+  -DCMAKE_CXX_COMPILER=g++-14 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DFLOX_ENABLE_TESTS=ON \
+  -DFLOX_ENABLE_BENCHMARKS=ON \
+  -DFLOX_ENABLE_DEMO=ON \
+  -DFLOX_ENABLE_LZ4=ON \
+  -DFLOX_ENABLE_BACKTEST=ON
+
+cmake --build build -j$(nproc)
+ctest --output-on-failure --test-dir build
+```
+
+### Build with Sanitizers
+
+```bash
+cmake -B build -G Ninja \
+  -DCMAKE_CXX_COMPILER=g++-14 \
+  -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer -g" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DFLOX_ENABLE_TESTS=ON
+
+cmake --build build
+ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest --output-on-failure --test-dir build
+```
+
+## Dependencies
+
+### Ubuntu
+
+```bash
+sudo apt-get install cmake ninja-build liblz4-dev g++-14
+```
+
+### macOS
+
+```bash
+brew install cmake ninja lz4
+```
+
+### Windows
+
+Uses vcpkg for dependencies:
+
+```powershell
+vcpkg install lz4:x64-windows gtest:x64-windows benchmark:x64-windows
+```
+
+## See Also
+
+- [Configuration](configuration.md) - Runtime configuration
+
+------------------------------------------------------------------------------
+# Source: docs/how-to/contributing.md
+# URL: https://flox-foundation.github.io/flox/how-to/contributing/
+------------------------------------------------------------------------------
+
+# Contributing
+
+Guidelines for contributing to FLOX.
+
+## Code Style
+
+A `.clang-format` file is provided in the repository. All C++ code must be formatted before committing.
+
+### clang-format Setup
+
+Install clang-format 18.x:
+
+```bash
+sudo apt install -y wget gnupg lsb-release software-properties-common
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh 18
+sudo apt install -y clang-format-18
+sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100
+```
+
+### Pre-commit Hook
+
+A `pre-commit` hook is installed automatically during CMake configuration. It formats all changed `.cpp` and `.h` files before each commit.
+
+To install manually:
+
+```bash
+cp scripts/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+## Pull Request Process
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes
+4. Ensure code is formatted (`clang-format`)
+5. Add tests for new functionality
+6. Run tests: `ctest --output-on-failure`
+7. Submit a pull request
+
+## Guidelines
+
+- Use existing naming and directory conventions
+- Add tests for new features
+- Add benchmarks for performance-critical code
+- Update documentation where appropriate
+- Keep commits focused and atomic
+
+## What to Contribute
+
+FLOX welcomes contributions in these areas:
+
+- **Features** — New functionality and capabilities
+- **Connectors** — New exchange integrations
+- **Bug fixes** — Correctness improvements
+- **Performance** — Latency and throughput optimizations
+- **Documentation** — Examples, tutorials, clarifications
+- **Tests** — Improved coverage
+
+## Build Options Reference
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `FLOX_ENABLE_TESTS` | `OFF` | Build unit tests |
+| `FLOX_ENABLE_BENCHMARKS` | `OFF` | Build benchmark binaries |
+| `FLOX_ENABLE_DEMO` | `OFF` | Build demo application |
+| `FLOX_ENABLE_TOOLS` | `OFF` | Build command-line tools (preagg_bars, etc.) |
+| `FLOX_ENABLE_BACKTEST` | `OFF` | Build backtest module (simulated execution) |
+| `FLOX_ENABLE_LZ4` | `OFF` | Enable LZ4 compression for binary logs |
+| `FLOX_ENABLE_CPU_AFFINITY` | `OFF` | Enable CPU affinity and NUMA functionality |
+| `FLOX_ENABLE_TRACY` | `OFF` | Enable Tracy profiler integration |
+| `FLOX_ENABLE_DEV_SETUP` | `OFF` | Install pre-commit hook automatically |
+
+Enable with:
+
+```bash
+cmake .. -DFLOX_ENABLE_TESTS=ON -DFLOX_ENABLE_BENCHMARKS=ON
+```
+
+## See Also
+
+- [Quickstart](../tutorials/quickstart.md) — Build and run FLOX
+- [Architecture](../explanation/architecture.md) — Understand the codebase
+
+==============================================================================
+# Section: Reference: Python
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/index.md
+# URL: https://flox-foundation.github.io/flox/reference/python/
+------------------------------------------------------------------------------
+
+# Python API Reference
+
+Complete reference for the `flox_py` Python module. All classes and functions are available directly from `import flox_py`.
+
+## Installation
+
+```bash
+pip install flox-py
+```
+
+Or build from source:
+
+```bash
+cmake -B build -DFLOX_ENABLE_PYTHON=ON -DFLOX_ENABLE_BACKTEST=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| [Engine & Backtest](engine.md) | Backtest engine, signal creation, batch execution |
+| [Indicators](indicators.md) | 20+ technical indicators (EMA, RSI, MACD, ATR, ...) |
+| [Aggregators](aggregators.md) | Bar aggregation (time, tick, volume, range, renko, Heikin-Ashi) |
+| [Order Books](books.md) | NLevelOrderBook, L3OrderBook, CompositeBookMatrix |
+| [Profiles](profiles.md) | Footprint bars, volume profile, market profile |
+| [Positions](positions.md) | Position tracking, group management, order tracking |
+| [Replay](replay.md) | Binary log reader/writer, market data recorder |
+| [Segment Ops](segment_ops.md) | Merge, split, export, validate, partition data |
+| [Backtest Components](backtest.md) | SimulatedExecutor, fills, trade records |
+| [Optimizer](optimizer.md) | Permutation test, correlation, bootstrap CI |
+
+## Conventions
+
+- **Prices and quantities** are passed as `float64` and converted to fixed-point (`int64`, scale 10^8) internally.
+- **Timestamps** are `int64` nanoseconds. Millisecond and microsecond inputs are auto-detected and converted.
+- **Numpy arrays** are the primary data format. Structured arrays use packed C structs for zero-copy access.
+- **GIL release**: All compute-heavy functions release the Python GIL for true parallelism.
+- **Raw values**: Fields ending in `_raw` are fixed-point integers (value * 10^8). Divide by `1e8` to get floats.
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/engine.md
+# URL: https://flox-foundation.github.io/flox/reference/python/engine/
+------------------------------------------------------------------------------
+
+# Engine & Backtest
+
+The core backtest engine. Load OHLCV data once, then run unlimited backtests with different signal sets.
+
+## Engine
+
+```python
+engine = flox.Engine(initial_capital=100_000, fee_rate=0.0001)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `initial_capital` | `float` | `100000.0` | Starting capital |
+| `fee_rate` | `float` | `0.0001` | Fee rate per trade (percentage mode) |
+
+### Methods
+
+#### `load_bars(bars)`
+
+Load bars from a numpy structured array with `PyBar` dtype.
+
+```python
+bars = np.zeros(n, dtype=flox.PyBar)
+bars['timestamp_ns'] = timestamps
+bars['open_raw'] = (opens * 1e8).astype(np.int64)
+bars['high_raw'] = (highs * 1e8).astype(np.int64)
+bars['low_raw'] = (lows * 1e8).astype(np.int64)
+bars['close_raw'] = (closes * 1e8).astype(np.int64)
+bars['volume_raw'] = (volumes * 1e8).astype(np.int64)
+engine.load_bars(bars)
+```
+
+#### `load_bars_df(timestamps, open, high, low, close, volume)`
+
+Load bars from separate numpy arrays (float64). Timestamps are auto-normalized to nanoseconds.
+
+```python
+engine.load_bars_df(timestamps, opens, highs, lows, closes, volumes)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `timestamps` | `int64[]` | Unix timestamps (s, ms, us, or ns — auto-detected) |
+| `open` | `float64[]` | Open prices |
+| `high` | `float64[]` | High prices |
+| `low` | `float64[]` | Low prices |
+| `close` | `float64[]` | Close prices |
+| `volume` | `float64[]` | Volume |
+
+#### `run(signals, symbol=1) -> dict`
+
+Run a single backtest. Returns a stats dictionary.
+
+```python
+stats = engine.run(signals, symbol=1)
+print(stats['net_pnl'], stats['sharpe'])
+```
+
+**Return keys:**
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `total_trades` | `int` | Round-trip trade count |
+| `winning_trades` | `int` | Profitable trade count |
+| `losing_trades` | `int` | Losing trade count |
+| `initial_capital` | `float` | Starting capital |
+| `final_capital` | `float` | Ending capital |
+| `total_pnl` | `float` | Gross PnL |
+| `total_fees` | `float` | Total fees paid |
+| `net_pnl` | `float` | PnL after fees |
+| `gross_profit` | `float` | Sum of winning trades |
+| `gross_loss` | `float` | Sum of losing trades |
+| `max_drawdown` | `float` | Maximum drawdown (absolute) |
+| `max_drawdown_pct` | `float` | Maximum drawdown (percentage) |
+| `win_rate` | `float` | Fraction of winning trades |
+| `profit_factor` | `float` | Gross profit / gross loss |
+| `avg_win` | `float` | Average winning trade |
+| `avg_loss` | `float` | Average losing trade |
+| `sharpe` | `float` | Annualized Sharpe ratio |
+| `sortino` | `float` | Annualized Sortino ratio |
+| `calmar` | `float` | Calmar ratio |
+| `return_pct` | `float` | Net return percentage |
+
+#### `run_batch(signal_sets, threads=0, symbol=1) -> list[dict]`
+
+Run N backtests in parallel using C++ threads. GIL released.
+
+```python
+results = engine.run_batch([signals_1, signals_2, ...], threads=0)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `signal_sets` | `list` | — | List of signal arrays |
+| `threads` | `int` | `0` | Thread count (0 = all cores) |
+| `symbol` | `int` | `1` | Symbol ID |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `bar_count` | `int` | Number of loaded bars |
+
+---
+
+## make_signals()
+
+Create a packed signal array from separate numpy arrays.
+
+```python
+signals = flox.make_signals(
+    timestamps,   # int64 — unix ms, us, or ns
+    sides,        # uint8 — 0=buy, 1=sell
+    quantities,   # float64 — position size
+    prices=None,  # float64 — limit price (optional)
+    types=None,   # uint8 — 0=market, 1=limit (optional)
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `timestamps` | `int64[]` | — | Trade timestamps (auto-normalized to ns) |
+| `sides` | `uint8[]` | — | 0 = buy, 1 = sell |
+| `quantities` | `float64[]` | — | Position sizes |
+| `prices` | `float64[]` | `None` | Limit prices (omit for market orders) |
+| `types` | `uint8[]` | `None` | Order types: 0 = market, 1 = limit |
+
+**Returns:** `numpy.ndarray` with `PySignal` dtype.
+
+---
+
+## Structured Dtypes
+
+### PySignal
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp_ns` | `int64` | Timestamp in nanoseconds |
+| `quantity_raw` | `int64` | Quantity * 10^8 |
+| `price_raw` | `int64` | Price * 10^8 (0 for market) |
+| `side` | `uint8` | 0 = buy, 1 = sell |
+| `order_type` | `uint8` | 0 = market, 1 = limit |
+
+### PyBar
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp_ns` | `int64` | Bar timestamp in nanoseconds |
+| `open_raw` | `int64` | Open * 10^8 |
+| `high_raw` | `int64` | High * 10^8 |
+| `low_raw` | `int64` | Low * 10^8 |
+| `close_raw` | `int64` | Close * 10^8 |
+| `volume_raw` | `int64` | Volume * 10^8 |
+
+---
+
+## Example
+
+```python
+import numpy as np
+import flox_py as flox
+
+engine = flox.Engine(initial_capital=100_000, fee_rate=0.0001)
+engine.load_bars_df(timestamps, opens, highs, lows, closes, volumes)
+
+# Simple MA crossover signals
+fast = flox.ema(closes, 10)
+slow = flox.ema(closes, 30)
+
+cross_up = (fast[1:] > slow[1:]) & (fast[:-1] <= slow[:-1])
+cross_down = (fast[1:] < slow[1:]) & (fast[:-1] >= slow[:-1])
+
+ts_list, side_list, qty_list = [], [], []
+for i in range(len(cross_up)):
+    if cross_up[i]:
+        ts_list.append(timestamps[i + 1])
+        side_list.append(0)  # buy
+        qty_list.append(1.0)
+    elif cross_down[i]:
+        ts_list.append(timestamps[i + 1])
+        side_list.append(1)  # sell
+        qty_list.append(1.0)
+
+signals = flox.make_signals(
+    np.array(ts_list, dtype=np.int64),
+    np.array(side_list, dtype=np.uint8),
+    np.array(qty_list, dtype=np.float64),
+)
+
+stats = engine.run(signals)
+print(f"Net PnL: {stats['net_pnl']:.2f}, Sharpe: {stats['sharpe']:.4f}")
+```
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/strategy.md
+# URL: https://flox-foundation.github.io/flox/reference/python/strategy/
+------------------------------------------------------------------------------
+
+# Strategy API
+
+Event-driven strategy classes for Python. Mirrors C++ `flox::Strategy`.
+
+## Class: `flox_py.Symbol`
+
+Returned by `SymbolRegistry.add_symbol`. Works transparently as an `int` wherever a symbol ID is expected.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `int` | Numeric symbol ID |
+| `name` | `str` | Symbol name, e.g. `"BTCUSDT"` |
+| `exchange` | `str` | Exchange name, e.g. `"binance"` |
+| `tick_size` | `float` | Minimum price increment |
+
+```python
+int(btc)   # 1
+print(btc) # Symbol(binance:BTCUSDT, id=1)
+```
+
+## Class: `flox_py.SymbolRegistry`
+
+```python
+registry = flox.SymbolRegistry()
+btc = registry.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `add_symbol(exchange, name, tick_size)` | `Symbol` | Register a symbol and return its `Symbol` object |
+
+## Class: `flox_py.Strategy`
+
+### Constructor
+
+```python
+Strategy(symbols: list[Symbol | int])
+```
+
+`symbols` — list of `Symbol` objects or raw integer IDs to subscribe to.
+
+### Overridable Callbacks
+
+#### `on_trade(ctx: SymbolContext, trade: TradeData)`
+
+Called on each trade event for subscribed symbols.
+
+```python
+def on_trade(self, ctx, trade):
+    if ctx.is_flat():
+        self.market_buy(0.01)
+```
+
+#### `on_book_update(ctx: SymbolContext)`
+
+Called on each order book update.
+
+#### `on_bar(ctx: SymbolContext, bar: BarData)`
+
+Called on each closed OHLC bar. `bar` exposes `open`, `high`, `low`, `close`,
+`volume`, `buy_volume`, `start_time_ns`, `end_time_ns`, `bar_type`,
+`bar_type_param`, `close_reason`. Use `BacktestRunner.run_bars(...)` to replay
+historical bars or `Runner.on_bar(...)` to push live bars.
+
+```python
+def on_bar(self, ctx, bar):
+    # detect breakout on bar close
+    if bar.close > self.prev_high and ctx.is_flat():
+        self.market_buy(0.01)
+    self.prev_high = max(getattr(self, "prev_high", 0.0), bar.high)
+```
+
+#### `on_start()` / `on_stop()`
+
+Lifecycle callbacks.
+
+### Order Emission — Shorthand
+
+These methods use the first registered symbol when `symbol` is omitted.
+
+| Method | Description |
+|--------|-------------|
+| `market_buy(qty, symbol=None)` | Market buy |
+| `market_sell(qty, symbol=None)` | Market sell |
+| `limit_buy(price, qty, symbol=None)` | Limit buy |
+| `limit_sell(price, qty, symbol=None)` | Limit sell |
+| `stop_market(side, trigger, qty, symbol=None)` | Stop market |
+| `close_position(symbol=None)` | Close position (reduce-only) |
+
+### Order Emission — Explicit (emit_* variants)
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `emit_market_buy(symbol, qty)` | `int` | Market buy, returns order ID |
+| `emit_market_sell(symbol, qty)` | `int` | Market sell |
+| `emit_limit_buy(symbol, price, qty)` | `int` | Limit buy |
+| `emit_limit_sell(symbol, price, qty)` | `int` | Limit sell |
+| `emit_cancel(order_id)` | `None` | Cancel order |
+| `emit_cancel_all(symbol)` | `None` | Cancel all orders for symbol |
+| `emit_modify(order_id, price, qty)` | `None` | Modify existing order |
+| `emit_stop_market(symbol, side, trigger, qty)` | `int` | Stop market order |
+| `emit_stop_limit(symbol, side, trigger, limit, qty)` | `int` | Stop limit order |
+| `emit_take_profit_market(symbol, side, trigger, qty)` | `int` | Take profit market |
+| `emit_take_profit_limit(symbol, side, trigger, limit, qty)` | `int` | Take profit limit |
+| `emit_trailing_stop(symbol, side, offset, qty)` | `int` | Trailing stop |
+| `emit_trailing_stop_percent(symbol, side, bps, qty)` | `int` | Trailing stop (%) |
+| `emit_close_position(symbol)` | `int` | Close position (reduce-only) |
+
+### Context Queries
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `position(symbol)` | `float` | Current position quantity |
+| `ctx(symbol)` | `SymbolContext` | Per-symbol context snapshot |
+| `get_order_status(order_id)` | `int` | Order status (-1 if not found) |
+
+## Class: `flox_py.SymbolContext`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `symbol_id` | `int` | Symbol identifier |
+| `position` | `float` | Current position |
+| `last_trade_price` | `float` | Last trade price |
+| `best_bid` | `float` | Best bid price |
+| `best_ask` | `float` | Best ask price |
+| `mid_price` | `float` | Mid price |
+| `unrealized_pnl` | `float` | Unrealized P&L |
+| `book_spread()` | `float` | Bid-ask spread |
+| `is_long()` | `bool` | True if long |
+| `is_short()` | `bool` | True if short |
+| `is_flat()` | `bool` | True if no position |
+
+## Class: `flox_py.TradeData`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `symbol` | `int` | Symbol ID |
+| `price` | `float` | Trade price |
+| `quantity` | `float` | Trade quantity |
+| `is_buy` | `bool` | Buy-side aggressor |
+| `timestamp_ns` | `int` | Timestamp (nanoseconds) |
+
+## Class: `flox_py.Runner`
+
+Feeds market data into strategies and routes emitted signals to a callback.
+
+```python
+runner = flox.Runner(registry, on_signal)                  # synchronous
+runner = flox.Runner(registry, on_signal, threaded=True)   # Disruptor background thread
+
+runner.add_strategy(strategy)
+runner.start()
+runner.on_trade(symbol, price, qty, is_buy, ts_ns)
+runner.on_book_snapshot(symbol, bid_prices, bid_qtys, ask_prices, ask_qtys, ts_ns)
+runner.on_bar(symbol, open, high, low, close, volume, ...)
+runner.stop()
+```
+
+| Method | Description |
+|--------|-------------|
+| `add_strategy(strategy)` | Register a strategy instance |
+| `start()` | Start the runner |
+| `stop()` | Stop the runner |
+| `on_trade(symbol, price, qty, is_buy, ts_ns)` | Inject a trade event |
+| `on_book_snapshot(symbol, bid_px, bid_qty, ask_px, ask_qty, ts_ns)` | Inject an order book snapshot |
+| `on_bar(symbol, open, high, low, close, volume=0, buy_volume=0, start_time_ns=0, end_time_ns=0, bar_type=0, bar_type_param=0, close_reason=0)` | Inject a closed OHLC bar |
+
+`symbol` accepts a `Symbol` object or a raw `int`.
+
+### Signal object
+
+Passed to the `on_signal` callback.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `side` | `str` | `"buy"` or `"sell"` |
+| `quantity` | `float` | Order quantity |
+| `price` | `float` | Limit price (0 for market) |
+| `order_type` | `str` | `"market"`, `"limit"`, etc. |
+| `order_id` | `int` | Internal order ID |
+
+## Class: `flox_py.BacktestRunner`
+
+Runs a strategy against historical CSV data.
+
+```python
+bt = flox.BacktestRunner(registry, fee_rate=0.0004, initial_capital=10_000)
+bt.set_strategy(strategy)
+
+stats = bt.run_csv("data.csv")             # auto-detects symbol from registry
+stats = bt.run_csv("data.csv", "BTCUSDT")  # explicit symbol name
+```
+
+| Method | Description |
+|--------|-------------|
+| `set_strategy(strategy)` | Set the strategy to backtest |
+| `run_csv(path, symbol=None)` | Run backtest against a CSV file, returns stats dict |
+| `run_ohlcv(ts, close, symbol=None)` | Replay close-only bars as synthetic trades (`Strategy.on_trade` fires) |
+| `run_bars(start_time_ns, end_time_ns, open, high, low, close, volume, symbol=None, bar_type=0, bar_type_param=0)` | Replay full OHLCV bars (`Strategy.on_bar` fires) |
+
+### Stats dict keys
+
+| Key | Description |
+|-----|-------------|
+| `return_pct` | Net return percentage |
+| `net_pnl` | Net P&L after fees |
+| `total_trades` | Round-trip trade count |
+| `win_rate` | Winning trade fraction |
+| `sharpe` | Annualized Sharpe ratio |
+| `max_drawdown_pct` | Peak-to-trough drawdown (%) |
+
+## Example
+
+```python
+import flox_py as flox
+
+registry = flox.SymbolRegistry()
+btc = registry.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+
+class SMAcross(flox.Strategy):
+    def __init__(self, symbols):
+        super().__init__(symbols)
+        self.fast = flox.SMA(10)
+        self.slow = flox.SMA(30)
+
+    def on_trade(self, ctx, trade):
+        f = self.fast.update(trade.price)
+        s = self.slow.update(trade.price)
+        if f is None or s is None:
+            return
+        if f > s and ctx.is_flat():
+            self.market_buy(0.01)
+        elif f < s and ctx.is_long():
+            self.close_position()
+
+# Live
+def on_signal(sig):
+    print(sig.side, sig.order_type, sig.quantity)
+
+runner = flox.Runner(registry, on_signal)
+runner.add_strategy(SMAcross([btc]))
+runner.start()
+
+# Backtest
+bt = flox.BacktestRunner(registry, fee_rate=0.0004, initial_capital=10_000)
+bt.set_strategy(SMAcross([btc]))
+stats = bt.run_csv("btcusdt_trades.csv", "BTCUSDT")
+print(stats)
+```
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/indicators.md
+# URL: https://flox-foundation.github.io/flox/reference/python/indicators/
+------------------------------------------------------------------------------
+
+# Indicators
+
+Vectorized technical indicators operating on numpy arrays. All functions release the GIL for parallel computation.
+
+## Streaming classes
+
+All streaming indicators share the same interface:
+
+```python
+ind = flox.EMA(20)
+result = ind.update(price)  # None during warmup, float when ready
+ind.value                   # None or float
+ind.ready                   # bool
+ind.reset()                 # clear state, keep config
+ind2 = ind.fresh()          # new independent instance, same config
+```
+
+During warmup, `update()` and `.value` return `None`. Check with `if result is not None` or use `.ready`.
+
+**Single value** — `update(value) -> float | None`:
+
+`SMA(period)`, `EMA(period)`, `RMA(period)`, `RSI(period)`, `DEMA(period)`, `TEMA(period)`, `KAMA(period, fast=2, slow=30)`, `Slope(length)`, `Skewness(period)`, `Kurtosis(period)`, `RollingZScore(period)`, `ShannonEntropy(period, bins=10)`
+
+**Multi-output** — `update(value) -> float | None`, named properties instead of `.value`:
+
+`MACD(fast=12, slow=26, signal=9)` → `.line`, `.signal`, `.histogram`  
+`Bollinger(period=20, multiplier=2.0)` → `.upper`, `.middle`, `.lower`
+
+**OHLC / multi-input:**
+
+`ATR(period)` — `update(high, low, close)`  
+`Stochastic(k_period=14, d_period=3)` — `update(high, low, close)` → `.k`, `.d`  
+`CCI(period=20)` — `update(high, low, close)`  
+`ParkinsonVol(period)` — `update(high, low)`  
+`RogersSatchellVol(period)` — `update(open, high, low, close)`  
+`Correlation(period)` — `update(x, y)`
+
+**Volume:**
+
+`OBV()` — `update(close, volume)`  
+`VWAP(window)` — `update(close, volume)`  
+`CVD()` — `update(open, high, low, close, volume)`
+
+---
+
+## Batch functions
+
+## Moving Averages
+
+### `ema(input, period) -> ndarray`
+
+Exponential Moving Average.
+
+```python
+result = flox.ema(closes, period=20)
+```
+
+### `sma(input, period) -> ndarray`
+
+Simple Moving Average.
+
+```python
+result = flox.sma(closes, period=20)
+```
+
+### `rma(input, period) -> ndarray`
+
+Wilder's Moving Average (alpha = 1/period). Used internally by RSI and ATR.
+
+```python
+result = flox.rma(closes, period=14)
+```
+
+### `dema(input, period) -> ndarray`
+
+Double EMA: `2*EMA - EMA(EMA)`. Reduces lag versus standard EMA.
+
+```python
+result = flox.dema(closes, period=20)
+```
+
+### `tema(input, period) -> ndarray`
+
+Triple EMA: `3*EMA - 3*EMA(EMA) + EMA(EMA(EMA))`. Further lag reduction.
+
+```python
+result = flox.tema(closes, period=20)
+```
+
+### `kama(input, period=10) -> ndarray`
+
+Kaufman Adaptive Moving Average. Adjusts smoothing based on market efficiency.
+
+```python
+result = flox.kama(closes, period=10)
+```
+
+---
+
+## Oscillators
+
+### `rsi(input, period) -> ndarray`
+
+Relative Strength Index (0–100).
+
+```python
+result = flox.rsi(closes, period=14)
+```
+
+### `macd(input, fast=12, slow=26, signal=9) -> dict`
+
+Moving Average Convergence Divergence. Returns a dict with three arrays.
+
+```python
+result = flox.macd(closes, fast=12, slow=26, signal=9)
+# result['line'], result['signal'], result['histogram']
+```
+
+### `stochastic(high, low, close, k_period=14, d_period=3) -> dict`
+
+Stochastic oscillator (%K and %D).
+
+```python
+result = flox.stochastic(highs, lows, closes, k_period=14, d_period=3)
+k = result['k']
+d = result['d']
+```
+
+### `cci(high, low, close, period=20) -> ndarray`
+
+Commodity Channel Index.
+
+```python
+result = flox.cci(highs, lows, closes, period=20)
+```
+
+---
+
+## Trend
+
+### `adx(high, low, close, period=14) -> dict`
+
+Average Directional Index with directional indicators.
+
+```python
+result = flox.adx(highs, lows, closes, period=14)
+# result['adx'], result['plus_di'], result['minus_di']
+```
+
+### `chop(high, low, close, period=14) -> ndarray`
+
+Choppiness Index (0–100). High values indicate ranging markets.
+
+```python
+result = flox.chop(highs, lows, closes, period=14)
+```
+
+### `slope(input, length=1) -> ndarray`
+
+Linear slope over a lookback window.
+
+```python
+result = flox.slope(closes, length=5)
+```
+
+---
+
+## Volatility
+
+### `atr(high, low, close, period) -> ndarray`
+
+Average True Range.
+
+```python
+result = flox.atr(highs, lows, closes, period=14)
+```
+
+### `bollinger(input, period=20, stddev=2.0) -> dict`
+
+Bollinger Bands.
+
+```python
+result = flox.bollinger(closes, period=20, stddev=2.0)
+# result['upper'], result['middle'], result['lower']
+```
+
+---
+
+## Statistical
+
+### `skewness(input, period) -> ndarray`
+
+Rolling Fisher-Pearson skewness. Measures distribution asymmetry. Requires period >= 3. NaN if std = 0.
+
+```python
+result = flox.skewness(closes, period=20)
+```
+
+### `kurtosis(input, period) -> ndarray`
+
+Rolling Fisher excess kurtosis. Measures tail heaviness. Requires period >= 4. NaN if std = 0.
+
+```python
+result = flox.kurtosis(closes, period=20)
+```
+
+### `rolling_zscore(input, period) -> ndarray`
+
+Rolling z-score normalization: `(x - mean) / std`. NaN if std = 0.
+
+```python
+result = flox.rolling_zscore(closes, period=20)
+```
+
+### `shannon_entropy(input, period, bins=10) -> ndarray`
+
+Rolling Shannon entropy with histogram binning, normalized to [0, 1]. Zero = all values identical, 1 = uniform distribution.
+
+```python
+result = flox.shannon_entropy(closes, period=20, bins=10)
+```
+
+### `parkinson_vol(high, low, period) -> ndarray`
+
+Parkinson high-low volatility estimator: `sqrt(mean(ln(H/L)^2) / (4*ln(2)))`. More efficient than close-to-close volatility.
+
+```python
+result = flox.parkinson_vol(highs, lows, period=20)
+```
+
+### `rogers_satchell_vol(open, high, low, close, period) -> ndarray`
+
+Rogers-Satchell OHLC volatility estimator. Unbiased with drift, suitable for trending markets.
+
+```python
+result = flox.rogers_satchell_vol(opens, highs, lows, closes, period=20)
+```
+
+### `correlation(x, y, period) -> ndarray`
+
+Rolling Pearson correlation between two series. NaN if either series is constant within the window.
+
+```python
+result = flox.correlation(closes_btc, closes_eth, period=20)
+```
+
+---
+
+## Volume
+
+### `vwap(close, volume, window=96) -> ndarray`
+
+Rolling Volume-Weighted Average Price.
+
+```python
+result = flox.vwap(closes, volumes, window=96)
+```
+
+### `obv(close, volume) -> ndarray`
+
+On-Balance Volume.
+
+```python
+result = flox.obv(closes, volumes)
+```
+
+### `cvd(open, high, low, close, volume) -> ndarray`
+
+Cumulative Volume Delta. Estimates buying/selling pressure from OHLCV data.
+
+```python
+result = flox.cvd(opens, highs, lows, closes, volumes)
+```
+
+---
+
+## Strategy Helpers
+
+### `bar_returns(signal_long, signal_short, log_returns) -> ndarray`
+
+Compute per-bar returns given position signals and log returns.
+
+```python
+returns = flox.bar_returns(signal_long, signal_short, log_returns)
+```
+
+`signal_long` and `signal_short` are `int8[]` (+1 or 0 / -1 or 0). `log_returns` is `float64[]`.
+
+### `trade_pnl(signal_long, signal_short, log_returns) -> ndarray`
+
+Extract per-trade PnL from position signals.
+
+```python
+pnls = flox.trade_pnl(signal_long, signal_short, log_returns)
+```
+
+### `profit_factor(returns) -> float`
+
+Ratio of gross profit to gross loss. Values > 1.0 indicate profitability.
+
+```python
+pf = flox.profit_factor(returns)
+```
+
+### `win_rate(trade_pnls) -> float`
+
+Fraction of trades with positive PnL.
+
+```python
+wr = flox.win_rate(pnls)
+```
+
+## Indicator catalog
+
+<!-- INDICATOR-LIST-START -->
+
+Every indicator below is **one Python class** with both a batch
+`compute()` method and streaming `update()`/`value`/`ready`/`reset()`.
+Same instance, two ways to use it:
+
+```python
+import flox_py as flox
+ema = flox.EMA(10)
+out = ema.compute(prices)             # batch
+for v in stream:
+    ema.update(v)
+    if ema.ready: print(ema.value)    # streaming on the same instance
+```
+
+| Indicator | Constructor | Kind |
+|---|---|---|
+| `EMA` | `flox.EMA(period)` | SingleInput |
+| `SMA` | `flox.SMA(period)` | SingleInput |
+| `RMA` | `flox.RMA(period)` | SingleInput |
+| `RSI` | `flox.RSI(period)` | SingleInput |
+| `KAMA` | `flox.KAMA(period, fast, slow)` | SingleInput |
+| `DEMA` | `flox.DEMA(period)` | SingleInput |
+| `TEMA` | `flox.TEMA(period)` | SingleInput |
+| `Slope` | `flox.Slope(length)` | SingleInput |
+| `Skewness` | `flox.Skewness(period)` | SingleInput |
+| `Kurtosis` | `flox.Kurtosis(period)` | SingleInput |
+| `RollingZScore` | `flox.RollingZScore(period)` | SingleInput |
+| `ShannonEntropy` | `flox.ShannonEntropy(period, bins)` | SingleInput |
+| `AutoCorrelation` | `flox.AutoCorrelation(window, lag)` | SingleInput |
+| `ATR` | `flox.ATR(period)` | BarInput |
+| `CCI` | `flox.CCI(period)` | BarInput |
+| `Stochastic` | `flox.Stochastic(k_period, d_period)` | BarInput |
+| `ParkinsonVol` | `flox.ParkinsonVol(period)` | HighLowInput |
+| `RogersSatchellVol` | `flox.RogersSatchellVol(period)` | OhlcInput |
+| `Correlation` | `flox.Correlation(period)` | PairInput |
+| `MACD` | `flox.MACD(fast, slow, signal)` | MultiOutput |
+| `Bollinger` | `flox.Bollinger(period, stddev)` | MultiOutput |
+
+Discovery: `flox.list_indicators()` returns the full list at runtime.
+
+<!-- INDICATOR-LIST-END -->
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/aggregators.md
+# URL: https://flox-foundation.github.io/flox/reference/python/aggregators/
+------------------------------------------------------------------------------
+
+# Aggregators
+
+Aggregate raw trades into bars using different policies. All functions accept numpy arrays and release the GIL.
+
+## Common Parameters
+
+All aggregation functions share the same input signature:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `timestamps` | `int64[]` | Trade timestamps in nanoseconds |
+| `prices` | `float64[]` | Trade prices |
+| `quantities` | `float64[]` | Trade quantities |
+| `is_buy` | `uint8[]` | Buy/sell flag (1 = buy, 0 = sell) |
+
+**Returns:** `numpy.ndarray` with `PyExtBar` structured dtype.
+
+### PyExtBar Dtype
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `start_time_ns` | `int64` | Bar open timestamp (unix ns) |
+| `end_time_ns` | `int64` | Bar close timestamp (unix ns) |
+| `open_raw` | `int64` | Open price * 10^8 |
+| `high_raw` | `int64` | High price * 10^8 |
+| `low_raw` | `int64` | Low price * 10^8 |
+| `close_raw` | `int64` | Close price * 10^8 |
+| `volume_raw` | `int64` | Total volume * 10^8 |
+| `buy_volume_raw` | `int64` | Buy volume * 10^8 |
+| `trade_count` | `int64` | Number of trades in bar |
+
+---
+
+## Functions
+
+### `aggregate_time_bars(..., interval_seconds)`
+
+Aggregate trades into fixed time intervals.
+
+```python
+bars = flox.aggregate_time_bars(timestamps, prices, quantities, is_buy,
+                                 interval_seconds=60.0)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `interval_seconds` | `float` | Bar duration in seconds |
+
+### `aggregate_tick_bars(..., tick_count)`
+
+Aggregate trades into bars with a fixed number of trades.
+
+```python
+bars = flox.aggregate_tick_bars(timestamps, prices, quantities, is_buy,
+                                 tick_count=100)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tick_count` | `int` | Trades per bar |
+
+### `aggregate_volume_bars(..., volume_threshold)`
+
+Aggregate trades into bars when cumulative volume exceeds a threshold.
+
+```python
+bars = flox.aggregate_volume_bars(timestamps, prices, quantities, is_buy,
+                                   volume_threshold=1000.0)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `volume_threshold` | `float` | Volume per bar |
+
+### `aggregate_range_bars(..., range_size)`
+
+Aggregate trades into bars when price range exceeds a threshold.
+
+```python
+bars = flox.aggregate_range_bars(timestamps, prices, quantities, is_buy,
+                                  range_size=10.0)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `range_size` | `float` | Maximum price range per bar |
+
+### `aggregate_renko_bars(..., brick_size)`
+
+Aggregate trades into Renko bars with a fixed brick size.
+
+```python
+bars = flox.aggregate_renko_bars(timestamps, prices, quantities, is_buy,
+                                  brick_size=50.0)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `brick_size` | `float` | Renko brick size |
+
+### `aggregate_heikin_ashi_bars(..., interval_seconds)`
+
+Aggregate trades into Heikin-Ashi bars (smoothed candlesticks).
+
+```python
+bars = flox.aggregate_heikin_ashi_bars(timestamps, prices, quantities, is_buy,
+                                        interval_seconds=60.0)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `interval_seconds` | `float` | Bar duration in seconds |
+
+---
+
+## Example
+
+```python
+import numpy as np
+import flox_py as flox
+
+# Load trade data
+reader = flox.DataReader("./data")
+trades = reader.read_trades()
+
+ts = trades['exchange_ts_ns']
+px = trades['price_raw'] / 1e8
+qty = trades['qty_raw'] / 1e8
+side = trades['side']
+
+# Create 1-minute time bars
+bars = flox.aggregate_time_bars(ts, px, qty, side, interval_seconds=60.0)
+print(f"Generated {len(bars)} time bars")
+
+# Create 500-tick bars
+tick_bars = flox.aggregate_tick_bars(ts, px, qty, side, tick_count=500)
+print(f"Generated {len(tick_bars)} tick bars")
+
+# Access bar data
+opens = bars['open_raw'] / 1e8
+highs = bars['high_raw'] / 1e8
+lows = bars['low_raw'] / 1e8
+closes = bars['close_raw'] / 1e8
+```
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/books.md
+# URL: https://flox-foundation.github.io/flox/reference/python/books/
+------------------------------------------------------------------------------
+
+# Order Books
+
+Order book implementations for managing price levels and simulating market impact.
+
+## OrderBook
+
+N-level order book with snapshot and delta support. Backed by the C++ `NLevelOrderBook<8192>`.
+
+```python
+book = flox.OrderBook(tick_size=0.01)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tick_size` | `float` | Minimum price increment |
+
+### Methods
+
+#### `apply_snapshot(bid_prices, bid_quantities, ask_prices, ask_quantities)`
+
+Apply a full book snapshot (replaces existing book state).
+
+```python
+book.apply_snapshot(
+    bid_prices=np.array([100.0, 99.99, 99.98]),
+    bid_quantities=np.array([10.0, 25.0, 15.0]),
+    ask_prices=np.array([100.01, 100.02, 100.03]),
+    ask_quantities=np.array([8.0, 20.0, 12.0]),
+)
+```
+
+#### `apply_delta(bid_prices, bid_quantities, ask_prices, ask_quantities)`
+
+Apply an incremental update (quantity=0 removes level).
+
+```python
+book.apply_delta(
+    bid_prices=np.array([100.0]),
+    bid_quantities=np.array([15.0]),  # update qty
+    ask_prices=np.array([100.01]),
+    ask_quantities=np.array([0.0]),   # remove level
+)
+```
+
+#### `best_bid() -> float | None`
+
+Best bid price, or `None` if book is empty.
+
+#### `best_ask() -> float | None`
+
+Best ask price, or `None` if book is empty.
+
+#### `mid() -> float | None`
+
+Mid price `(best_bid + best_ask) / 2`, or `None`.
+
+#### `spread() -> float | None`
+
+Bid-ask spread, or `None`.
+
+#### `bid_at_price(price) -> float`
+
+Quantity at a specific bid price level.
+
+#### `ask_at_price(price) -> float`
+
+Quantity at a specific ask price level.
+
+#### `get_bids(max_levels=20) -> ndarray`
+
+Get bid levels as Nx2 array `[price, quantity]`, sorted best-to-worst.
+
+```python
+bids = book.get_bids(max_levels=10)
+# bids[0] = [best_bid_price, best_bid_qty]
+```
+
+#### `get_asks(max_levels=20) -> ndarray`
+
+Get ask levels as Nx2 array `[price, quantity]`, sorted best-to-worst.
+
+#### `consume_asks(quantity) -> tuple[float, float]`
+
+Simulate a market buy order. Returns `(filled_qty, total_cost)`.
+
+```python
+filled, cost = book.consume_asks(100.0)
+avg_price = cost / filled if filled > 0 else 0
+```
+
+#### `consume_bids(quantity) -> tuple[float, float]`
+
+Simulate a market sell order. Returns `(filled_qty, total_cost)`.
+
+#### `is_crossed() -> bool`
+
+Check if the book is in a crossed state (best bid >= best ask).
+
+#### `clear()`
+
+Remove all price levels.
+
+---
+
+## L3Book
+
+Level-3 order book with individual order tracking. Backed by `L3OrderBook<8192>`.
+
+```python
+book = flox.L3Book()
+```
+
+### Methods
+
+#### `add_order(order_id, price, quantity, side) -> str`
+
+Add an order. Returns status: `"ok"`, `"no_capacity"`, `"extant"`.
+
+```python
+status = book.add_order(order_id=1, price=100.0, quantity=10.0, side="buy")
+```
+
+#### `remove_order(order_id) -> str`
+
+Remove an order by ID. Returns `"ok"` or `"not_found"`.
+
+#### `modify_order(order_id, new_quantity) -> str`
+
+Modify an order's quantity. Returns `"ok"` or `"not_found"`.
+
+#### `best_bid() -> float | None`
+
+Best bid price, or `None`.
+
+#### `best_ask() -> float | None`
+
+Best ask price, or `None`.
+
+#### `bid_at_price(price) -> float`
+
+Total bid quantity at a price level.
+
+#### `ask_at_price(price) -> float`
+
+Total ask quantity at a price level.
+
+#### `export_snapshot() -> list[dict]`
+
+Export all orders as a list of dicts.
+
+```python
+orders = book.export_snapshot()
+# [{"id": 1, "price": 100.0, "quantity": 10.0, "side": "buy"}, ...]
+```
+
+#### `build_from_snapshot(orders)`
+
+Rebuild the book from a snapshot.
+
+```python
+book.build_from_snapshot([
+    {"id": 1, "price": 100.0, "quantity": 10.0, "side": "buy"},
+    {"id": 2, "price": 100.01, "quantity": 5.0, "side": "sell"},
+])
+```
+
+---
+
+## CompositeBookMatrix
+
+Cross-exchange composite order book. Tracks best bid/ask across up to 4 exchanges per symbol with lock-free atomic reads.
+
+```python
+matrix = flox.CompositeBookMatrix(staleness_threshold_ms=5000)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `staleness_threshold_ms` | `int` | `5000` | Time in ms before a quote is considered stale |
+
+### Methods
+
+#### `update_book(exchange, symbol, bid_prices, bid_quantities, ask_prices, ask_quantities, recv_ns=0)`
+
+Feed a book update from an exchange.
+
+```python
+matrix.update_book(
+    exchange=0, symbol=1,
+    bid_prices=np.array([50000.0]),
+    bid_quantities=np.array([1.5]),
+    ask_prices=np.array([50001.0]),
+    ask_quantities=np.array([2.0]),
+    recv_ns=1704067200_000_000_000,
+)
+```
+
+#### `best_bid(symbol) -> dict | None`
+
+Best bid across all non-stale exchanges. Returns `{"price": float, "quantity": float, "exchange": int}` or `None`.
+
+```python
+bid = matrix.best_bid(symbol=1)
+if bid:
+    print(f"Best bid: {bid['price']} on exchange {bid['exchange']}")
+```
+
+#### `best_ask(symbol) -> dict | None`
+
+Best ask across all non-stale exchanges.
+
+#### `bid_for_exchange(symbol, exchange) -> dict | None`
+
+Best bid on a specific exchange.
+
+#### `ask_for_exchange(symbol, exchange) -> dict | None`
+
+Best ask on a specific exchange.
+
+#### `has_arbitrage_opportunity(symbol) -> bool`
+
+Returns `True` if the best bid on one exchange exceeds the best ask on another.
+
+```python
+if matrix.has_arbitrage_opportunity(symbol=1):
+    bid = matrix.best_bid(1)
+    ask = matrix.best_ask(1)
+    profit = bid['price'] - ask['price']
+    print(f"Arb: buy on ex{ask['exchange']} sell on ex{bid['exchange']}, profit={profit}")
+```
+
+#### `spread(symbol) -> float | None`
+
+Composite spread (best ask - best bid), or `None` if no valid quotes.
+
+#### `mark_stale(exchange, symbol)`
+
+Mark a specific exchange+symbol pair as stale (excluded from best quote queries).
+
+#### `mark_exchange_stale(exchange)`
+
+Mark all symbols on an exchange as stale (e.g., on disconnect).
+
+#### `check_staleness(now_ns)`
+
+Check all entries against the staleness threshold configured at construction.
+
+```python
+import time
+matrix.check_staleness(int(time.time_ns()))
+```
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/profiles.md
+# URL: https://flox-foundation.github.io/flox/reference/python/profiles/
+------------------------------------------------------------------------------
+
+# Profiles
+
+Order flow and volume analysis tools: footprint bars, volume profile, and market profile (TPO).
+
+## FootprintBar
+
+Tracks bid/ask volume at each price level within a bar for order flow analysis.
+
+```python
+fp = flox.FootprintBar(tick_size=0.01)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tick_size` | `float` | Price level granularity |
+
+### Methods
+
+#### `add_trade(price, quantity, is_buy)`
+
+Add a single trade.
+
+#### `add_trades(prices, quantities, is_buy)`
+
+Add trades from numpy arrays (GIL released).
+
+```python
+fp.add_trades(
+    prices=np.array([100.0, 100.01, 100.0]),
+    quantities=np.array([5.0, 3.0, 2.0]),
+    is_buy=np.array([1, 0, 1], dtype=np.uint8),
+)
+```
+
+#### `total_delta() -> float`
+
+Net delta (buy volume - sell volume).
+
+#### `total_volume() -> float`
+
+Total volume across all levels.
+
+#### `num_levels() -> int`
+
+Number of price levels with activity.
+
+#### `levels() -> list[dict]`
+
+All price levels with volume breakdown.
+
+```python
+for lvl in fp.levels():
+    print(f"{lvl['price']}: bid={lvl['bid_volume']}, ask={lvl['ask_volume']}, "
+          f"delta={lvl['delta']}, imbalance={lvl['imbalance_ratio']:.2f}")
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `price` | `float` | Price level |
+| `bid_volume` | `float` | Buy volume at level |
+| `ask_volume` | `float` | Sell volume at level |
+| `delta` | `float` | Bid - ask volume |
+| `imbalance_ratio` | `float` | Volume imbalance ratio |
+| `total_volume` | `float` | Total volume at level |
+
+#### `highest_buying_pressure() -> float`
+
+Price with the most buy volume.
+
+#### `highest_selling_pressure() -> float`
+
+Price with the most sell volume.
+
+#### `strongest_imbalance(threshold=0.7) -> float | None`
+
+Price level with the strongest volume imbalance above threshold, or `None`.
+
+#### `clear()`
+
+Reset all data.
+
+---
+
+## VolumeProfile
+
+Volume distribution across price levels. Computes POC, value area, and per-level delta.
+
+```python
+vp = flox.VolumeProfile(tick_size=0.01)
+```
+
+### Methods
+
+#### `add_trade(price, quantity, is_buy)`
+
+Add a single trade.
+
+#### `add_trades(prices, quantities, is_buy)`
+
+Add trades from numpy arrays (GIL released).
+
+#### `poc() -> float`
+
+Point of Control — price level with the highest volume.
+
+#### `value_area_high() -> float`
+
+Upper bound of the value area (70% of volume).
+
+#### `value_area_low() -> float`
+
+Lower bound of the value area.
+
+#### `total_volume() -> float`
+
+Total volume across all levels.
+
+#### `total_delta() -> float`
+
+Net delta across all levels.
+
+#### `num_levels() -> int`
+
+Number of active price levels.
+
+#### `levels() -> list[dict]`
+
+All levels with volume breakdown.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `price` | `float` | Price level |
+| `volume` | `float` | Total volume |
+| `buy_volume` | `float` | Buy volume |
+| `sell_volume` | `float` | Sell volume |
+| `delta` | `float` | Buy - sell volume |
+
+#### `volume_at(price) -> float`
+
+Volume at a specific price level.
+
+#### `clear()`
+
+Reset all data.
+
+---
+
+## MarketProfile
+
+Market Profile (TPO) aggregator. Tracks price activity across time periods for auction theory analysis.
+
+```python
+mp = flox.MarketProfile(tick_size=0.01, period_minutes=30, session_start_ns=start_ns)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tick_size` | `float` | Price level granularity |
+| `period_minutes` | `int` | TPO period duration |
+| `session_start_ns` | `int64` | Session start timestamp (unix ns) |
+
+### Methods
+
+#### `add_trade(timestamp_ns, price, quantity, is_buy)`
+
+Add a single trade with timestamp.
+
+#### `add_trades(timestamps_ns, prices, quantities, is_buy)`
+
+Add trades from numpy arrays (GIL released).
+
+#### `poc() -> float`
+
+Point of Control.
+
+#### `value_area_high() -> float`
+
+Value area high.
+
+#### `value_area_low() -> float`
+
+Value area low.
+
+#### `initial_balance_high() -> float`
+
+Initial balance high (first period's high).
+
+#### `initial_balance_low() -> float`
+
+Initial balance low (first period's low).
+
+#### `single_prints() -> list[float]`
+
+Price levels visited in only one TPO period (potential support/resistance).
+
+#### `is_poor_high() -> bool`
+
+Whether the profile has a poor high (weak auction at top).
+
+#### `is_poor_low() -> bool`
+
+Whether the profile has a poor low.
+
+#### `num_levels() -> int`
+
+Number of price levels.
+
+#### `current_period() -> int`
+
+Current TPO period index.
+
+#### `levels() -> list[dict]`
+
+All levels with TPO data.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `price` | `float` | Price level |
+| `tpo_count` | `int` | Number of TPO periods at this level |
+| `is_single_print` | `bool` | Only visited in one period |
+
+#### `clear()`
+
+Reset all data.
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/positions.md
+# URL: https://flox-foundation.github.io/flox/reference/python/positions/
+------------------------------------------------------------------------------
+
+# Positions
+
+Position tracking, group management, and order lifecycle tracking.
+
+## PositionTracker
+
+Tracks net positions per symbol with configurable cost basis methods.
+
+```python
+tracker = flox.PositionTracker(cost_basis="fifo")
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `cost_basis` | `str` | `"fifo"` | Cost basis method: `"fifo"`, `"lifo"`, or `"average"` |
+
+### Methods
+
+#### `on_fill(symbol, side, price, quantity)`
+
+Record a fill.
+
+```python
+tracker.on_fill(symbol=1, side="buy", price=50000.0, quantity=1.0)
+tracker.on_fill(symbol=1, side="sell", price=51000.0, quantity=0.5)
+```
+
+#### `position(symbol) -> float`
+
+Signed net position for a symbol. Positive = long, negative = short.
+
+#### `avg_entry_price(symbol) -> float`
+
+Average entry price for current position.
+
+#### `realized_pnl(symbol) -> float`
+
+Realized PnL for a symbol.
+
+#### `total_realized_pnl() -> float`
+
+Total realized PnL across all symbols.
+
+---
+
+## PositionGroupTracker
+
+Individual position management with grouping support. Track each trade as a separate position, organize into groups, and compute per-group metrics.
+
+```python
+tracker = flox.PositionGroupTracker()
+```
+
+### Methods
+
+#### `open_position(order_id, symbol, side, price, quantity) -> int`
+
+Open a new position. Returns a position ID.
+
+```python
+pid = tracker.open_position(order_id=1, symbol=1, side="buy",
+                             price=50000.0, quantity=1.0)
+```
+
+#### `close_position(position_id, exit_price)`
+
+Close a position at the given exit price.
+
+```python
+tracker.close_position(pid, exit_price=51000.0)
+```
+
+#### `partial_close(position_id, quantity, exit_price)`
+
+Partially close a position.
+
+```python
+tracker.partial_close(pid, quantity=0.5, exit_price=50500.0)
+```
+
+#### `create_group(parent_id=0) -> int`
+
+Create a position group. Returns a group ID.
+
+```python
+gid = tracker.create_group()
+```
+
+#### `assign_to_group(position_id, group_id) -> bool`
+
+Assign a position to a group.
+
+#### `get_position(position_id) -> dict | None`
+
+Get position details.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `position_id` | `int` | Position ID |
+| `order_id` | `int` | Original order ID |
+| `symbol` | `int` | Symbol ID |
+| `side` | `str` | `"buy"` or `"sell"` |
+| `entry_price` | `float` | Entry price |
+| `quantity` | `float` | Remaining quantity |
+| `realized_pnl` | `float` | Realized PnL |
+| `closed` | `bool` | Whether fully closed |
+| `group_id` | `int` | Assigned group (0 = none) |
+
+#### `net_position(symbol) -> float`
+
+Net position for a symbol.
+
+#### `group_net_position(group_id) -> float`
+
+Net position for a group.
+
+#### `realized_pnl(symbol) -> float`
+
+Realized PnL for a symbol.
+
+#### `total_realized_pnl() -> float`
+
+Total realized PnL.
+
+#### `group_realized_pnl(group_id) -> float`
+
+Realized PnL for a group.
+
+#### `group_unrealized_pnl(group_id, current_price) -> float`
+
+Unrealized PnL for a group at the given market price.
+
+#### `open_positions(symbol) -> list[dict]`
+
+List of open position dicts for a symbol.
+
+#### `open_position_count(symbol=None) -> int`
+
+Count of open positions. Pass `None` for total across all symbols.
+
+#### `prune_closed()`
+
+Remove closed positions from memory.
+
+---
+
+## OrderTracker
+
+Order lifecycle tracking: submitted, filled, canceled, rejected.
+
+```python
+tracker = flox.OrderTracker()
+```
+
+### Methods
+
+#### `on_submitted(order_id, exchange_order_id, client_order_id="") -> bool`
+
+Record an order submission.
+
+```python
+tracker.on_submitted(order_id=1, exchange_order_id="EX-12345")
+```
+
+#### `on_filled(order_id, fill_quantity) -> bool`
+
+Record a fill (partial or full).
+
+#### `on_canceled(order_id) -> bool`
+
+Record a cancellation.
+
+#### `on_rejected(order_id, reason) -> bool`
+
+Record a rejection.
+
+#### `get(order_id) -> dict | None`
+
+Get order state.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `order_id` | `int` | Local order ID |
+| `exchange_order_id` | `str` | Exchange-assigned ID |
+| `client_order_id` | `str` | Client-assigned ID |
+| `status` | `str` | Current status (see below) |
+| `filled` | `float` | Filled quantity |
+| `is_terminal` | `bool` | Whether order is in a terminal state |
+
+**Status values:** `"new"`, `"submitted"`, `"accepted"`, `"partially_filled"`, `"filled"`, `"pending_cancel"`, `"canceled"`, `"expired"`, `"rejected"`, `"replaced"`, `"pending_trigger"`, `"triggered"`, `"trailing_updated"`.
+
+#### `is_active(order_id) -> bool`
+
+Check if an order is still active (non-terminal).
+
+#### `active_count() -> int`
+
+Number of active orders.
+
+#### `total_count() -> int`
+
+Total tracked orders.
+
+#### `prune_terminal()`
+
+Remove terminal orders from memory.
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/replay.md
+# URL: https://flox-foundation.github.io/flox/reference/python/replay/
+------------------------------------------------------------------------------
+
+# Replay
+
+Read, write, and record market data in Flox binary format. Supports LZ4 compression, time-range filtering, and symbol filtering.
+
+## inspect()
+
+Quick summary of a data directory without loading all data.
+
+```python
+info = flox.inspect(data_dir="./data")
+print(f"Events: {info['total_events']}, Duration: {info['duration_seconds']:.0f}s")
+```
+
+**Returns dict:**
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `first_event_ns` | `int` | First event timestamp |
+| `last_event_ns` | `int` | Last event timestamp |
+| `total_events` | `int` | Total event count |
+| `segment_count` | `int` | Number of segment files |
+| `total_bytes` | `int` | Total data size |
+| `duration_seconds` | `float` | Time span in seconds |
+| `fully_indexed` | `bool` | Whether all segments have indexes |
+
+---
+
+## DataReader
+
+Read trades and book updates from binary log files.
+
+```python
+reader = flox.DataReader(
+    data_dir="./data",
+    from_ns=None,     # start timestamp filter
+    to_ns=None,       # end timestamp filter
+    symbols=None,     # list of symbol IDs to filter
+)
+```
+
+### Methods
+
+#### `summary() -> dict`
+
+Dataset summary (same keys as `inspect()` plus `data_dir` and `symbols`).
+
+#### `count() -> int`
+
+Total event count.
+
+#### `symbols() -> set[int]`
+
+Set of available symbol IDs.
+
+#### `time_range() -> tuple[int, int] | None`
+
+`(start_ns, end_ns)` tuple, or `None` if empty.
+
+#### `read_trades() -> ndarray`
+
+Read all trades as a numpy structured array with `PyTrade` dtype.
+
+```python
+trades = reader.read_trades()
+prices = trades['price_raw'] / 1e8
+quantities = trades['qty_raw'] / 1e8
+```
+
+#### `read_trades_from(start_ts_ns) -> ndarray`
+
+Read trades starting from a given timestamp.
+
+```python
+trades = reader.read_trades_from(start_ts_ns=1704067200_000_000_000)
+```
+
+#### `read_bbo() -> ndarray`
+
+Read top-of-book (best bid/ask) from every book update event as a numpy structured array with `PyBBO` dtype.
+
+```python
+bbos = reader.read_bbo()
+mids = (bbos['bid_price_raw'] + bbos['ask_price_raw']) / 2 / 1e8
+```
+
+#### `read_bbo_from(start_ts_ns) -> ndarray`
+
+Same as `read_bbo()` but starts iterating from the first event whose `exchange_ts_ns >= start_ts_ns`.
+
+```python
+bbos = reader.read_bbo_from(start_ts_ns=1704067200_000_000_000)
+```
+
+#### `read_book_updates() -> tuple[ndarray, ndarray]`
+
+Read every book update event with full depth. Returns `(headers, levels)`:
+
+- `headers` — structured array of `PyBookUpdateHeader`. Each row carries `level_offset`, `bid_count`, `ask_count` for slicing the levels array.
+- `levels` — single flat structured array of `PyLevel` shared by all events; bids first, then asks, per event.
+
+```python
+headers, levels = reader.read_book_updates()
+for h in headers:
+    off, nb, na = h['level_offset'], h['bid_count'], h['ask_count']
+    bids = levels[off : off + nb]
+    asks = levels[off + nb : off + nb + na]
+```
+
+#### `read_book_updates_from(start_ts_ns) -> tuple[ndarray, ndarray]`
+
+Same as `read_book_updates()` but starts iterating from the first event whose `exchange_ts_ns >= start_ts_ns`.
+
+```python
+headers, levels = reader.read_book_updates_from(start_ts_ns=1704067200_000_000_000)
+```
+
+#### `stats() -> dict`
+
+Reader statistics.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `files_read` | `int` | Segment files read |
+| `events_read` | `int` | Total events processed |
+| `trades_read` | `int` | Trade events |
+| `book_updates_read` | `int` | Book update events |
+| `bytes_read` | `int` | Bytes read |
+| `crc_errors` | `int` | CRC checksum failures |
+
+#### `segment_files() -> list[str]`
+
+List of segment file paths.
+
+#### `segments() -> list[dict]`
+
+Segment metadata.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `path` | `str` | File path |
+| `first_event_ns` | `int` | First event timestamp |
+| `last_event_ns` | `int` | Last event timestamp |
+| `event_count` | `int` | Events in segment |
+| `has_index` | `bool` | Whether segment has an index |
+
+### PyTrade Dtype
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `exchange_ts_ns` | `int64` | Exchange timestamp (ns) |
+| `recv_ts_ns` | `int64` | Local receive timestamp (ns) |
+| `price_raw` | `int64` | Price * 10^8 |
+| `qty_raw` | `int64` | Quantity * 10^8 |
+| `trade_id` | `uint64` | Exchange trade ID |
+| `symbol_id` | `uint32` | Symbol ID |
+| `side` | `uint8` | 0 = buy, 1 = sell |
+
+### PyBBO Dtype
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `exchange_ts_ns` | `int64` | Exchange timestamp (ns) |
+| `recv_ts_ns` | `int64` | Local receive timestamp (ns) |
+| `seq` | `int64` | Exchange sequence number |
+| `symbol_id` | `uint32` | Symbol ID |
+| `event_type` | `uint8` | 2 = snapshot, 3 = delta |
+| `bid_price_raw` | `int64` | Best bid price * 10^8 (0 if absent) |
+| `bid_qty_raw` | `int64` | Best bid quantity * 10^8 |
+| `ask_price_raw` | `int64` | Best ask price * 10^8 (0 if absent) |
+| `ask_qty_raw` | `int64` | Best ask quantity * 10^8 |
+
+### PyBookUpdateHeader Dtype
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `exchange_ts_ns` | `int64` | Exchange timestamp (ns) |
+| `recv_ts_ns` | `int64` | Local receive timestamp (ns) |
+| `seq` | `int64` | Exchange sequence number |
+| `symbol_id` | `uint32` | Symbol ID |
+| `bid_count` | `uint16` | Number of bid levels for this event |
+| `ask_count` | `uint16` | Number of ask levels for this event |
+| `level_offset` | `uint32` | Index of this event's first level in the levels array |
+| `event_type` | `uint8` | 2 = snapshot, 3 = delta |
+
+### PyLevel Dtype
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `price_raw` | `int64` | Price * 10^8 |
+| `qty_raw` | `int64` | Quantity * 10^8 |
+| `side` | `uint8` | 0 = bid, 1 = ask |
+
+---
+
+## DataWriter
+
+Write trade data to binary log files.
+
+```python
+writer = flox.DataWriter(
+    output_dir="./output",
+    max_segment_mb=256,
+    exchange_id=0,
+    compression="none",   # "none" or "lz4"
+)
+```
+
+### Methods
+
+#### `write_trade(exchange_ts_ns, recv_ts_ns, price, qty, trade_id, symbol_id, side) -> bool`
+
+Write a single trade. Returns `True` on success.
+
+```python
+writer.write_trade(
+    exchange_ts_ns=1704067200_000_000_000,
+    recv_ts_ns=1704067200_001_000_000,
+    price=50000.0,
+    qty=1.5,
+    trade_id=12345,
+    symbol_id=1,
+    side=0,
+)
+```
+
+#### `write_trades(exchange_ts_ns, recv_ts_ns, prices, quantities, trade_ids, symbol_ids, sides) -> int`
+
+Vectorized write from numpy arrays. Returns number of trades written.
+
+```python
+count = writer.write_trades(
+    exchange_ts_ns=ts_array,
+    recv_ts_ns=recv_array,
+    prices=price_array,
+    quantities=qty_array,
+    trade_ids=id_array,
+    symbol_ids=sym_array,
+    sides=side_array,
+)
+```
+
+#### `flush()`
+
+Flush buffered data to disk.
+
+#### `close()`
+
+Close the writer and finalize all segments.
+
+#### `stats() -> dict`
+
+Writer statistics.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `bytes_written` | `int` | Total bytes |
+| `events_written` | `int` | Total events |
+| `segments_created` | `int` | Segment files created |
+| `trades_written` | `int` | Trade events |
+| `book_updates_written` | `int` | Book update events |
+| `blocks_written` | `int` | Data blocks |
+| `uncompressed_bytes` | `int` | Uncompressed size |
+| `compressed_bytes` | `int` | Compressed size |
+
+#### `current_segment_path() -> str`
+
+Path of the current segment being written.
+
+---
+
+## DataRecorder
+
+High-level market data recorder with symbol metadata support.
+
+```python
+recorder = flox.DataRecorder(
+    output_dir="./recordings",
+    exchange_name="binance",
+    max_segment_mb=256,
+)
+```
+
+### Methods
+
+#### `add_symbol(symbol_id, name, base="", quote="", price_precision=8, qty_precision=8)`
+
+Register a symbol with metadata.
+
+```python
+recorder.add_symbol(1, "BTCUSDT", base="BTC", quote="USDT",
+                     price_precision=2, qty_precision=6)
+```
+
+#### `start()`
+
+Start recording.
+
+#### `stop()`
+
+Stop recording and finalize output.
+
+#### `flush()`
+
+Flush buffered data.
+
+#### `is_recording() -> bool`
+
+Check if currently recording.
+
+#### `stats() -> dict`
+
+Recorder statistics.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `trades_written` | `int` | Trades recorded |
+| `book_updates_written` | `int` | Book updates recorded |
+| `bytes_written` | `int` | Bytes written |
+| `files_created` | `int` | Files created |
+| `errors` | `int` | Error count |
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/segment_ops.md
+# URL: https://flox-foundation.github.io/flox/reference/python/segment_ops/
+------------------------------------------------------------------------------
+
+# Segment Operations
+
+Utilities for merging, splitting, exporting, validating, and partitioning binary log data.
+
+## Merge
+
+### `merge(input_paths, output_dir, output_name="merged", compression="none", sort=True) -> dict`
+
+Merge multiple segment files into one.
+
+```python
+result = flox.merge(
+    input_paths=["seg1.flox", "seg2.flox"],
+    output_dir="./merged",
+    output_name="combined",
+    compression="lz4",
+    sort=True,
+)
+print(f"Merged {result['segments_merged']} segments, {result['events_written']} events")
+```
+
+**Returns dict:**
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `success` | `bool` | Whether merge succeeded |
+| `output_path` | `str` | Output file path |
+| `segments_merged` | `int` | Input segments processed |
+| `events_written` | `int` | Events in output |
+| `bytes_written` | `int` | Output size |
+| `errors` | `list` | Error messages |
+
+### `merge_dir(input_dir, output_dir) -> dict`
+
+Merge all segments in a directory (shorthand for `merge`).
+
+```python
+result = flox.merge_dir("./raw_data", "./merged_data")
+```
+
+---
+
+## Split
+
+### `split(input_path, output_dir, mode="time", time_interval_ns=3600000000000, events_per_file=1000000) -> dict`
+
+Split a segment file into multiple files.
+
+```python
+result = flox.split(
+    input_path="large_file.flox",
+    output_dir="./split",
+    mode="time",
+    time_interval_ns=3600_000_000_000,  # 1 hour
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `mode` | `str` | `"time"` | Split mode: `"time"`, `"event_count"`, `"size"`, `"symbol"` |
+| `time_interval_ns` | `int` | 1 hour | Time interval for `"time"` mode |
+| `events_per_file` | `int` | 1000000 | Events per file for `"event_count"` mode |
+
+**Returns dict:**
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `success` | `bool` | Whether split succeeded |
+| `output_paths` | `list[str]` | Output file paths |
+| `segments_created` | `int` | Files created |
+| `events_written` | `int` | Total events |
+| `errors` | `list` | Error messages |
+
+---
+
+## Export
+
+### `export_data(input_path, output_path, format="csv", from_ns=None, to_ns=None, symbols=None) -> dict`
+
+Export binary data to CSV, JSON, or JSONLines.
+
+```python
+result = flox.export_data(
+    input_path="data.flox",
+    output_path="trades.csv",
+    format="csv",
+    symbols=[1, 2],
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `format` | `str` | `"csv"` | Output format: `"csv"`, `"json"`, `"jsonlines"`, `"binary"` |
+| `from_ns` | `int` | `None` | Start timestamp filter |
+| `to_ns` | `int` | `None` | End timestamp filter |
+| `symbols` | `list[int]` | `None` | Symbol ID filter |
+
+**Returns dict:**
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `success` | `bool` | Whether export succeeded |
+| `output_path` | `str` | Output file path |
+| `events_exported` | `int` | Events exported |
+| `bytes_written` | `int` | Output size |
+| `errors` | `list` | Error messages |
+
+---
+
+## Other Operations
+
+### `recompress(input_path, output_path, compression="lz4") -> bool`
+
+Re-compress a segment file. Returns `True` on success.
+
+```python
+ok = flox.recompress("uncompressed.flox", "compressed.flox", "lz4")
+```
+
+### `extract_symbols(input_path, output_path, symbols) -> int`
+
+Extract specific symbols to a new file. Returns event count.
+
+```python
+count = flox.extract_symbols("all_data.flox", "btc_only.flox", [1])
+```
+
+### `extract_time_range(input_path, output_path, from_ns, to_ns) -> int`
+
+Extract a time range to a new file. Returns event count.
+
+```python
+count = flox.extract_time_range("data.flox", "morning.flox",
+                                 from_ns=start, to_ns=end)
+```
+
+---
+
+## Validation
+
+### `validate(segment_path, verify_crc=True, verify_timestamps=True) -> dict`
+
+Validate a single segment file.
+
+```python
+result = flox.validate("data.flox")
+if not result['valid']:
+    for issue in result['issues']:
+        print(f"[{issue['severity']}] {issue['message']}")
+```
+
+**Returns dict:**
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `path` | `str` | File path |
+| `valid` | `bool` | Overall validity |
+| `header_valid` | `bool` | Header integrity |
+| `reported_event_count` | `int` | Events per header |
+| `actual_event_count` | `int` | Events found |
+| `has_index` | `bool` | Has index section |
+| `index_valid` | `bool` | Index integrity |
+| `trades_found` | `int` | Trade count |
+| `book_updates_found` | `int` | Book update count |
+| `crc_errors` | `int` | CRC failures |
+| `timestamp_anomalies` | `int` | Out-of-order timestamps |
+| `has_errors` | `bool` | Has error-level issues |
+| `has_critical` | `bool` | Has critical issues |
+| `issues` | `list[dict]` | Issue details |
+
+### `validate_dataset(data_dir) -> dict`
+
+Validate all segments in a directory.
+
+```python
+result = flox.validate_dataset("./data")
+print(f"{result['valid_segments']}/{result['total_segments']} valid")
+```
+
+---
+
+## Partitioner
+
+Partition datasets for parallel processing or walk-forward backtesting.
+
+```python
+part = flox.Partitioner(data_dir="./data")
+```
+
+### Methods
+
+#### `partition_by_time(num_partitions, warmup_ns=0) -> list[dict]`
+
+Split into N equal time-based partitions.
+
+```python
+partitions = part.partition_by_time(num_partitions=4, warmup_ns=3600_000_000_000)
+```
+
+#### `partition_by_duration(duration_ns, warmup_ns=0) -> list[dict]`
+
+Partition by fixed time duration.
+
+#### `partition_by_calendar(unit, warmup_ns=0) -> list[dict]`
+
+Partition by calendar unit.
+
+| Unit | Description |
+|------|-------------|
+| `"hour"` | Hourly partitions |
+| `"day"` | Daily partitions |
+| `"week"` | Weekly partitions |
+| `"month"` | Monthly partitions |
+
+#### `partition_by_symbol(num_partitions) -> list[dict]`
+
+Group symbols into N partitions.
+
+#### `partition_per_symbol() -> list[dict]`
+
+One partition per symbol.
+
+#### `partition_by_event_count(num_partitions) -> list[dict]`
+
+Split by event count.
+
+### Partition Dict
+
+Each partition is a dict:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `partition_id` | `int` | Partition index |
+| `from_ns` | `int` | Start timestamp |
+| `to_ns` | `int` | End timestamp |
+| `warmup_from_ns` | `int` | Warmup start timestamp |
+| `estimated_events` | `int` | Estimated event count |
+| `estimated_bytes` | `int` | Estimated data size |
+| `symbols` | `list[int]` | Symbols in partition |
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/backtest.md
+# URL: https://flox-foundation.github.io/flox/reference/python/backtest/
+------------------------------------------------------------------------------
+
+# Backtest Components
+
+Standalone simulated exchange for step-by-step backtesting and fill analysis.
+
+## SimulatedExecutor
+
+A simulated exchange that matches orders against bar closes and trade prices. Supports market, limit, stop, take-profit, and trailing stop orders.
+
+```python
+executor = flox.SimulatedExecutor()
+```
+
+### Methods
+
+#### `submit_order(id, side, price, quantity, type="market", symbol=1)`
+
+Submit an order to the simulated exchange.
+
+```python
+executor.submit_order(id=1, side="buy", price=0.0, quantity=1.0,
+                       type="market", symbol=1)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `id` | `int` | — | Order ID |
+| `side` | `str` | — | `"buy"` or `"sell"` |
+| `price` | `float` | — | Limit/trigger price (0 for market) |
+| `quantity` | `float` | — | Order size |
+| `type` | `str` | `"market"` | Order type (see below) |
+| `symbol` | `int` | `1` | Symbol ID |
+
+**Order types:** `"market"`, `"limit"`, `"stop_market"`, `"stop_limit"`, `"take_profit_market"`, `"take_profit_limit"`, `"trailing_stop"`.
+
+#### `cancel_order(order_id)`
+
+Cancel an order by ID.
+
+#### `cancel_all(symbol)`
+
+Cancel all orders for a symbol.
+
+#### `on_bar(symbol, close_price)`
+
+Feed a bar close price for order matching. Limit orders are matched against this price.
+
+```python
+executor.on_bar(symbol=1, close_price=50000.0)
+```
+
+#### `on_trade(symbol, price, is_buy)`
+
+Feed a trade for order matching.
+
+```python
+executor.on_trade(symbol=1, price=50000.0, is_buy=True)
+```
+
+#### `on_trade_qty(symbol, price, qty, is_buy)`
+
+Feed a trade with quantity. Required for `QUEUE_FULL` queue simulation.
+
+```python
+executor.on_trade_qty(symbol=1, price=50000.0, qty=0.5, is_buy=True)
+```
+
+#### `on_best_levels(symbol, bid_price, bid_qty, ask_price, ask_qty)`
+
+Feed a top-of-book snapshot.
+
+```python
+executor.on_best_levels(1, 49999.0, 2.0, 50001.0, 1.5)
+```
+
+#### `set_default_slippage(model, ticks=0, tick_size=0.0, bps=0.0, impact_coeff=0.0)`
+
+Configure slippage for all symbols.
+
+```python
+from flox import SLIPPAGE_FIXED_BPS
+executor.set_default_slippage(SLIPPAGE_FIXED_BPS, bps=2.0)
+```
+
+| `model` constant | Value | Description |
+|-----------------|-------|-------------|
+| `SLIPPAGE_NONE` | `0` | No slippage |
+| `SLIPPAGE_FIXED_TICKS` | `1` | Fixed tick count |
+| `SLIPPAGE_FIXED_BPS` | `2` | Fixed basis points |
+| `SLIPPAGE_VOLUME_IMPACT` | `3` | Volume-proportional impact |
+
+#### `set_symbol_slippage(symbol, model, ticks=0, tick_size=0.0, bps=0.0, impact_coeff=0.0)`
+
+Per-symbol slippage override. Same parameters as `set_default_slippage`.
+
+#### `set_queue_model(model, depth=1)`
+
+Configure limit order queue simulation.
+
+```python
+from flox import QUEUE_TOB
+executor.set_queue_model(QUEUE_TOB, depth=1)
+```
+
+| `model` constant | Value | Description |
+|-----------------|-------|-------------|
+| `QUEUE_NONE` | `0` | Fill limit orders immediately at price |
+| `QUEUE_TOB` | `1` | Fill only when price trades through level |
+| `QUEUE_FULL` | `2` | Model queue position; fill as volume passes |
+
+#### `advance_clock(timestamp_ns)`
+
+Advance the simulation clock.
+
+```python
+executor.advance_clock(timestamp_ns=1704067200_000_000_000)
+```
+
+#### `fills() -> ndarray`
+
+Get all fills as a numpy structured array with `PyFill` dtype.
+
+```python
+fills = executor.fills()
+for i in range(len(fills)):
+    print(f"Fill: order={fills[i]['order_id']}, price={fills[i]['price_raw']/1e8}")
+```
+
+#### `fills_list() -> list[dict]`
+
+Get fills as a list of dicts (more convenient, less performant).
+
+```python
+for fill in executor.fills_list():
+    print(f"{fill['side']} {fill['quantity']} @ {fill['price']}")
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `order_id` | `int` | Order ID |
+| `symbol` | `int` | Symbol ID |
+| `side` | `str` | `"buy"` or `"sell"` |
+| `price` | `float` | Fill price |
+| `quantity` | `float` | Fill quantity |
+| `timestamp_ns` | `int` | Fill timestamp |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `fill_count` | `int` | Number of fills |
+
+---
+
+## BacktestResult
+
+Computes statistics and equity curve from a `SimulatedExecutor`'s fills.
+
+```python
+result = flox.BacktestResult(initial_capital=10_000.0, fee_rate=0.0004)
+result.ingest_executor(executor)
+stats = result.stats()
+print(stats['net_pnl'], stats['sharpe'])
+```
+
+### Constructor
+
+```python
+flox.BacktestResult(
+    initial_capital=100000.0,
+    fee_rate=0.0001,
+    use_percentage_fee=True,
+    fixed_fee_per_trade=0.0,
+    risk_free_rate=0.0,
+    annualization_factor=252.0,
+)
+```
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `record_fill(order_id, symbol, side, price, qty, timestamp_ns)` | `None` | Record a single fill |
+| `ingest_executor(executor)` | `None` | Drain all fills from a `SimulatedExecutor` |
+| `stats()` | `dict` | Compute and return statistics |
+| `equity_curve_size()` | `int` | Number of equity curve points |
+| `write_equity_curve_csv(path)` | `bool` | Write equity curve to CSV |
+| `close()` | `None` | Free resources |
+
+`stats()` returns the same keys as `Engine.run()` plus `start_time_ns` and `end_time_ns`.
+
+---
+
+## Structured Dtypes
+
+### PyFill
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `order_id` | `uint64` | Order ID |
+| `symbol` | `uint32` | Symbol ID |
+| `side` | `uint8` | 0 = buy, 1 = sell |
+| `price_raw` | `int64` | Fill price * 10^8 |
+| `quantity_raw` | `int64` | Fill quantity * 10^8 |
+| `timestamp_ns` | `int64` | Fill timestamp (ns) |
+
+### PyTradeRecord
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `symbol` | `uint32` | Symbol ID |
+| `side` | `uint8` | 0 = buy, 1 = sell |
+| `entry_price_raw` | `int64` | Entry price * 10^8 |
+| `exit_price_raw` | `int64` | Exit price * 10^8 |
+| `quantity_raw` | `int64` | Trade quantity * 10^8 |
+| `entry_time_ns` | `int64` | Entry timestamp |
+| `exit_time_ns` | `int64` | Exit timestamp |
+| `pnl_raw` | `int64` | PnL * 10^8 |
+| `fee_raw` | `int64` | Fee * 10^8 |
+
+---
+
+## Example
+
+```python
+import flox_py as flox
+
+executor = flox.SimulatedExecutor()
+
+# Simulate a simple trade
+executor.advance_clock(1_000_000_000)  # t=1s
+executor.submit_order(id=1, side="buy", price=0, quantity=1.0)
+executor.on_bar(symbol=1, close_price=50000.0)
+
+executor.advance_clock(2_000_000_000)  # t=2s
+executor.submit_order(id=2, side="sell", price=0, quantity=1.0)
+executor.on_bar(symbol=1, close_price=51000.0)
+
+for fill in executor.fills_list():
+    print(f"{fill['side']} {fill['quantity']} @ {fill['price']}")
+```
+
+------------------------------------------------------------------------------
+# Source: docs/reference/python/optimizer.md
+# URL: https://flox-foundation.github.io/flox/reference/python/optimizer/
+------------------------------------------------------------------------------
+
+# Optimizer
+
+Statistical tools for strategy validation and parameter optimization.
+
+## permutation_test()
+
+Two-sample permutation test. Tests whether two groups have the same mean. Useful for comparing strategy returns against random shuffles.
+
+```python
+p_value = flox.permutation_test(group1, group2, num_permutations=10000)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `group1` | `float64[]` | — | First sample |
+| `group2` | `float64[]` | — | Second sample |
+| `num_permutations` | `int` | `10000` | Number of permutation iterations |
+
+**Returns:** `float` — p-value (probability of observing the actual difference by chance).
+
+```python
+# Test if strategy returns are significantly different from random
+strategy_returns = np.array([0.01, 0.02, -0.005, 0.015, ...])
+random_returns = np.array([0.001, -0.003, 0.002, -0.001, ...])
+
+p = flox.permutation_test(strategy_returns, random_returns)
+print(f"p-value: {p:.4f}")
+if p < 0.05:
+    print("Strategy returns are statistically significant")
+```
+
+---
+
+## correlation()
+
+Pearson correlation coefficient between two arrays.
+
+```python
+r = flox.correlation(x, y)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `x` | `float64[]` | First variable |
+| `y` | `float64[]` | Second variable (same length as x) |
+
+**Returns:** `float` — correlation coefficient in [-1, 1].
+
+```python
+# Check parameter sensitivity
+param_values = np.array([10, 20, 30, 40, 50], dtype=np.float64)
+sharpe_ratios = np.array([0.5, 1.2, 1.8, 1.5, 0.8])
+
+r = flox.correlation(param_values, sharpe_ratios)
+print(f"Correlation: {r:.4f}")
+```
+
+---
+
+## bootstrap_ci()
+
+Bootstrap confidence interval for the mean. Resamples the data with replacement to estimate uncertainty.
+
+```python
+lower, median, upper = flox.bootstrap_ci(data, confidence=0.95, num_samples=10000)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `data` | `float64[]` | — | Sample data (must be non-empty) |
+| `confidence` | `float` | `0.95` | Confidence level (e.g., 0.95 for 95%) |
+| `num_samples` | `int` | `10000` | Bootstrap iterations |
+
+**Returns:** `tuple[float, float, float]` — `(lower, median, upper)` bounds.
+
+```python
+# Estimate confidence interval for strategy Sharpe ratio
+trade_pnls = np.array([100, -50, 200, -30, 150, ...], dtype=np.float64)
+
+lower, median, upper = flox.bootstrap_ci(trade_pnls, confidence=0.95)
+print(f"Mean PnL: {median:.2f} [{lower:.2f}, {upper:.2f}] (95% CI)")
+```
+
+---
+
+## Example: Full Validation Pipeline
+
+```python
+import numpy as np
+import flox_py as flox
+
+engine = flox.Engine(initial_capital=100_000)
+engine.load_bars_df(timestamps, opens, highs, lows, closes, volumes)
+
+# Run strategy
+signals = my_strategy(closes)
+base_stats = engine.run(signals)
+base_pnl = base_stats['net_pnl']
+
+# Monte Carlo permutation test
+rng = np.random.default_rng(42)
+shuffled_sets = []
+for _ in range(1000):
+    idx = rng.permutation(len(signals))
+    shuffled = signals[idx]
+    shuffled_sets.append(shuffled)
+
+results = engine.run_batch(shuffled_sets)
+random_pnls = np.array([r['net_pnl'] for r in results])
+
+# Statistical significance
+p_value = np.mean(random_pnls >= base_pnl)
+print(f"Strategy PnL: {base_pnl:.2f}, p-value: {p_value:.4f}")
+
+# Confidence interval on trade PnLs
+trade_pnls = flox.trade_pnl(signal_long, signal_short, log_returns)
+lo, med, hi = flox.bootstrap_ci(trade_pnls)
+print(f"Trade PnL: {med:.4f} [{lo:.4f}, {hi:.4f}]")
+
+# Parameter sensitivity
+param_sharpes = []
+for period in range(5, 50):
+    sigs = ma_strategy(closes, period)
+    stats = engine.run(sigs)
+    param_sharpes.append(stats['sharpe'])
+
+r = flox.correlation(
+    np.arange(5, 50, dtype=np.float64),
+    np.array(param_sharpes),
+)
+print(f"Period-Sharpe correlation: {r:.4f}")
+```
+
+==============================================================================
+# Section: Reference: Node.js
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/reference/node/index.md
+# URL: https://flox-foundation.github.io/flox/reference/node/
+------------------------------------------------------------------------------
+
+# Node.js API reference
+
+Full API for `@flox-foundation/flox`. See [Getting started](../../bindings/node.md) for build instructions and worked examples.
+
+## Modules
+
+| Page | Contents |
+|------|----------|
+| [Strategy & Runner](strategy.md) | SymbolRegistry, Symbol, strategy object, Runner |
+| [Backtest components](backtest.md) | BacktestRunner, SimulatedExecutor, BacktestResult, Engine, SignalBuilder |
+| [Indicators](indicators.md) | Batch functions, streaming classes |
+| [Bar aggregation](aggregators.md) | Time, tick, volume, range, Renko, Heikin-Ashi bars |
+| [Order books](books.md) | OrderBook, L3Book, CompositeBookMatrix |
+| [Position tracking](positions.md) | PositionTracker, PositionGroupTracker, OrderTracker |
+| [Profiles & statistics](profiles.md) | VolumeProfile, MarketProfile, FootprintBar, statistics functions |
+| [Data I/O](data.md) | DataWriter, DataReader, DataRecorder, Partitioner |
+
+------------------------------------------------------------------------------
+# Source: docs/reference/node/strategy.md
+# URL: https://flox-foundation.github.io/flox/reference/node/strategy/
+------------------------------------------------------------------------------
+
+# Strategy, Runner
+
+```javascript
+const { SymbolRegistry, Runner } = require('@flox-foundation/flox');
+```
+
+---
+
+## SymbolRegistry
+
+```javascript
+const registry = new flox.SymbolRegistry();
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `addSymbol(exchange, name, tickSize)` | `Symbol` | Register a symbol |
+| `symbolCount()` | `number` | Number of registered symbols |
+
+### Symbol
+
+Returned by `addSymbol`. Coerces to a number wherever a symbol ID is expected.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `number` | Numeric symbol ID |
+| `name` | `string` | Symbol name |
+| `exchange` | `string` | Exchange name |
+| `tickSize` | `number` | Tick size |
+
+```javascript
+const btc = registry.addSymbol('binance', 'BTCUSDT', 0.01);
+
+btc.id         // 1
+btc.name       // "BTCUSDT"
+Number(btc)    // 1
+btc + 0        // 1
+btc.toString() // "Symbol(binance:BTCUSDT, id=1)"
+```
+
+---
+
+## Strategy object
+
+A plain JavaScript object with callback properties.
+
+```javascript
+const strategy = {
+    symbols: [btc],   // array of Symbol or number
+
+    onStart() {},
+    onStop() {},
+
+    onTrade(ctx, trade, emit) { ... },
+    onBookUpdate(ctx, emit) { ... },
+    onBar(ctx, bar, emit) { ... },
+};
+```
+
+### BarData (`bar`)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `open`, `high`, `low`, `close` | `number` | OHLC prices |
+| `volume`, `buyVolume` | `number` | Total / buy-side volume |
+| `startTimeNs`, `endTimeNs` | `number` | Bar window timestamps (nanoseconds) |
+| `barType`, `barTypeParam` | `number` | 0=Time, 1=Tick, ... + interval/threshold |
+| `closeReason` | `number` | 0=Threshold, 1=Gap, 2=Forced, 3=Warmup |
+
+### SymbolContext (`ctx`)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `position` | `number` | Current position quantity |
+| `symbolId` | `number` | Symbol ID |
+| `lastTradePrice` | `number` | Last trade price |
+| `bestBid` | `number` | Best bid |
+| `bestAsk` | `number` | Best ask |
+| `midPrice` | `number` | Mid price |
+
+### TradeData (`trade`)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `price` | `number` | Trade price |
+| `qty` | `number` | Trade quantity |
+| `isBuy` | `boolean` | Buy-side aggressor |
+| `side` | `string` | `"buy"` or `"sell"` |
+| `timestampNs` | `BigInt` | Timestamp (nanoseconds) |
+
+### emit methods
+
+| Method | Description |
+|--------|-------------|
+| `emit.marketBuy(qty)` | Market buy |
+| `emit.marketSell(qty)` | Market sell |
+| `emit.limitBuy(price, qty)` | Limit buy |
+| `emit.limitSell(price, qty)` | Limit sell |
+| `emit.cancel(orderId)` | Cancel order |
+| `emit.closePosition()` | Close position (reduce-only) |
+
+---
+
+## Runner
+
+Synchronous strategy host. Strategy callbacks fire in the caller's thread before the push call returns.
+
+```javascript
+const runner = new flox.Runner(registry, onSignal);        // synchronous
+const runner = new flox.Runner(registry, onSignal, true);  // Disruptor background thread
+```
+
+In threaded mode, events are published to a lock-free ring buffer and callbacks fire in a background C++ thread.
+
+| Method | Description |
+|--------|-------------|
+| `addStrategy(strategy)` | Register a strategy object |
+| `start()` | Start the runner |
+| `stop()` | Stop and clean up |
+| `onTrade(symbol, price, qty, isBuy, tsNs)` | Inject a trade tick |
+| `onBookSnapshot(symbol, bidPrices, bidQtys, askPrices, askQtys, tsNs)` | Inject an L2 snapshot |
+| `onBar(symbol, { open, high, low, close, volume?, ... })` | Inject a closed OHLC bar |
+
+`symbol` accepts a `Symbol` object or a raw number.
+
+### Signal callback
+
+```javascript
+function onSignal(sig) {
+    // sig.side       — "buy" | "sell"
+    // sig.quantity
+    // sig.price      — 0 for market orders
+    // sig.orderType  — "market" | "limit" | "stop_market" | ...
+    // sig.orderId
+}
+```
+
+------------------------------------------------------------------------------
+# Source: docs/reference/node/backtest.md
+# URL: https://flox-foundation.github.io/flox/reference/node/backtest/
+------------------------------------------------------------------------------
+
+# Backtest components
+
+```javascript
+const { BacktestRunner, SimulatedExecutor, BacktestResult, Engine, SignalBuilder } = require('@flox-foundation/flox');
+```
+
+---
+
+## BacktestRunner
+
+Replays OHLCV data through a strategy. Emitted orders go to a `SimulatedExecutor`; statistics are returned at the end.
+
+```javascript
+const bt = new flox.BacktestRunner(registry, feeRate, initialCapital);
+bt.setStrategy(strategy);
+
+const stats = bt.runCsv('/path/to/data.csv', 'BTCUSDT');
+const stats = bt.runOhlcv(timestampsNs, closePrices, 'BTCUSDT');
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `setStrategy(strategy)` | `void` | Attach a strategy |
+| `runCsv(path, symbol)` | stats object | Replay a CSV file (timestamp, open, high, low, close, volume) |
+| `runOhlcv(timestamps, closes, symbol)` | stats object | Replay raw arrays (timestamps as Float64Array, closes as Float64Array) |
+
+### Stats object
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `totalTrades` | `number` | Round-trip trade count |
+| `winningTrades` | `number` | Winning trades |
+| `losingTrades` | `number` | Losing trades |
+| `initialCapital` | `number` | Starting capital |
+| `finalCapital` | `number` | Ending capital |
+| `netPnl` | `number` | Net P&L after fees |
+| `totalPnl` | `number` | Gross P&L |
+| `totalFees` | `number` | Total fees paid |
+| `grossProfit` | `number` | Sum of winning trades |
+| `grossLoss` | `number` | Sum of losing trades |
+| `maxDrawdown` | `number` | Max drawdown (absolute) |
+| `maxDrawdownPct` | `number` | Max drawdown (%) |
+| `winRate` | `number` | Winning trade ratio |
+| `profitFactor` | `number` | Gross profit / gross loss |
+| `avgWin` | `number` | Average winning trade |
+| `avgLoss` | `number` | Average losing trade |
+| `sharpe` | `number` | Annualized Sharpe ratio |
+| `sortino` | `number` | Sortino ratio |
+| `calmar` | `number` | Calmar ratio |
+| `returnPct` | `number` | Net return (%) |
+
+---
+
+## SimulatedExecutor
+
+Lower-level backtest executor. Use directly when you need more control over fill logic than `BacktestRunner` provides.
+
+```javascript
+const exec = new flox.SimulatedExecutor();
+exec.setDefaultSlippage('fixed_bps', 0, 0, 2.0, 0);
+exec.setQueueModel('tob', 1);
+```
+
+| Method / Property | Description |
+|-------------------|-------------|
+| `submitOrder(id, side, price, qty, type, symbol)` | Submit an order (`side`: `"buy"`/`"sell"`, `type`: `"market"`/`"limit"`) |
+| `cancelOrder(orderId)` | Cancel an order |
+| `cancelAll(symbol)` | Cancel all orders for a symbol |
+| `onBar(symbol, closePrice)` | Feed a bar close |
+| `onTrade(symbol, price, isBuy)` | Feed a trade |
+| `advanceClock(timestampNs)` | Advance simulated time |
+| `setDefaultSlippage(model, ticks, tickSize, bps, impactCoeff)` | Configure slippage. `model` is a string or one of `SLIPPAGE_NONE`, `SLIPPAGE_FIXED_TICKS`, `SLIPPAGE_FIXED_BPS`, `SLIPPAGE_VOLUME_IMPACT` |
+| `setQueueModel(model, depth)` | Configure limit order queue. `model` is a string or one of `QUEUE_NONE`, `QUEUE_TOB`, `QUEUE_FULL` |
+| `fillCount` | Number of fills (property) |
+
+---
+
+## BacktestResult
+
+Computes statistics and equity curve from a `SimulatedExecutor`'s fills.
+
+```javascript
+const result = new flox.BacktestResult(initialCapital, feeRate);
+result.ingestExecutor(exec);
+const stats = result.stats();
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `recordFill(orderId, symbol, side, price, qty, timestampNs)` | `void` | Record a single fill |
+| `ingestExecutor(exec)` | `void` | Drain all fills from a `SimulatedExecutor` |
+| `stats()` | stats object | Same fields as `BacktestRunner` stats |
+
+---
+
+## Engine
+
+Bulk backtesting engine. Loads OHLCV data once, then runs strategies against it.
+
+```javascript
+const engine = new flox.Engine(registry);
+engine.loadCsv('/path/to/data.csv', 'BTCUSDT');
+const stats = engine.run(strategy);
+```
+
+| Method / Property | Returns | Description |
+|-------------------|---------|-------------|
+| `loadCsv(path, symbol)` | `void` | Load OHLCV CSV |
+| `loadOhlcv(timestamps, opens, highs, lows, closes, volumes, symbol)` | `void` | Load raw OHLCV arrays |
+| `resample(intervalSeconds)` | `void` | Resample loaded data |
+| `run(strategyOrSignals)` | stats object | Run a strategy or `SignalBuilder` |
+| `barCount()` | `number` | Number of bars loaded |
+| `ts()` | `Float64Array` | Timestamps |
+| `open()` | `Float64Array` | Open prices |
+| `high()` | `Float64Array` | High prices |
+| `low()` | `Float64Array` | Low prices |
+| `close()` | `Float64Array` | Close prices |
+| `volume()` | `Float64Array` | Volumes |
+| `symbols` | `string[]` | Registered symbol names (property) |
+
+---
+
+## SignalBuilder
+
+Builds a signal array to pass to `engine.run()`.
+
+```javascript
+const signals = new flox.SignalBuilder();
+signals.buy(i);     // enter long at bar i
+signals.sell(i);    // enter short at bar i
+const stats = engine.run(signals);
+```
+
+| Method / Property | Description |
+|-------------------|-------------|
+| `buy(index)` | Add a long entry signal at bar `index` |
+| `sell(index)` | Add a short entry signal at bar `index` |
+| `limitBuy(index, price)` | Limit long entry |
+| `limitSell(index, price)` | Limit short entry |
+| `clear()` | Clear all signals |
+| `length` | Number of signals (property) |
+
+------------------------------------------------------------------------------
+# Source: docs/reference/node/indicators.md
+# URL: https://flox-foundation.github.io/flox/reference/node/indicators/
+------------------------------------------------------------------------------
+
+# Indicators
+
+---
+
+## Batch functions
+
+Input arrays are `Float64Array`. Single-output functions return `Float64Array`.
+
+```javascript
+const ema  = flox.ema(closes, 20);
+const macd = flox.macd(closes, 12, 26, 9);       // { line, signal, histogram }
+const bb   = flox.bollinger(closes, 20, 2.0);     // { upper, middle, lower }
+const st   = flox.stochastic(hi, lo, cl, 14, 3); // { k, d }
+const adx  = flox.adx(hi, lo, cl, 14);           // { adx, plusDi, minusDi }
+```
+
+**Single value** — `(input, period)`:
+
+`sma`, `ema`, `rma`, `rsi`, `dema`, `tema`, `kama`, `slope`
+
+**OHLC input:**
+
+`atr(high, low, close, period)`, `cci(high, low, close, period)`, `chop(high, low, close, period)`,
+`parkinson_vol(high, low, period)`, `rogers_satchell_vol(open, high, low, close, period)`
+
+**Statistical** — `(input, period)`:
+
+`skewness`, `kurtosis`, `rolling_zscore`, `shannon_entropy(input, period, bins)`, `correlation(x, y, period)`
+
+**Volume:**
+
+`obv(close, volume)`, `vwap(close, volume, window)`, `cvd(open, high, low, close, volume)`
+
+---
+
+## Streaming classes
+
+All streaming indicators share the same interface:
+
+```javascript
+const ind = new flox.EMA(14);
+ind.update(price);   // returns current value (null during warmup)
+ind.value            // current value
+ind.ready            // true once warmed up
+ind.reset()          // clear state, keep config
+```
+
+**Single value** — `update(value)`:
+
+`SMA(period)`, `EMA(period)`, `RMA(period)`, `RSI(period)`, `DEMA(period)`, `TEMA(period)`,
+`KAMA(period, fast?, slow?)`, `Slope(length)`, `Skewness(period)`, `Kurtosis(period)`,
+`RollingZScore(period)`, `ShannonEntropy(period, bins)`
+
+**Multi-output** — `update(value)`, named properties instead of `.value`:
+
+`MACD(fast?, slow?, signal?)` — defaults 12/26/9 → `.line`, `.signal`, `.histogram`  
+`Bollinger(period, stdDev?)` — default stdDev 2.0 → `.upper`, `.middle`, `.lower`
+
+**OHLC / multi-input:**
+
+`ATR(period)` — `update(high, low, close)`  
+`Stochastic(kPeriod, dPeriod?)` — `update(high, low, close)` → `.k`, `.d`  
+`CCI(period)` — `update(high, low, close)`  
+`ParkinsonVol(period)` — `update(high, low)`  
+`RogersSatchellVol(period)` — `update(open, high, low, close)`  
+`Correlation(period)` — `update(x, y)`
+
+**Volume:**
+
+`OBV()` — `update(close, volume)`  
+`VWAP(window)` — `update(close, volume)`  
+`CVD()` — `update(open, high, low, close, volume)`
+
+## Indicator catalog
+
+<!-- INDICATOR-LIST-START -->
+
+Every indicator below is **one Node.js class** with both a batch
+`compute()` method and streaming `update()` / `value` / `ready` / `reset()`.
+Same instance, two ways to use it:
+
+```js
+const flox = require('flox-node');
+const ema = new flox.EMA(10);
+const out = ema.compute(prices);            // batch
+for (const v of stream) {
+  ema.update(v);
+  if (ema.ready) console.log(ema.value);    // streaming on the same instance
+}
+```
+
+| Indicator | Constructor | Kind |
+|---|---|---|
+| `EMA` | `new flox.EMA(period)` | SingleInput |
+| `SMA` | `new flox.SMA(period)` | SingleInput |
+| `RMA` | `new flox.RMA(period)` | SingleInput |
+| `RSI` | `new flox.RSI(period)` | SingleInput |
+| `KAMA` | `new flox.KAMA(period, fast, slow)` | SingleInput |
+| `DEMA` | `new flox.DEMA(period)` | SingleInput |
+| `TEMA` | `new flox.TEMA(period)` | SingleInput |
+| `Slope` | `new flox.Slope(length)` | SingleInput |
+| `Skewness` | `new flox.Skewness(period)` | SingleInput |
+| `Kurtosis` | `new flox.Kurtosis(period)` | SingleInput |
+| `RollingZScore` | `new flox.RollingZScore(period)` | SingleInput |
+| `ShannonEntropy` | `new flox.ShannonEntropy(period, bins)` | SingleInput |
+| `AutoCorrelation` | `new flox.AutoCorrelation(window, lag)` | SingleInput |
+| `ATR` | `new flox.ATR(period)` | BarInput |
+| `CCI` | `new flox.CCI(period)` | BarInput |
+| `Stochastic` | `new flox.Stochastic(k_period, d_period)` | BarInput |
+| `ParkinsonVol` | `new flox.ParkinsonVol(period)` | HighLowInput |
+| `RogersSatchellVol` | `new flox.RogersSatchellVol(period)` | OhlcInput |
+| `Correlation` | `new flox.Correlation(period)` | PairInput |
+| `MACD` | `new flox.MACD(fast, slow, signal)` | MultiOutput |
+| `Bollinger` | `new flox.Bollinger(period, stddev)` | MultiOutput |
+
+
+<!-- INDICATOR-LIST-END -->
+
+------------------------------------------------------------------------------
+# Source: docs/reference/node/aggregators.md
+# URL: https://flox-foundation.github.io/flox/reference/node/aggregators/
+------------------------------------------------------------------------------
+
+# Bar aggregation
+
+All functions take `(timestamps, prices, quantities, isBuy, param)` where `timestamps`, `prices`, `quantities` are `Float64Array` and `isBuy` is `Uint8Array`. Return an array of bar objects.
+
+| Function | Param | Description |
+|----------|-------|-------------|
+| `aggregateTimeBars(ts, px, qty, ib, intervalSeconds)` | seconds | Time bars |
+| `aggregateTickBars(ts, px, qty, ib, tickCount)` | ticks | Tick bars |
+| `aggregateVolumeBars(ts, px, qty, ib, threshold)` | volume | Volume bars |
+| `aggregateRangeBars(ts, px, qty, ib, rangeSize)` | price range | Range bars |
+| `aggregateRenkoBars(ts, px, qty, ib, brickSize)` | brick size | Renko bars |
+| `aggregateHeikinAshiBars(ts, px, qty, ib, intervalSeconds)` | seconds | Heikin-Ashi |
+
+Each returned bar object:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `startTimeNs` | `number` | Open time (ns) |
+| `endTimeNs` | `number` | Close time (ns) |
+| `open` | `number` | Open price |
+| `high` | `number` | High price |
+| `low` | `number` | Low price |
+| `close` | `number` | Close price |
+| `volume` | `number` | Total volume |
+| `buyVolume` | `number` | Buy-side volume |
+| `tradeCount` | `number` | Number of trades |
+
+------------------------------------------------------------------------------
+# Source: docs/reference/node/books.md
+# URL: https://flox-foundation.github.io/flox/reference/node/books/
+------------------------------------------------------------------------------
+
+# Order books
+
+---
+
+## OrderBook
+
+L2 order book.
+
+```javascript
+const book = new flox.OrderBook(tickSize);
+book.applySnapshot(bidPrices, bidQtys, askPrices, askQtys);
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `applySnapshot(bp, bq, ap, aq)` | `void` | Full snapshot (Float64Arrays) |
+| `applyDelta(bp, bq, ap, aq)` | `void` | Incremental update |
+| `bestBid()` | `number \| null` | Best bid price |
+| `bestAsk()` | `number \| null` | Best ask price |
+| `mid()` | `number \| null` | Mid price |
+| `spread()` | `number \| null` | Bid-ask spread |
+| `getBids(n)` | `[price, qty][]` | Top N bid levels |
+| `getAsks(n)` | `[price, qty][]` | Top N ask levels |
+| `isCrossed()` | `boolean` | True if book is crossed |
+| `clear()` | `void` | Clear all levels |
+
+---
+
+## L3Book
+
+Order-level book with individual order tracking.
+
+```javascript
+const book = new flox.L3Book();
+book.addOrder(orderId, price, qty, 'buy');
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `addOrder(orderId, price, qty, side)` | `number` | 0 on success |
+| `removeOrder(orderId)` | `number` | 0 on success |
+| `modifyOrder(orderId, newQty)` | `number` | 0 on success |
+| `bestBid()` | `number \| null` | Best bid price |
+| `bestAsk()` | `number \| null` | Best ask price |
+| `bidAtPrice(price)` | `number` | Total bid quantity at price |
+| `askAtPrice(price)` | `number` | Total ask quantity at price |
+
+---
+
+## CompositeBookMatrix
+
+Aggregates books across multiple exchanges per symbol.
+
+```javascript
+const matrix = new flox.CompositeBookMatrix();
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `bestBid(symbol)` | `{ price, qty } \| null` | Best bid across exchanges |
+| `bestAsk(symbol)` | `{ price, qty } \| null` | Best ask across exchanges |
+| `hasArbitrage(symbol)` | `boolean` | True if arbitrage opportunity exists |
+| `markStale(exchange, symbol)` | `void` | Mark exchange data as stale |
+| `checkStaleness(nowNs, thresholdNs)` | `void` | Evict stale data |
+
+------------------------------------------------------------------------------
+# Source: docs/reference/node/positions.md
+# URL: https://flox-foundation.github.io/flox/reference/node/positions/
+------------------------------------------------------------------------------
+
+# Position tracking
+
+---
+
+## PositionTracker
+
+FIFO/average-cost position tracking.
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `flox.POSITION_FIFO` | `0` | First-in first-out (default) |
+| `flox.POSITION_AVG_COST` | `1` | Average cost basis |
+
+```javascript
+const tracker = new flox.PositionTracker(flox.POSITION_FIFO);
+const tracker = new flox.PositionTracker(flox.POSITION_AVG_COST);
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `onFill(symbol, side, price, qty)` | `void` | Record a fill |
+| `position(symbol)` | `number` | Current net position |
+| `avgEntryPrice(symbol)` | `number` | Average entry price |
+| `realizedPnl(symbol)` | `number` | Realized PnL for symbol |
+| `totalRealizedPnl()` | `number` | Total realized PnL |
+
+---
+
+## PositionGroupTracker
+
+Tracks individual named positions (open/partial-close/close).
+
+```javascript
+const tracker = new flox.PositionGroupTracker();
+const posId = tracker.openPosition(orderId, symbol, 'buy', price, qty);
+tracker.closePosition(posId, exitPrice);
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `openPosition(orderId, symbol, side, price, qty)` | `number` (position ID) | Open a position |
+| `closePosition(positionId, exitPrice)` | `void` | Close a position fully |
+| `partialClose(positionId, qty, exitPrice)` | `void` | Partial close |
+| `netPosition(symbol)` | `number` | Net position for symbol |
+| `realizedPnl(symbol)` | `number` | Realized PnL for symbol |
+| `totalRealizedPnl()` | `number` | Total realized PnL |
+| `openCount(symbol)` | `number` | Number of open positions |
+| `prune()` | `void` | Free closed position memory |
+
+---
+
+## OrderTracker
+
+Tracks submitted/filled/canceled orders.
+
+```javascript
+const tracker = new flox.OrderTracker();
+tracker.onSubmitted(orderId, symbol, 'buy', price, qty);
+tracker.onFilled(orderId, fillQty);
+```
+
+| Method / Property | Returns | Description |
+|-------------------|---------|-------------|
+| `onSubmitted(orderId, symbol, side, price, qty)` | `boolean` | Register a submitted order |
+| `onFilled(orderId, fillQty)` | `boolean` | Record a fill |
+| `onCanceled(orderId)` | `boolean` | Record a cancellation |
+| `isActive(orderId)` | `boolean` | True if order is still active |
+| `activeCount` | `number` | Number of active orders (property) |
+| `totalCount` | `number` | Total orders seen (property) |
+| `prune()` | `void` | Free completed order memory |
+
+------------------------------------------------------------------------------
+# Source: docs/reference/node/profiles.md
+# URL: https://flox-foundation.github.io/flox/reference/node/profiles/
+------------------------------------------------------------------------------
+
+# Profiles & statistics
+
+---
+
+## VolumeProfile
+
+```javascript
+const vp = new flox.VolumeProfile(tickSize);
+vp.addTrade(price, qty, isBuy);
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `addTrade(price, qty, isBuy)` | `void` | Feed a trade |
+| `poc()` | `number` | Point of control (highest volume price) |
+| `valueAreaHigh()` | `number` | Value area high |
+| `valueAreaLow()` | `number` | Value area low |
+| `totalVolume()` | `number` | Total volume |
+| `clear()` | `void` | Reset |
+
+---
+
+## MarketProfile
+
+```javascript
+const mp = new flox.MarketProfile(tickSize, periodMinutes, sessionStartNs);
+mp.addTrade(timestampNs, price, qty, isBuy);
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `addTrade(tsNs, price, qty, isBuy)` | `void` | Feed a trade |
+| `poc()` | `number` | Point of control |
+| `valueAreaHigh()` | `number` | Value area high |
+| `valueAreaLow()` | `number` | Value area low |
+| `initialBalanceHigh()` | `number` | Initial balance high |
+| `initialBalanceLow()` | `number` | Initial balance low |
+| `isPoorHigh()` | `boolean` | Poor high |
+| `isPoorLow()` | `boolean` | Poor low |
+| `clear()` | `void` | Reset |
+
+---
+
+## FootprintBar
+
+Buy/sell delta per price level.
+
+```javascript
+const fp = new flox.FootprintBar(tickSize);
+fp.addTrade(price, qty, isBuy);
+```
+
+| Method / Property | Returns | Description |
+|-------------------|---------|-------------|
+| `addTrade(price, qty, isBuy)` | `void` | Feed a trade |
+| `totalDelta()` | `number` | Net buy minus sell volume |
+| `totalVolume()` | `number` | Total volume |
+| `numLevels` | `number` | Number of price levels (property) |
+| `clear()` | `void` | Reset |
+
+---
+
+## Statistics
+
+All functions take `Float64Array` inputs.
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `correlation(x, y)` | `number` | Pearson correlation |
+| `profitFactor(pnl)` | `number` | Gross profit / gross loss |
+| `winRate(pnl)` | `number` | Fraction of positive values |
+| `bootstrapCI(data, confidence?, samples?)` | `{ lower, median, upper }` | Bootstrap confidence interval (default: 0.95, 10000 samples) |
+| `permutationTest(group1, group2, samples?)` | `number` | Two-sample permutation p-value (default: 10000) |
+| `barReturns(longSignals, shortSignals, logReturns)` | `Float64Array` | Per-bar returns given signal arrays |
+| `tradePnl(longSignals, shortSignals, logReturns)` | `Float64Array` | PnL per closed trade |
+
+------------------------------------------------------------------------------
+# Source: docs/reference/node/data.md
+# URL: https://flox-foundation.github.io/flox/reference/node/data/
+------------------------------------------------------------------------------
+
+# Data I/O
+
+---
+
+## DataWriter
+
+Writes trades to binary log segments.
+
+```javascript
+const writer = new flox.DataWriter(outputDir, maxSegmentMb?, exchangeId?);
+writer.writeTrade(exchangeTsNs, recvTsNs, price, qty, tradeId, symbolId, side);
+writer.flush();
+writer.close();
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `writeTrade(exchangeTsNs, recvTsNs, price, qty, tradeId, symbolId, side)` | `boolean` | Write a trade record |
+| `flush()` | `void` | Flush to disk |
+| `close()` | `void` | Close and finalize |
+| `stats()` | `{ bytesWritten, eventsWritten, segmentsCreated, tradesWritten }` | Write statistics |
+
+---
+
+## DataReader
+
+Reads binary log segments.
+
+```javascript
+const reader = new flox.DataReader(dataDir, fromNs?, toNs?);
+const trades = reader.readTrades();
+const bbos = reader.readBBO();
+const events = reader.readBookUpdates();
+```
+
+| Method / Property | Returns | Description |
+|-------------------|---------|-------------|
+| `count` | `number` | Total event count (property) |
+| `summary()` | `{ firstEventNs, lastEventNs, totalEvents, segmentCount, totalBytes, durationSeconds }` | Dataset summary |
+| `stats()` | `{ filesRead, eventsRead, tradesRead, bookUpdatesRead, bytesRead, crcErrors }` | Read statistics |
+| `readTrades(max?)` | trade record array | Read up to `max` trades (all if omitted) |
+| `readTradesFrom(startTsNs, max?)` | trade record array | Same as `readTrades` starting from `startTsNs` |
+| `readBBO(max?)` | BBO record array | Top of book per book update event |
+| `readBBOFrom(startTsNs, max?)` | BBO record array | Same as `readBBO` starting from `startTsNs` |
+| `readBookUpdates()` | book update array | Full depth: each event includes `bids` and `asks` arrays |
+| `readBookUpdatesFrom(startTsNs)` | book update array | Same as `readBookUpdates` starting from `startTsNs` |
+
+Record shapes:
+
+- **Trade**: `{ exchangeTsNs, recvTsNs, price, qty, tradeId, symbolId, side }`
+- **BBO**: `{ exchangeTsNs, recvTsNs, seq, symbolId, eventType, bidPrice, bidQty, askPrice, askQty }`
+- **Book update**: `{ exchangeTsNs, recvTsNs, seq, symbolId, eventType, bids: [{price, qty}, ...], asks: [{price, qty}, ...] }`
+
+`eventType` is `2` for a snapshot, `3` for a delta.
+
+`startTsNs`, `fromNs`, `toNs` accept either a `number` or a `bigint`. Pass
+`bigint` for real nanosecond timestamps — JS `number` is float64 and silently
+rounds values past 2^53 (e.g. `1765615835519000000` becomes
+`1765615835519000064`), which can shift seek boundaries off by one event.
+
+---
+
+## DataRecorder
+
+Records live market data to disk.
+
+```javascript
+const recorder = new flox.DataRecorder(outputDir, exchangeName?, maxSegmentMb?);
+recorder.addSymbol(symbolId, name, base?, quote?, pricePrecision?, qtyPrecision?);
+recorder.start();
+// feed data...
+recorder.stop();
+```
+
+| Method / Property | Description |
+|-------------------|-------------|
+| `addSymbol(symbolId, name, base?, quote?, pricePrecision?, qtyPrecision?)` | Register a symbol for recording |
+| `start()` | Start recording |
+| `stop()` | Stop recording |
+| `flush()` | Flush buffers to disk |
+| `isRecording` | `boolean` property |
+
+---
+
+## Partitioner
+
+Splits a dataset into partitions for parallel backtesting.
+
+```javascript
+const partitioner = new flox.Partitioner(dataDir);
+const partitions = partitioner.byTime(numPartitions, warmupNs);
+```
+
+All methods return an array of partition objects `{ partitionId, fromNs, toNs, warmupFromNs, estimatedEvents, estimatedBytes }`. Pass `0` as `warmupNs` if no warmup period is needed.
+
+| Method | Description |
+|--------|-------------|
+| `byTime(numPartitions, warmupNs)` | Split into N equal time slices |
+| `byDuration(durationNs, warmupNs)` | Split by fixed duration |
+| `byCalendar(unit, warmupNs)` | Split by calendar unit (0=day, 1=week, 2=month) |
+| `bySymbol(numPartitions)` | Split by symbol group |
+| `perSymbol()` | One partition per symbol |
+| `byEventCount(numPartitions)` | Split by event count |
+
+==============================================================================
+# Section: Reference: Codon
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/reference/codon/index.md
+# URL: https://flox-foundation.github.io/flox/reference/codon/
+------------------------------------------------------------------------------
+
+# Codon API Reference
+
+Flox Codon bindings provide a Python-like API compiled to native code via the
+[Codon compiler](https://github.com/exaloop/codon).
+
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| [`flox.strategy`](strategy.md) | Strategy base class for event-driven strategies |
+| [`flox.types`](types.md) | Core types: Price, Quantity, TradeData, SymbolContext |
+| [`flox.indicators`](indicators.md) | Technical indicators (batch and streaming) |
+| [`flox.runner`](runner.md) | Runner, BacktestRunner, Signal |
+| [`flox.backtest`](backtest.md) | SimulatedExecutor, BacktestResult, BacktestStats, Engine, SignalBuilder |
+| [`flox.tools`](tools.md) | Order books, position tracking, profiles, data I/O, statistics, segment ops |
+
+## Quick Start
+
+```python
+from flox.strategy import Strategy
+from flox.context import SymbolContext
+from flox.types import TradeData
+
+class MyStrategy(Strategy):
+    def on_trade(self, ctx: SymbolContext, trade: TradeData):
+        if trade.price.to_double() > 100.0:
+            self.emit_market_buy(self._symbols[0], 1.0)
+```
+
+Compile with:
+```bash
+codon build -exe -o my_strategy -lflox_capi my_strategy.codon
+```
+
+## Architecture
+
+Codon strategies call the C API (`libflox_capi.so`) via Codon's C FFI.
+Strategy callbacks are compiled to native code via Codon's C FFI.
+
+See [Codon Bindings guide](../../bindings/codon.md) for build instructions.
+
+------------------------------------------------------------------------------
+# Source: docs/reference/codon/strategy.md
+# URL: https://flox-foundation.github.io/flox/reference/codon/strategy/
+------------------------------------------------------------------------------
+
+# Strategy
+
+::: flox.strategy.Strategy
+
+Base class for Codon event-driven strategies. Mirrors C++ `flox::Strategy`.
+
+## Class: `Strategy`
+
+### Constructor
+
+```python
+Strategy(symbols: List[int])
+```
+
+**Parameters:**
+
+- `symbols` -- List of symbol IDs to subscribe to
+
+### Overridable Callbacks
+
+#### `on_trade(ctx, trade)`
+
+Called on each trade event for subscribed symbols.
+
+```python
+def on_trade(self, ctx: SymbolContext, trade: TradeData):
+    price = trade.price.to_double()
+    # strategy logic here
+```
+
+#### `on_book_update(ctx)`
+
+Called on each order book update for subscribed symbols.
+
+```python
+def on_book_update(self, ctx: SymbolContext):
+    spread = ctx.book_spread()
+    # strategy logic here
+```
+
+#### `on_bar(ctx, bar)`
+
+Called on each closed OHLC bar.
+
+```python
+def on_bar(self, ctx: SymbolContext, bar: BarData):
+    # bar.open, bar.high, bar.low, bar.close, bar.volume, ...
+    if bar.close > bar.open and self.position() == 0.0:
+        self.market_buy(0.01)
+```
+
+#### `on_start()` / `on_stop()`
+
+Lifecycle callbacks.
+
+### Signal Emission
+
+#### `emit_market_buy(symbol, qty) -> int`
+
+Submit a market buy order. Returns order ID.
+
+#### `emit_market_sell(symbol, qty) -> int`
+
+Submit a market sell order. Returns order ID.
+
+#### `emit_limit_buy(symbol, price, qty) -> int`
+
+Submit a limit buy order. Returns order ID.
+
+#### `emit_limit_sell(symbol, price, qty) -> int`
+
+Submit a limit sell order. Returns order ID.
+
+#### `emit_cancel(order_id)`
+
+Cancel an order by ID.
+
+#### `emit_cancel_all(symbol)`
+
+Cancel all orders for a symbol.
+
+#### `emit_modify(order_id, new_price, new_qty)`
+
+Modify an existing order's price and quantity.
+
+#### `emit_stop_market(symbol, side, trigger, qty) -> int`
+
+Submit a stop market order. `side`: 0=BUY, 1=SELL.
+
+#### `emit_stop_limit(symbol, side, trigger, limit_price, qty) -> int`
+
+Submit a stop limit order.
+
+#### `emit_take_profit_market(symbol, side, trigger, qty) -> int`
+
+Submit a take profit market order.
+
+#### `emit_take_profit_limit(symbol, side, trigger, limit_price, qty) -> int`
+
+Submit a take profit limit order.
+
+#### `emit_trailing_stop(symbol, side, offset, qty) -> int`
+
+Submit a trailing stop order.
+
+#### `emit_trailing_stop_percent(symbol, side, callback_bps, qty) -> int`
+
+Submit a trailing stop with percentage callback. `callback_bps`: 100 = 1%.
+
+#### `emit_limit_buy_tif(symbol, price, qty, tif) -> int`
+
+Submit a limit buy with TimeInForce. `tif`: 0=GTC, 1=IOC, 2=FOK, 4=POST_ONLY.
+
+#### `emit_limit_sell_tif(symbol, price, qty, tif) -> int`
+
+Submit a limit sell with TimeInForce.
+
+#### `emit_close_position(symbol) -> int`
+
+Close entire position with a reduce-only market order.
+
+### Context Queries
+
+#### `position(symbol=None) -> float`
+
+Current position quantity. If `symbol` is None, uses the first subscribed symbol.
+
+#### `ctx(symbol=None) -> SymbolContext`
+
+Get a `SymbolContext` for querying per-symbol state.
+
+#### `get_order_status(order_id) -> int`
+
+Get order status. Returns -1 if not found.
+
+### Properties
+
+#### `primary_symbol -> int`
+
+Returns the first symbol in the subscription list.
+
+## Example
+
+```python
+from flox.strategy import Strategy
+from flox.context import SymbolContext
+from flox.types import TradeData
+from flox.indicators import EMA
+
+class EmaCrossover(Strategy):
+    fast_ema: EMA
+    slow_ema: EMA
+
+    def __init__(self, symbols: List[int]):
+        super().__init__(symbols)
+        self.fast_ema = EMA(12)
+        self.slow_ema = EMA(26)
+
+    def on_trade(self, ctx: SymbolContext, trade: TradeData):
+        price = trade.price.to_double()
+        fast = self.fast_ema.update(price)
+        slow = self.slow_ema.update(price)
+
+        if not self.slow_ema.ready:
+            return
+
+        sym = self.primary_symbol
+        if fast > slow and ctx.is_flat():
+            self.emit_market_buy(sym, 1.0)
+        elif fast < slow and ctx.is_long():
+            self.emit_close_position(sym)
+```
+
+------------------------------------------------------------------------------
+# Source: docs/reference/codon/types.md
+# URL: https://flox-foundation.github.io/flox/reference/codon/types/
+------------------------------------------------------------------------------
+
+# Types
+
+Core data types for Codon strategies. All types mirror their C++ equivalents
+and use fixed-point arithmetic (scale 1e8) internally.
+
+## `Price`
+
+Fixed-point price with 8 decimal places.
+
+```python
+p = Price.from_double(42000.50)
+print(p.to_double())   # 42000.5
+print(p.raw())          # 4200050000000
+print(p.is_zero())      # False
+```
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `Price.from_double(value)` | `Price` | Create from float |
+| `Price.from_raw(raw)` | `Price` | Create from raw int64 |
+| `to_double()` | `float` | Convert to float |
+| `raw()` | `int` | Get raw int64 value |
+| `is_zero()` | `bool` | Check if zero |
+
+Supports comparison operators: `==`, `<`, `>`, `<=`, `>=` and arithmetic: `+`, `-`.
+
+## `Quantity`
+
+Fixed-point quantity with 8 decimal places. Same API as `Price`.
+
+```python
+q = Quantity.from_double(1.5)
+print(q.to_double())  # 1.5
+```
+
+## `TradeData`
+
+Trade event data passed to `Strategy.on_trade()`.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `symbol` | `int` | Symbol ID |
+| `price` | `Price` | Trade price |
+| `quantity` | `Quantity` | Trade quantity |
+| `is_buy` | `bool` | Whether trade was a buy |
+| `timestamp_ns` | `int` | Exchange timestamp (nanoseconds) |
+
+## Constants
+
+### Side
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `BUY` | `0` | Buy side |
+| `SELL` | `1` | Sell side |
+
+### Order Type
+
+| Constant | Value |
+|----------|-------|
+| `ORDER_MARKET` | `0` |
+| `ORDER_LIMIT` | `1` |
+| `ORDER_STOP_MARKET` | `2` |
+| `ORDER_STOP_LIMIT` | `3` |
+| `ORDER_TAKE_PROFIT_MARKET` | `4` |
+| `ORDER_TAKE_PROFIT_LIMIT` | `5` |
+| `ORDER_TRAILING_STOP` | `6` |
+
+### Time in Force
+
+| Constant | Value |
+|----------|-------|
+| `TIF_GTC` | `0` |
+| `TIF_IOC` | `1` |
+| `TIF_FOK` | `2` |
+| `TIF_POST_ONLY` | `4` |
+
+## `SymbolContext`
+
+Per-symbol state passed to `Strategy.on_trade()` and `Strategy.on_book_update()`. Also accessible via `Strategy.ctx(symbol)`.
+
+```python
+from flox.context import SymbolContext
+
+def on_trade(self, ctx: SymbolContext, trade: TradeData):
+    if ctx.is_flat() and trade.price.to_double() > ctx.best_ask():
+        self.emit_market_buy(ctx.symbol_id, 1.0)
+```
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `symbol_id` | `int` | Numeric symbol ID |
+| `symbol` | `str` | Symbol name |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `position()` | `float` | Current position quantity |
+| `position_raw()` | `int` | Current position (raw int64, scale 1e8) |
+| `last_trade_price()` | `float` | Last trade price |
+| `best_bid()` | `float` | Best bid price |
+| `best_ask()` | `float` | Best ask price |
+| `mid_price()` | `float` | Mid price |
+| `book_spread()` | `float` | Bid-ask spread |
+| `is_long()` | `bool` | Position > 0 |
+| `is_short()` | `bool` | Position < 0 |
+| `is_flat()` | `bool` | Position == 0 |
+
+---
+
+## Scale
+
+All fixed-point types use `SCALE = 100_000_000` (1e8), matching the C++ `Decimal` template.
+
+------------------------------------------------------------------------------
+# Source: docs/reference/codon/indicators.md
+# URL: https://flox-foundation.github.io/flox/reference/codon/indicators/
+------------------------------------------------------------------------------
+
+# Indicators
+
+Technical indicators for Codon strategies. Two types:
+
+1. **Batch** — compute over an entire array at once (calls C++ via C API)
+2. **Streaming** — update one value at a time per tick (pure Codon, compiled to native)
+
+---
+
+## Batch indicators
+
+```codon
+from flox.indicators import ema, sma, rsi, atr, macd, bollinger
+from flox.indicators import Skewness, Kurtosis, RollingZScore, ShannonEntropy
+from flox.indicators import ParkinsonVol, RogersSatchellVol, Correlation
+```
+
+**Single value** — returns `List[float]`:
+
+`ema(data, period)`, `sma(data, period)`, `rma(data, period)`, `rsi(data, period)`, `dema(data, period)`, `tema(data, period)`, `kama(data, period)`
+
+**OHLC / multi-input** — returns `List[float]`:
+
+`atr(high, low, close, period)`, `ParkinsonVol.compute(high, low, period)`, `RogersSatchellVol.compute(open, high, low, close, period)`, `Correlation.compute(x, y, period)`
+
+**Statistical** — returns `List[float]`:
+
+`Skewness.compute(data, period)`, `Kurtosis.compute(data, period)`, `RollingZScore.compute(data, period)`, `ShannonEntropy.compute(data, period, bins)`
+
+**Multi-output:**
+
+`macd(data, fast=12, slow=26, signal=9)` — returns `MacdResult`: `.line`, `.signal`, `.histogram`  
+`bollinger(data, period=20, multiplier=2.0)` — returns `BollingerResult`: `.upper`, `.middle`, `.lower`
+
+```codon
+values = ema(prices, 20)
+
+m = macd(prices, 12, 26, 9)
+print(m.line[-1], m.signal[-1])
+
+ranges = atr(highs, lows, closes, 14)
+```
+
+---
+
+## Streaming indicators
+
+All streaming indicators share the same pattern: call `update()` each tick, read `.value`, check `.ready`. All support `.reset()` to clear state.
+
+```codon
+from flox.indicators import EMA, SMA, RSI, ATR, MACD, Bollinger
+from flox.indicators import RMA, DEMA, TEMA, KAMA, Slope
+from flox.indicators import OBV, VWAP, CVD
+from flox.indicators import Skewness, Kurtosis, RollingZScore, ShannonEntropy
+from flox.indicators import ParkinsonVol, RogersSatchellVol, Correlation
+```
+
+### Single-price indicators
+
+#### `EMA`
+
+```codon
+ema = EMA(period=20)
+value = ema.update(price)
+if ema.ready:
+    print(ema.value)
+```
+
+#### `SMA`
+
+Uses a circular buffer for O(1) updates.
+
+```codon
+sma = SMA(period=20)
+value = sma.update(price)
+```
+
+#### `RMA`
+
+Wilder's Moving Average (used internally by RSI and ATR).
+
+```codon
+rma = RMA(period=14)
+value = rma.update(price)
+```
+
+#### `DEMA`
+
+Double Exponential Moving Average. `.ready` is true after `2 * period` values.
+
+```codon
+dema = DEMA(period=20)
+value = dema.update(price)
+```
+
+#### `TEMA`
+
+Triple Exponential Moving Average. `.ready` is true after `3 * period` values.
+
+```codon
+tema = TEMA(period=20)
+value = tema.update(price)
+```
+
+#### `KAMA`
+
+Kaufman's Adaptive Moving Average.
+
+```codon
+kama = KAMA(period=10)
+value = kama.update(price)
+```
+
+#### `Slope`
+
+Linear regression slope over a rolling window.
+
+```codon
+slope = Slope(period=20)
+value = slope.update(price)
+```
+
+#### `RSI`
+
+```codon
+rsi = RSI(period=14)
+value = rsi.update(price)
+if rsi.ready:
+    print(rsi.value)  # 0..100
+```
+
+#### `Skewness`
+
+Fisher-Pearson skewness. Requires period >= 3.
+
+```codon
+skew = Skewness(period=20)
+value = skew.update(price)
+```
+
+#### `Kurtosis`
+
+Fisher excess kurtosis. Requires period >= 4.
+
+```codon
+kurt = Kurtosis(period=20)
+value = kurt.update(price)
+```
+
+#### `RollingZScore`
+
+`(x - mean) / std`.
+
+```codon
+zscore = RollingZScore(period=20)
+value = zscore.update(price)
+```
+
+#### `ShannonEntropy`
+
+Rolling Shannon entropy, normalized to [0, 1].
+
+```codon
+ent = ShannonEntropy(period=20, bins=10)
+value = ent.update(price)
+```
+
+---
+
+### Multi-value indicators
+
+#### `ATR`
+
+```codon
+atr = ATR(period=14)
+value = atr.update(high, low, close)
+```
+
+#### `MACD`
+
+```codon
+macd = MACD(fast=12, slow=26, signal=9)
+macd.update(price)
+if macd.ready:
+    print(macd.line, macd.signal, macd.histogram)
+```
+
+#### `Bollinger`
+
+```codon
+bb = Bollinger(period=20, multiplier=2.0)
+bb.update(price)
+if bb.ready:
+    print(bb.upper, bb.middle, bb.lower)
+```
+
+#### `ParkinsonVol`
+
+Parkinson high-low volatility estimator.
+
+```codon
+pvol = ParkinsonVol(period=20)
+value = pvol.update(high, low)
+```
+
+#### `RogersSatchellVol`
+
+Rogers-Satchell OHLC volatility estimator.
+
+```codon
+rsv = RogersSatchellVol(period=20)
+value = rsv.update(open_, high, low, close)
+```
+
+#### `Correlation`
+
+Rolling Pearson correlation between two series.
+
+```codon
+corr = Correlation(period=20)
+value = corr.update(x, y)
+```
+
+---
+
+### Volume indicators
+
+#### `OBV`
+
+On-Balance Volume.
+
+```codon
+obv = OBV()
+value = obv.update(price, volume, is_buy)
+```
+
+#### `VWAP`
+
+Volume Weighted Average Price.
+
+```codon
+vwap = VWAP()
+value = vwap.update(price, volume)
+```
+
+#### `CVD`
+
+Cumulative Volume Delta.
+
+```codon
+cvd = CVD()
+value = cvd.update(volume, is_buy)
+```
+
+---
+
+## Aliases
+
+`StreamingEMA` and `StreamingSMA` are available as aliases for `EMA` and `SMA` for backward compatibility.
+
+## Indicator catalog
+
+<!-- INDICATOR-LIST-START -->
+
+Every indicator below is **one Codon class** with both a batch
+`compute()` method and streaming `update()` / `value` / `ready` / `reset()`.
+
+| Indicator | Constructor | Kind |
+|---|---|---|
+| `EMA` | `flox.EMA(size_t period)` | SingleInput |
+| `SMA` | `flox.SMA(size_t period)` | SingleInput |
+| `RMA` | `flox.RMA(size_t period)` | SingleInput |
+| `RSI` | `flox.RSI(size_t period)` | SingleInput |
+| `KAMA` | `flox.KAMA(size_t period, size_t fast, size_t slow)` | SingleInput |
+| `DEMA` | `flox.DEMA(size_t period)` | SingleInput |
+| `TEMA` | `flox.TEMA(size_t period)` | SingleInput |
+| `Slope` | `flox.Slope(size_t length)` | SingleInput |
+| `Skewness` | `flox.Skewness(size_t period)` | SingleInput |
+| `Kurtosis` | `flox.Kurtosis(size_t period)` | SingleInput |
+| `RollingZScore` | `flox.RollingZScore(size_t period)` | SingleInput |
+| `ShannonEntropy` | `flox.ShannonEntropy(size_t period, size_t bins)` | SingleInput |
+| `AutoCorrelation` | `flox.AutoCorrelation(size_t window, size_t lag)` | SingleInput |
+| `ATR` | `flox.ATR(size_t period)` | BarInput |
+| `CCI` | `flox.CCI(size_t period)` | BarInput |
+| `Stochastic` | `flox.Stochastic(size_t k_period, size_t d_period)` | BarInput |
+| `ParkinsonVol` | `flox.ParkinsonVol(size_t period)` | HighLowInput |
+| `RogersSatchellVol` | `flox.RogersSatchellVol(size_t period)` | OhlcInput |
+| `Correlation` | `flox.Correlation(size_t period)` | PairInput |
+| `MACD` | `flox.MACD(size_t fast, size_t slow, size_t signal)` | MultiOutput |
+| `Bollinger` | `flox.Bollinger(size_t period, double stddev)` | MultiOutput |
+
+
+<!-- INDICATOR-LIST-END -->
+
+------------------------------------------------------------------------------
+# Source: docs/reference/codon/runner.md
+# URL: https://flox-foundation.github.io/flox/reference/codon/runner/
+------------------------------------------------------------------------------
+
+# Runner, LiveEngine, BacktestRunner
+
+```codon
+from flox.runner import Runner, BacktestRunner
+```
+
+---
+
+## Signal
+
+Emitted by a strategy when it places an order.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `order_id` | `int` | Order ID |
+| `symbol` | `int` | Symbol ID |
+| `side` | `str` | `"buy"` or `"sell"` |
+| `order_type` | `str` | `"market"`, `"limit"`, `"stop_market"`, `"stop_limit"`, `"tp_market"`, `"tp_limit"`, `"trailing_stop"`, `"cancel"`, `"cancel_all"`, `"modify"` |
+| `price` | `float` | Limit price (0 for market orders) |
+| `quantity` | `float` | Order quantity |
+| `trigger_price` | `float` | Stop/take-profit trigger |
+| `trailing_offset` | `float` | Trailing stop absolute offset |
+| `trailing_bps` | `int` | Trailing stop callback rate (basis points) |
+| `new_price` | `float` | Modify: updated price |
+| `new_quantity` | `float` | Modify: updated quantity |
+
+---
+
+## Runner
+
+Synchronous strategy host. Push market data; strategy callbacks fire before the call returns. Pass `threaded=True` to use a Disruptor ring buffer with strategy callbacks running in a background C++ thread.
+
+```codon
+from flox.runner import Runner
+
+def on_signal(sig: Signal):
+    print(sig.side, sig.quantity, sig.price)
+
+runner = Runner(registry, on_signal)          # synchronous
+runner = Runner(registry, on_signal, True)    # threaded
+
+runner.add_strategy(my_strategy)
+runner.start()
+runner.on_trade(btc, 67000.0, 0.01, True, ts_ns)
+runner.on_book_snapshot(btc, bid_prices, bid_qtys, ask_prices, ask_qtys, ts_ns)
+runner.stop()
+```
+
+### Constructor
+
+```codon
+Runner(registry: cobj, on_signal: Function[[Signal], None], threaded: bool = False)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `registry` | Handle from `flox_registry_create()` |
+| `on_signal` | Called when a strategy emits an order |
+| `threaded` | If `True`, use Disruptor-based consumer thread |
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `add_strategy(strategy)` | Register a strategy instance |
+| `start()` | Start the runner |
+| `stop()` | Stop and clean up |
+| `on_trade(symbol, price, qty, is_buy, ts_ns)` | Push a trade tick |
+| `on_book_snapshot(symbol, bid_prices, bid_qtys, ask_prices, ask_qtys, ts_ns)` | Push a full L2 snapshot |
+
+`symbol` accepts a symbol ID (`int`) or any value with a `symbol_id` property.
+
+---
+
+## BacktestRunner
+
+Replays OHLCV data through a strategy. Emitted orders go to `SimulatedExecutor` automatically.
+
+```codon
+from flox.runner import BacktestRunner
+
+bt = BacktestRunner(registry, fee_rate=0.0004, initial_capital=10_000.0)
+bt.set_strategy(my_strategy)
+
+stats = bt.run_csv("data/btcusdt.csv", "BTCUSDT")
+stats = bt.run_ohlcv(timestamps, closes, "BTCUSDT")
+print(stats.return_pct, stats.sharpe)
+```
+
+### Constructor
+
+```codon
+BacktestRunner(registry: cobj, fee_rate: float = 0.0004, initial_capital: float = 10_000.0)
+```
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `set_strategy(strategy)` | `None` | Attach a strategy |
+| `run_csv(path, symbol)` | `BacktestStats` | Replay a CSV file (columns: timestamp, open, high, low, close, volume) |
+| `run_ohlcv(timestamps, closes, symbol)` | `BacktestStats` | Replay raw arrays (`List[int]` timestamps in ns, `List[float]` closes) |
+| `close()` | `None` | Free resources |
+
+See [Backtest](backtest.md) for the `BacktestStats` field reference.
+
+------------------------------------------------------------------------------
+# Source: docs/reference/codon/backtest.md
+# URL: https://flox-foundation.github.io/flox/reference/codon/backtest/
+------------------------------------------------------------------------------
+
+# Backtest components
+
+```codon
+from flox.backtest import SimulatedExecutor, BacktestResult, BacktestStats
+from flox.backtest import SLIPPAGE_NONE, SLIPPAGE_FIXED_TICKS, SLIPPAGE_FIXED_BPS, SLIPPAGE_VOLUME_IMPACT
+from flox.backtest import QUEUE_NONE, QUEUE_TOB, QUEUE_FULL
+from flox.engine import Engine, SignalBuilder
+```
+
+---
+
+## BacktestStats
+
+Returned by `BacktestRunner.run_csv()` / `run_ohlcv()` and `BacktestResult.stats()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `total_trades` | `int` | Round-trip trade count |
+| `winning_trades` | `int` | Winning trades |
+| `losing_trades` | `int` | Losing trades |
+| `max_consecutive_wins` | `int` | Max consecutive wins |
+| `max_consecutive_losses` | `int` | Max consecutive losses |
+| `initial_capital` | `float` | Starting capital |
+| `final_capital` | `float` | Ending capital |
+| `total_pnl` | `float` | Gross P&L |
+| `total_fees` | `float` | Total fees paid |
+| `net_pnl` | `float` | Net P&L after fees |
+| `gross_profit` | `float` | Sum of winning trades |
+| `gross_loss` | `float` | Sum of losing trades |
+| `max_drawdown` | `float` | Max drawdown (absolute) |
+| `max_drawdown_pct` | `float` | Max drawdown (%) |
+| `win_rate` | `float` | Winning trade ratio |
+| `profit_factor` | `float` | Gross profit / gross loss |
+| `avg_win` | `float` | Average winning trade |
+| `avg_loss` | `float` | Average losing trade |
+| `avg_win_loss_ratio` | `float` | `avg_win / avg_loss` |
+| `avg_trade_duration_ns` | `float` | Average trade duration (ns) |
+| `median_trade_duration_ns` | `float` | Median trade duration (ns) |
+| `max_trade_duration_ns` | `float` | Longest trade (ns) |
+| `sharpe` | `float` | Annualized Sharpe ratio |
+| `sortino` | `float` | Sortino ratio |
+| `calmar` | `float` | Calmar ratio |
+| `time_weighted_return` | `float` | Time-weighted return |
+| `return_pct` | `float` | Net return (%) |
+| `start_time_ns` | `int` | Backtest start timestamp (ns) |
+| `end_time_ns` | `int` | Backtest end timestamp (ns) |
+
+---
+
+## SimulatedExecutor
+
+Fills orders from simulated market data. Use directly when you need more control than `BacktestRunner` provides.
+
+```codon
+from flox.backtest import SimulatedExecutor, SLIPPAGE_FIXED_BPS, QUEUE_TOB
+
+exec = SimulatedExecutor()
+exec.set_default_slippage(SLIPPAGE_FIXED_BPS, bps=2.0)
+exec.set_queue_model(QUEUE_TOB, depth=1)
+
+exec.submit_order(order_id, "buy", price, qty)
+exec.on_bar(symbol, close_price)
+exec.on_trade(symbol, price, is_buy)
+exec.advance_clock(ts_ns)
+```
+
+### Constructor
+
+```codon
+SimulatedExecutor()
+```
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `submit_order(id, side, price, qty, order_type="market", symbol=1)` | Submit an order (`side`: `"buy"`/`"sell"`, `order_type`: `"market"`/`"limit"`) |
+| `cancel_order(order_id)` | Cancel an order |
+| `cancel_all(symbol)` | Cancel all orders for a symbol |
+| `on_bar(symbol, close_price)` | Feed a bar close |
+| `on_trade(symbol, price, is_buy)` | Feed a trade |
+| `on_trade_qty(symbol, price, qty, is_buy)` | Feed a trade with quantity (enables queue-fill simulation) |
+| `on_best_levels(symbol, bid_price, bid_qty, ask_price, ask_qty)` | Feed top-of-book snapshot |
+| `advance_clock(timestamp_ns)` | Advance simulated time |
+| `set_default_slippage(model, ticks=0, tick_size=0.0, bps=0.0, impact_coeff=0.0)` | Configure slippage for all symbols |
+| `set_symbol_slippage(symbol, model, ticks=0, tick_size=0.0, bps=0.0, impact_coeff=0.0)` | Per-symbol slippage override |
+| `set_queue_model(model, depth=1)` | Configure limit order queue simulation |
+| `close()` | Free resources |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `fill_count` | `int` | Number of fills generated |
+
+### Slippage models
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `SLIPPAGE_NONE` | `0` | No slippage |
+| `SLIPPAGE_FIXED_TICKS` | `1` | Fixed tick count per fill |
+| `SLIPPAGE_FIXED_BPS` | `2` | Fixed basis points per fill |
+| `SLIPPAGE_VOLUME_IMPACT` | `3` | Volume-proportional impact |
+
+### Queue models
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `QUEUE_NONE` | `0` | Fill limit orders immediately at price |
+| `QUEUE_TOB` | `1` | Fill only when price trades through level |
+| `QUEUE_FULL` | `2` | Model queue position; fill as volume passes |
+
+---
+
+## BacktestResult
+
+Aggregates fills from a `SimulatedExecutor` into statistics and an equity curve.
+
+```codon
+from flox.backtest import BacktestResult
+
+result = BacktestResult(initial_capital=10_000.0, fee_rate=0.0004)
+result.ingest_executor(exec)
+stats = result.stats()
+```
+
+### Constructor
+
+```codon
+BacktestResult(
+    initial_capital: float = 100000.0,
+    fee_rate: float = 0.0001,
+    use_percentage_fee: bool = True,
+    fixed_fee_per_trade: float = 0.0,
+    risk_free_rate: float = 0.0,
+    annualization_factor: float = 252.0
+)
+```
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `record_fill(order_id, symbol, side, price, qty, timestamp_ns)` | `None` | Record a single fill |
+| `ingest_executor(executor)` | `None` | Drain all fills from a `SimulatedExecutor` |
+| `stats()` | `BacktestStats` | Compute and return statistics |
+| `equity_curve_size()` | `int` | Number of equity curve points |
+| `write_equity_curve_csv(path)` | `bool` | Write equity curve to CSV |
+| `close()` | `None` | Free resources |
+
+---
+
+## Engine
+
+Bulk backtesting engine. Loads OHLCV data once, then runs a `SignalBuilder` against it.
+
+```codon
+from flox.engine import Engine, SignalBuilder
+
+engine = Engine(initial_capital=10_000.0, fee_rate=0.0004)
+engine.load_csv("data/btcusdt.csv", symbol="BTCUSDT")
+
+signals = SignalBuilder()
+close = engine.close()
+for i in range(1, len(close)):
+    if close[i] > close[i-1]:
+        signals.buy(engine.ts()[i], 0.01, "BTCUSDT")
+    else:
+        signals.sell(engine.ts()[i], 0.01, "BTCUSDT")
+
+stats = engine.run(signals)
+```
+
+### Constructor
+
+```codon
+Engine(initial_capital: float = 100000.0, fee_rate: float = 0.0001)
+```
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `load_csv(path, symbol="")` | `None` | Load OHLCV CSV (columns: timestamp, open, high, low, close, volume) |
+| `load_ohlcv(timestamps, opens, highs, lows, closes, volumes, symbol="")` | `None` | Load raw OHLCV arrays |
+| `bar_count(symbol="")` | `int` | Number of bars loaded |
+| `run(signals, default_symbol="")` | `BacktestStats` | Run a `SignalBuilder` and return statistics |
+
+### Data accessors
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `ts(symbol="")` | `List[int]` | Timestamps (ns) |
+| `open(symbol="")` | `List[float]` | Open prices |
+| `high(symbol="")` | `List[float]` | High prices |
+| `low(symbol="")` | `List[float]` | Low prices |
+| `close(symbol="")` | `List[float]` | Close prices |
+| `volume(symbol="")` | `List[float]` | Volumes |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `symbols` | `List[str]` | Registered symbol names |
+
+---
+
+## SignalBuilder
+
+Builds a signal list to pass to `Engine.run()`.
+
+```codon
+signals = SignalBuilder()
+signals.buy(ts_ms, 0.01, "BTCUSDT")
+signals.sell(ts_ms, 0.01)
+stats = engine.run(signals)
+```
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `buy(ts_ms, qty, symbol="")` | Add a market long entry at `ts_ms` |
+| `sell(ts_ms, qty, symbol="")` | Add a market short entry at `ts_ms` |
+| `limit_buy(ts_ms, price, qty, symbol="")` | Add a limit long entry |
+| `limit_sell(ts_ms, price, qty, symbol="")` | Add a limit short entry |
+| `clear()` | Clear all signals |
+| `__len__()` | Number of signals |
+
+------------------------------------------------------------------------------
+# Source: docs/reference/codon/tools.md
+# URL: https://flox-foundation.github.io/flox/reference/codon/tools/
+------------------------------------------------------------------------------
+
+# Tools
+
+Utility classes for order books, position tracking, profiles, data I/O, and statistics.
+
+```codon
+from flox.tools import (
+    OrderBook, L3Book, CompositeBook,
+    PositionTracker, PositionGroupTracker, OrderTracker,
+    VolumeProfile, MarketProfile, FootprintBar,
+    DataWriter, DataReader, DataRecorder, Partitioner,
+    correlation, profit_factor, win_rate,
+    permutation_test, bootstrap_ci,
+    validate_segment, merge_segments, merge_dir,
+    split_segment, export_segment, validate_segment_full, validate_dataset,
+    recompress_segment, extract_symbols, extract_time_range,
+)
+```
+
+---
+
+## Order books
+
+### OrderBook
+
+L2 order book.
+
+```codon
+book = OrderBook(tick_size=0.01)
+book.apply_snapshot(bid_prices, bid_qtys, ask_prices, ask_qtys)
+bid = book.best_bid()
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `apply_snapshot(bp, bq, ap, aq)` | `None` | Full snapshot |
+| `apply_delta(bp, bq, ap, aq)` | `None` | Incremental update |
+| `best_bid()` | `Optional[float]` | Best bid price |
+| `best_ask()` | `Optional[float]` | Best ask price |
+| `mid()` | `Optional[float]` | Mid price |
+| `spread()` | `Optional[float]` | Bid-ask spread |
+| `is_crossed()` | `bool` | True if book is crossed |
+| `clear()` | `None` | Clear all levels |
+
+### L3Book
+
+Order-level book with individual order tracking.
+
+```codon
+book = L3Book()
+book.add_order(order_id, price, qty, "buy")
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `add_order(order_id, price, qty, side)` | `int` | 0 on success |
+| `remove_order(order_id)` | `int` | 0 on success |
+| `modify_order(order_id, new_qty)` | `int` | 0 on success |
+| `best_bid()` | `Optional[float]` | Best bid price |
+| `best_ask()` | `Optional[float]` | Best ask price |
+| `bid_at_price(price)` | `float` | Total bid quantity at price |
+| `ask_at_price(price)` | `float` | Total ask quantity at price |
+
+### CompositeBook
+
+Aggregates books across multiple exchanges per symbol.
+
+```codon
+cb = CompositeBook()
+result = cb.best_bid(symbol_id)  # Optional[Tuple[float, float]]
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `best_bid(symbol)` | `Optional[Tuple[float, float]]` | `(price, qty)` or `None` |
+| `best_ask(symbol)` | `Optional[Tuple[float, float]]` | `(price, qty)` or `None` |
+| `has_arbitrage(symbol)` | `bool` | True if arbitrage opportunity exists |
+| `mark_stale(exchange, symbol)` | `None` | Mark exchange data as stale |
+| `check_staleness(now_ns, threshold_ns)` | `None` | Evict stale data |
+
+---
+
+## Position tracking
+
+### PositionTracker
+
+FIFO/average-cost position tracking.
+
+```codon
+tracker = PositionTracker()          # FIFO (default)
+tracker = PositionTracker(1)         # average cost
+
+tracker.on_fill(symbol, "buy", price, qty)
+pos = tracker.position(symbol)
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `on_fill(symbol, side, price, qty)` | `None` | Record a fill |
+| `position(symbol)` | `float` | Current net position |
+| `avg_entry_price(symbol)` | `float` | Average entry price |
+| `realized_pnl(symbol)` | `float` | Realized PnL for symbol |
+| `total_realized_pnl()` | `float` | Total realized PnL |
+
+### PositionGroupTracker
+
+Tracks individual named positions (open/partial-close/close).
+
+```codon
+tracker = PositionGroupTracker()
+pos_id = tracker.open_position(order_id, symbol, "buy", price, qty)
+tracker.close_position(pos_id, exit_price)
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `open_position(order_id, symbol, side, price, qty)` | `int` (position ID) | Open a position |
+| `close_position(position_id, exit_price)` | `None` | Close fully |
+| `partial_close(position_id, qty, exit_price)` | `None` | Partial close |
+| `net_position(symbol)` | `float` | Net position for symbol |
+| `realized_pnl(symbol)` | `float` | Realized PnL for symbol |
+| `total_realized_pnl()` | `float` | Total realized PnL |
+| `open_position_count(symbol)` | `int` | Number of open positions |
+| `prune()` | `None` | Free closed position memory |
+
+### OrderTracker
+
+Tracks submitted/filled/canceled orders.
+
+```codon
+tracker = OrderTracker()
+tracker.on_submitted(order_id, symbol, "buy", price, qty)
+tracker.on_filled(order_id, fill_qty)
+```
+
+| Method / Property | Returns | Description |
+|-------------------|---------|-------------|
+| `on_submitted(order_id, symbol, side, price, qty)` | `bool` | Register a submitted order |
+| `on_filled(order_id, fill_qty)` | `bool` | Record a fill |
+| `on_canceled(order_id)` | `bool` | Record a cancellation |
+| `is_active(order_id)` | `bool` | True if order is still active |
+| `active_count` | `int` | Number of active orders |
+| `total_count` | `int` | Total orders seen |
+| `prune()` | `None` | Free completed order memory |
+
+---
+
+## Profiles
+
+### VolumeProfile
+
+```codon
+vp = VolumeProfile(tick_size=0.01)
+vp.add_trade(price, qty, is_buy)
+poc = vp.poc()
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `add_trade(price, qty, is_buy)` | `None` | Feed a trade |
+| `poc()` | `float` | Point of control |
+| `value_area_high()` | `float` | Value area high |
+| `value_area_low()` | `float` | Value area low |
+| `total_volume()` | `float` | Total volume |
+| `clear()` | `None` | Reset |
+
+### MarketProfile
+
+```codon
+mp = MarketProfile(tick_size=0.01, period_minutes=30, session_start_ns=0)
+mp.add_trade(timestamp_ns, price, qty, is_buy)
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `add_trade(ts_ns, price, qty, is_buy)` | `None` | Feed a trade |
+| `poc()` | `float` | Point of control |
+| `value_area_high()` | `float` | Value area high |
+| `value_area_low()` | `float` | Value area low |
+| `initial_balance_high()` | `float` | Initial balance high |
+| `initial_balance_low()` | `float` | Initial balance low |
+| `is_poor_high()` | `bool` | Poor high |
+| `is_poor_low()` | `bool` | Poor low |
+| `clear()` | `None` | Reset |
+
+### FootprintBar
+
+Buy/sell delta per price level.
+
+```codon
+fp = FootprintBar(tick_size=0.01)
+fp.add_trade(price, qty, is_buy)
+delta = fp.total_delta()
+```
+
+| Method / Property | Returns | Description |
+|-------------------|---------|-------------|
+| `add_trade(price, qty, is_buy)` | `None` | Feed a trade |
+| `total_delta()` | `float` | Net buy minus sell volume |
+| `total_volume()` | `float` | Total volume |
+| `num_levels` | `int` | Number of price levels |
+| `clear()` | `None` | Reset |
+
+---
+
+## Statistics
+
+```codon
+from flox.tools import correlation, profit_factor, win_rate, permutation_test, bootstrap_ci
+
+r = correlation(x, y)
+pf = profit_factor(pnl_list)
+wr = win_rate(pnl_list)
+p = permutation_test(group1, group2, num_permutations=10000)
+lo, med, hi = bootstrap_ci(data, confidence=0.95, num_samples=10000)
+```
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `correlation(x, y)` | `float` | Pearson correlation |
+| `profit_factor(pnl)` | `float` | Gross profit / gross loss |
+| `win_rate(pnl)` | `float` | Fraction of positive values |
+| `permutation_test(g1, g2, n=10000)` | `float` | Two-sample permutation p-value |
+| `bootstrap_ci(data, confidence=0.95, n=10000)` | `Tuple[float, float, float]` | `(lower, median, upper)` |
+
+---
+
+## Data I/O
+
+### DataWriter
+
+```codon
+writer = DataWriter("./data", max_segment_mb=256, exchange_id=0)
+writer.write_trade(exchange_ts_ns, recv_ts_ns, price, qty, trade_id, symbol_id, side)
+writer.flush()
+writer.close()
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `write_trade(exchange_ts_ns, recv_ts_ns, price, qty, trade_id, symbol_id, side)` | `bool` | Write a trade record |
+| `flush()` | `None` | Flush to disk |
+| `close()` | `None` | Close and finalize |
+| `stats()` | `WriterStats` | Write statistics |
+
+`WriterStats` fields: `bytes_written`, `events_written`, `segments_created`, `trades_written`.
+
+### DataReader
+
+```codon
+reader = DataReader("./data")
+reader = DataReader.create_filtered("./data", from_ns=0, to_ns=0, symbols=[])
+trades = reader.read_trades()
+bbos = reader.read_bbo()
+events = reader.read_book_updates()
+```
+
+| Method / Property | Returns | Description |
+|-------------------|---------|-------------|
+| `count()` | `int` | Total event count |
+| `summary()` | `DatasetSummary` | Dataset summary |
+| `reader_stats()` | `ReaderStats` | Read statistics |
+| `read_trades(max_trades=0)` | `List[TradeRecord]` | Read trades (all if `max_trades=0`) |
+| `read_trades_from(start_ts_ns, max_trades=0)` | `List[TradeRecord]` | Same as `read_trades` starting from `start_ts_ns` |
+| `read_bbo(max_events=0)` | `List[BBO]` | Top of book per book update event |
+| `read_bbo_from(start_ts_ns, max_events=0)` | `List[BBO]` | Same as `read_bbo` starting from `start_ts_ns` |
+| `read_book_updates()` | `List[BookUpdate]` | Full depth per book update event |
+| `read_book_updates_from(start_ts_ns)` | `List[BookUpdate]` | Same as `read_book_updates` starting from `start_ts_ns` |
+
+`DatasetSummary` fields: `first_event_ns`, `last_event_ns`, `total_events`, `segment_count`, `total_bytes`, `duration_seconds`.
+
+`TradeRecord` fields: `exchange_ts_ns`, `recv_ts_ns`, `price_raw`, `qty_raw`, `trade_id`, `symbol_id`, `side`. Methods: `price()`, `qty()`, `is_buy()`.
+
+`BBO` fields: `exchange_ts_ns`, `recv_ts_ns`, `seq`, `symbol_id`, `event_type` (2=snapshot, 3=delta), `bid_price_raw`, `bid_qty_raw`, `ask_price_raw`, `ask_qty_raw`. Methods: `bid_price()`, `ask_price()`, `bid_qty()`, `ask_qty()`.
+
+`BookLevel` fields: `price_raw`, `qty_raw`, `side` (0=bid, 1=ask). Methods: `price()`, `qty()`.
+
+`BookUpdate` fields: `exchange_ts_ns`, `recv_ts_ns`, `seq`, `symbol_id`, `event_type`, `bids: List[BookLevel]`, `asks: List[BookLevel]`.
+
+### DataRecorder
+
+```codon
+recorder = DataRecorder("./data", exchange_name="binance", max_segment_mb=256)
+recorder.add_symbol(symbol_id, "BTCUSDT", base="BTC", quote="USDT")
+recorder.start()
+# feed live data...
+recorder.stop()
+```
+
+| Method / Property | Description |
+|-------------------|-------------|
+| `add_symbol(symbol_id, name, base="", quote="", price_precision=8, qty_precision=8)` | Register a symbol |
+| `start()` | Start recording |
+| `stop()` | Stop recording |
+| `flush()` | Flush buffers to disk |
+| `is_recording` | `bool` property |
+
+---
+
+## Partitioner
+
+Splits a dataset into partitions for parallel backtesting.
+
+```codon
+p = Partitioner("./data")
+partitions = p.by_time(num_partitions=4, warmup_ns=0)
+for part in partitions:
+    # part.from_ns, part.to_ns, part.warmup_from_ns, ...
+    pass
+p.close()
+```
+
+`Partition` fields: `partition_id`, `from_ns`, `to_ns`, `warmup_from_ns`, `estimated_events`, `estimated_bytes`.
+
+| Method | Description |
+|--------|-------------|
+| `by_time(num_partitions, warmup_ns=0)` | Split into N equal time slices |
+| `by_duration(duration_ns, warmup_ns=0)` | Split by fixed duration |
+| `by_calendar(unit=CALENDAR_MONTHLY, warmup_ns=0)` | Split by calendar unit |
+| `by_symbol(num_partitions)` | Split by symbol group |
+| `per_symbol()` | One partition per symbol |
+| `by_event_count(num_partitions)` | Split by event count |
+| `close()` | Free resources |
+
+Calendar unit constants: `Partitioner.CALENDAR_DAILY = 0`, `CALENDAR_WEEKLY = 1`, `CALENDAR_MONTHLY = 2`.
+
+---
+
+## Segment operations
+
+```codon
+from flox.tools import validate_segment, merge_segments, merge_dir, split_segment, export_segment
+
+validate_segment("path/to/seg")            # bool
+merge_segments("input_dir", "output.bin")  # bool
+```
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `validate_segment(path)` | `bool` | Quick validation |
+| `validate_segment_full(path, verify_crc=True, verify_timestamps=True)` | `SegmentValidation` | Full validation |
+| `validate_dataset(data_dir)` | `DatasetValidation` | Validate all segments in directory |
+| `merge_segments(input_dir, output_path)` | `bool` | Merge directory into one file |
+| `merge_dir(input_dir, output_dir)` | `MergeResult` | Merge with result metadata |
+| `split_segment(input_path, output_dir, mode=0, time_interval_ns=0, events_per_file=0)` | `SplitResult` | Split segment |
+| `export_segment(input_path, output_path, format=0, from_ns=0, to_ns=0, symbols=[])` | `ExportResult` | Export to CSV or other format |
+| `recompress_segment(input_path, output_path, compression=1)` | `bool` | Recompress |
+| `extract_symbols(input_path, output_path, symbols)` | `int` | Extract specific symbols |
+| `extract_time_range(input_path, output_path, from_ns, to_ns)` | `int` | Extract time slice |
+
+==============================================================================
+# Section: Reference: embedded JavaScript
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/reference/quickjs/index.md
+# URL: https://flox-foundation.github.io/flox/reference/quickjs/
+------------------------------------------------------------------------------
+
+# JavaScript (embedded) API reference
+
+Full API for embedded QuickJS strategies. See [Getting started](../../bindings/javascript.md) for build instructions and examples.
+
+## Modules
+
+| Page | Contents |
+|------|----------|
+| [Strategy](strategy.md) | Strategy class, callbacks, order methods, context queries |
+| [Indicators](indicators.md) | Per-tick streaming and batch compute |
+| [Tools](tools.md) | Order books, position tracking, profiles, statistics, segment ops |
+| [Backtest & runtime](backtest.md) | SimulatedExecutor, memory limits, IDE support |
+
+------------------------------------------------------------------------------
+# Source: docs/reference/quickjs/strategy.md
+# URL: https://flox-foundation.github.io/flox/reference/quickjs/strategy/
+------------------------------------------------------------------------------
+
+# Strategy
+
+Extend `Strategy` and call `flox.register` with an instance.
+
+```javascript
+class MyStrategy extends Strategy {
+    constructor() {
+        super({ exchange: 'Binance', symbols: ['BTCUSDT'] });
+    }
+
+    onTrade(ctx, trade) { ... }
+    onBookUpdate(ctx, book) { ... }
+    onBar(ctx, bar) { ... }
+    onStart() { ... }
+    onStop() { ... }
+}
+
+flox.register(new MyStrategy());
+```
+
+### Constructor options
+
+```javascript
+// Single exchange
+super({ exchange: 'Binance', symbols: ['BTCUSDT', 'ETHUSDT'] })
+
+// Multi-exchange (qualified names)
+super({ symbols: ['Binance:BTCUSDT', 'Bybit:ETHUSDT'] })
+```
+
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `primarySymbol` | `string` | First symbol name |
+| `symbols` | `string[]` | All registered symbol names |
+| `hasPosition` | `boolean` | Whether a position is open (primary symbol) |
+
+---
+
+## Callbacks
+
+### `onTrade(ctx, trade)`
+
+| Field | Type | Description |
+|---|---|---|
+| `ctx.symbol` | `string` | Symbol name |
+| `ctx.symbolId` | `number` | Numeric symbol ID |
+| `ctx.position` | `number` | Current position size |
+| `ctx.avgEntryPrice` | `number` | Average entry price |
+| `ctx.book.bidPrice` | `number` | Best bid |
+| `ctx.book.askPrice` | `number` | Best ask |
+| `trade.symbol` | `string` | Symbol name |
+| `trade.price` | `number` | Trade price |
+| `trade.qty` | `number` | Trade quantity |
+| `trade.side` | `string` | `"buy"` or `"sell"` |
+| `trade.isBuy` | `boolean` | |
+| `trade.timestampNs` | `number` | Nanosecond timestamp |
+
+### `onBar(ctx, bar)`
+
+| Field | Type | Description |
+|---|---|---|
+| `bar.open`, `bar.high`, `bar.low`, `bar.close` | `number` | OHLC prices |
+| `bar.volume`, `bar.buyVolume` | `number` | Total / buy-side volume |
+| `bar.startTimeNs`, `bar.endTimeNs` | `number` | Bar window timestamps (nanoseconds) |
+| `bar.barType`, `bar.barTypeParam` | `number` | 0=Time, 1=Tick, ... + interval/threshold |
+| `bar.closeReason` | `number` | 0=Threshold, 1=Gap, 2=Forced, 3=Warmup |
+
+### `onStart()` / `onStop()`
+
+Called when the strategy starts and stops.
+
+---
+
+## Order methods
+
+All methods accept an options object. `symbol` defaults to the primary symbol when omitted.
+
+### Market
+
+```javascript
+this.marketBuy({ qty: 1.0 })
+this.marketSell({ symbol: 'ETHUSDT', qty: 2.0 })
+```
+
+### Limit
+
+```javascript
+this.limitBuy({ price: 50000, qty: 0.1 })
+this.limitSell({ price: 51000, qty: 0.1, tif: 'IOC' })  // tif: GTC (default) | IOC | FOK
+```
+
+### Stop / take-profit
+
+```javascript
+this.stopMarket({ side: 'sell', trigger: 48000, qty: 0.1 })
+this.stopLimit({ side: 'buy', trigger: 52000, price: 52100, qty: 0.1 })
+this.takeProfitMarket({ side: 'sell', trigger: 55000, qty: 0.1 })
+this.takeProfitLimit({ side: 'sell', trigger: 55000, price: 54900, qty: 0.1 })
+```
+
+### Trailing stop
+
+```javascript
+this.trailingStop({ side: 'sell', offset: 100, qty: 0.1 })
+this.trailingStopPercent({ side: 'sell', callbackBps: 50, qty: 0.1 })
+```
+
+### Order management
+
+```javascript
+this.cancel(orderId)
+this.cancelAll()
+this.modify(orderId, { price: 50100, qty: 0.2 })
+this.closePosition()
+```
+
+---
+
+## Context queries
+
+```javascript
+this.position()             // primary symbol
+this.position('ETHUSDT')    // specific symbol
+this.bestBid()
+this.bestAsk()
+this.midPrice()
+this.lastPrice()
+this.orderStatus(orderId)   // -1 if not found
+```
+
+------------------------------------------------------------------------------
+# Source: docs/reference/quickjs/indicators.md
+# URL: https://flox-foundation.github.io/flox/reference/quickjs/indicators/
+------------------------------------------------------------------------------
+
+# Indicators
+
+Each indicator has `.update()` for per-tick use and a static `.compute()` for batch. All classes support `.reset()` to clear state.
+
+```javascript
+// Single value
+const ema = new EMA(20);
+ema.update(price);        // returns current value (NaN during warmup)
+ema.reset();
+
+// Multi-output
+const macd = new MACD(12, 26, 9);
+macd.update(price);
+macd.line; macd.signal; macd.histogram;
+
+// OHLC input
+const atr = new ATR(14);
+atr.update(high, low, close);
+
+const stoch = new Stochastic(14, 3);
+stoch.update(high, low, close);
+stoch.k; stoch.d;
+
+// Multi-input
+const corr = new Correlation(20);
+corr.update(x, y);
+
+const pvol = new ParkinsonVol(20);
+pvol.update(high, low);
+
+// Batch
+const adxResult = ADX.compute(highs, lows, closes, 14);
+adxResult.adx; adxResult.plusDi; adxResult.minusDi;
+
+const skewArr = Skewness.compute(prices, 20);
+```
+
+**Single value** — `update(value)`:
+
+`SMA`, `EMA`, `RMA`, `DEMA`, `TEMA`, `KAMA`, `RSI`, `Slope`, `Skewness`, `Kurtosis`, `RollingZScore`, `ShannonEntropy`
+
+**Multi-output** — named properties instead of `.value`:
+
+`MACD` → `.line`, `.signal`, `.histogram`  
+`Bollinger` → `.upper`, `.middle`, `.lower`
+
+**OHLC / multi-input:**
+
+`ATR`, `CCI`, `CHOP` — `update(high, low, close)`  
+`Stochastic` — `update(high, low, close)` → `.k`, `.d`  
+`ADX` — batch only: `ADX.compute(highs, lows, closes, period)` → `.adx`, `.plusDi`, `.minusDi`  
+`ParkinsonVol` — `update(high, low)`  
+`RogersSatchellVol` — `update(open, high, low, close)`  
+`Correlation` — `update(x, y)`
+
+**Volume:**
+
+`OBV`, `VWAP`, `CVD`
+
+## Indicator catalog
+
+<!-- INDICATOR-LIST-START -->
+
+Every indicator below is **one QuickJS class** with both a batch
+`compute()` method and streaming `update()` / `value` / `ready` / `reset()`.
+Same instance, two ways to use it:
+
+```js
+const flox = require('flox-node');
+const ema = new flox.EMA(10);
+const out = ema.compute(prices);            // batch
+for (const v of stream) {
+  ema.update(v);
+  if (ema.ready) console.log(ema.value);    // streaming on the same instance
+}
+```
+
+| Indicator | Constructor | Kind |
+|---|---|---|
+| `EMA` | `new flox.EMA(period)` | SingleInput |
+| `SMA` | `new flox.SMA(period)` | SingleInput |
+| `RMA` | `new flox.RMA(period)` | SingleInput |
+| `RSI` | `new flox.RSI(period)` | SingleInput |
+| `KAMA` | `new flox.KAMA(period, fast, slow)` | SingleInput |
+| `DEMA` | `new flox.DEMA(period)` | SingleInput |
+| `TEMA` | `new flox.TEMA(period)` | SingleInput |
+| `Slope` | `new flox.Slope(length)` | SingleInput |
+| `Skewness` | `new flox.Skewness(period)` | SingleInput |
+| `Kurtosis` | `new flox.Kurtosis(period)` | SingleInput |
+| `RollingZScore` | `new flox.RollingZScore(period)` | SingleInput |
+| `ShannonEntropy` | `new flox.ShannonEntropy(period, bins)` | SingleInput |
+| `AutoCorrelation` | `new flox.AutoCorrelation(window, lag)` | SingleInput |
+| `ATR` | `new flox.ATR(period)` | BarInput |
+| `CCI` | `new flox.CCI(period)` | BarInput |
+| `Stochastic` | `new flox.Stochastic(k_period, d_period)` | BarInput |
+| `ParkinsonVol` | `new flox.ParkinsonVol(period)` | HighLowInput |
+| `RogersSatchellVol` | `new flox.RogersSatchellVol(period)` | OhlcInput |
+| `Correlation` | `new flox.Correlation(period)` | PairInput |
+| `MACD` | `new flox.MACD(fast, slow, signal)` | MultiOutput |
+| `Bollinger` | `new flox.Bollinger(period, stddev)` | MultiOutput |
+
+
+<!-- INDICATOR-LIST-END -->
+
+------------------------------------------------------------------------------
+# Source: docs/reference/quickjs/tools.md
+# URL: https://flox-foundation.github.io/flox/reference/quickjs/tools/
+------------------------------------------------------------------------------
+
+# Order books, positions, profiles, statistics
+
+---
+
+## Order book
+
+```javascript
+const book = new OrderBook(0.01);  // tick size
+book.applySnapshot([50000, 49999], [1.5, 2.0], [50001, 50002], [0.5, 1.0]);
+book.bestBid();    // 50000
+book.bestAsk();    // 50001
+book.mid();
+book.spread();
+book.getBids(5);   // [[price, qty], ...]
+book.getAsks(5);
+
+// L3 (order-level)
+const l3 = new L3Book();
+l3.addOrder(1, 50000, 1.5, 'buy');
+l3.removeOrder(1);
+l3.bestBid();
+```
+
+---
+
+## Position tracking
+
+```javascript
+const tracker = new PositionTracker();
+tracker.onFill(symbolId, 'buy', 50000, 1.0);
+tracker.onFill(symbolId, 'sell', 50100, 1.0);
+tracker.position(symbolId);        // 0
+tracker.realizedPnl(symbolId);     // 100
+tracker.totalRealizedPnl();
+
+// Group tracking
+const groups = new PositionGroupTracker();
+const pid = groups.openPosition(symbolId, groupId, 'buy', 50000, 1.0);
+groups.closePosition(pid, 50500);
+groups.totalRealizedPnl();
+```
+
+---
+
+## Profiles
+
+```javascript
+// Volume profile
+const vp = new VolumeProfile(0.01);
+vp.addTrade(50000, 1.0, true);
+vp.poc();
+vp.valueAreaHigh();
+vp.valueAreaLow();
+
+// Market profile
+const mp = new MarketProfile(0.01, 30, 0);
+mp.addTrade(Date.now() * 1e6, 50000, 1.0, true);
+mp.poc();
+mp.initialBalanceHigh();
+mp.isPoorHigh();
+
+// Footprint
+const fp = new FootprintBar(0.01);
+fp.addTrade(50000, 1.0, true);
+fp.totalDelta();
+fp.totalVolume();
+```
+
+---
+
+## Statistics
+
+```javascript
+flox.correlation([1, 2, 3], [1, 2, 3]);
+flox.profitFactor([100, -50, 200, -30]);
+flox.winRate([100, -50, 200, -30]);
+flox.bootstrapCI([1, 2, 3, 4, 5], 0.95, 10000);  // { lower, median, upper }
+flox.permutationTest([1, 2, 3], [4, 5, 6], 10000); // p-value
+```
+
+---
+
+## Segment operations
+
+```javascript
+flox.validateSegment('/path/to/segment.flx');
+flox.mergeSegments('/path/to/input_dir', '/path/to/output_dir');
+```
+
+---
+
+## Data reader / writer / recorder
+
+Read trades and book updates from binary log segments, or record live data.
+
+```javascript
+const reader = new DataReader('./data');
+// Filtered reader:
+//   new DataReader({ dir: './data', fromNs, toNs, symbols })
+
+reader.count;            // total events
+reader.summary();        // { firstEventNs, lastEventNs, totalEvents, segmentCount, totalBytes, durationSeconds }
+reader.stats();          // { filesRead, eventsRead, tradesRead, bookUpdatesRead, bytesRead, crcErrors }
+
+const trades = reader.readTrades(maxTrades = 0);   // 0 = all
+const bbos = reader.readBBO(maxEvents = 0);
+const events = reader.readBookUpdates();
+
+// Mid-stream seek: start from a given timestamp
+const tradesFrom = reader.readTradesFrom(startTsNs, maxTrades = 0);
+const bbosFrom = reader.readBBOFrom(startTsNs, maxEvents = 0);
+const eventsFrom = reader.readBookUpdatesFrom(startTsNs);
+
+reader.destroy();
+```
+
+Record shapes:
+
+- **Trade**: `{ exchangeTsNs, recvTsNs, price, qty, tradeId, symbolId, side }`
+- **BBO**: `{ exchangeTsNs, recvTsNs, seq, symbolId, eventType, bidPrice, bidQty, askPrice, askQty }`
+- **Book update**: `{ exchangeTsNs, recvTsNs, seq, symbolId, eventType, bids: [{price, qty}, ...], asks: [{price, qty}, ...] }`
+
+`eventType` is `2` for a snapshot, `3` for a delta.
+
+```javascript
+const writer = new DataWriter('./out', maxSegmentMb, exchangeId);
+writer.writeTrade(exchangeTsNs, recvTsNs, price, qty, tradeId, symbolId, side);
+writer.flush();
+writer.close();
+writer.stats();          // { bytesWritten, eventsWritten, segmentsCreated, tradesWritten }
+
+const recorder = new DataRecorder('./out', exchangeName, maxSegmentMb);
+recorder.addSymbol(symbolId, name, base, quote, pricePrecision, qtyPrecision);
+recorder.start();
+// feed live data...
+recorder.stop();
+```
+
+------------------------------------------------------------------------------
+# Source: docs/reference/quickjs/backtest.md
+# URL: https://flox-foundation.github.io/flox/reference/quickjs/backtest/
+------------------------------------------------------------------------------
+
+# Backtest & runtime
+
+---
+
+## Simulated executor
+
+```javascript
+const executor = new SimulatedExecutor();
+executor.submitOrder(id, 'buy', 50000, 1.0, 0, symbolId);
+executor.onBar(symbolId, 50100);
+executor.advanceClock(tsNs);
+executor.fillCount;
+```
+
+---
+
+## Runtime limits
+
+The JS runtime defaults to 32 MB. To change it when embedding via C++:
+
+```cpp
+FloxJsEngine engine(64 * 1024 * 1024);  // 64 MB
+FloxJsEngine engine(0);                  // no limit
+```
+
+---
+
+## IDE support
+
+Copy `quickjs/types/flox.d.ts` and `quickjs/jsconfig.json` into your project directory for VS Code autocomplete.
+
+==============================================================================
+# Section: Reference: C API
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/reference/api/capi/flox_capi.md
+# URL: https://flox-foundation.github.io/flox/reference/api/capi/flox_capi/
+------------------------------------------------------------------------------
+
+# C API reference
+
+```c
+#include "flox/capi/flox_capi.h"
+```
+
+All language bindings (Python, Node.js, Codon, embedded JS) call into this header. You can use it directly to integrate Flox into any language with a C FFI, or embed it in a C/C++ project.
+
+---
+
+## Opaque handles
+
+```c
+typedef void* FloxRegistryHandle;
+typedef void* FloxStrategyHandle;
+typedef void* FloxRunnerHandle;
+typedef void* FloxLiveEngineHandle;
+typedef void* FloxBacktestRunnerHandle;
+typedef void* FloxBacktestResultHandle;
+typedef void* FloxExecutorHandle;
+typedef void* FloxBookHandle;
+typedef void* FloxL3BookHandle;
+typedef void* FloxCompositeBookHandle;
+typedef void* FloxPositionTrackerHandle;
+typedef void* FloxPositionGroupHandle;
+typedef void* FloxOrderTrackerHandle;
+typedef void* FloxVolumeProfileHandle;
+typedef void* FloxMarketProfileHandle;
+typedef void* FloxFootprintHandle;
+typedef void* FloxDataWriterHandle;
+typedef void* FloxDataReaderHandle;
+typedef void* FloxDataRecorderHandle;
+typedef void* FloxPartitionerHandle;
+```
+
+---
+
+## Structs
+
+### `FloxTradeData`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `symbol` | `uint32_t` | Symbol ID |
+| `price_raw` | `int64_t` | Price × 1e8 |
+| `quantity_raw` | `int64_t` | Quantity × 1e8 |
+| `is_buy` | `uint8_t` | 1 = buy, 0 = sell |
+| `exchange_ts_ns` | `int64_t` | Exchange timestamp (ns) |
+
+### `FloxBookLevel`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `price_raw` | `int64_t` | Price × 1e8 |
+| `quantity_raw` | `int64_t` | Quantity × 1e8 |
+
+### `FloxBookSnapshot`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bid_price_raw` | `int64_t` | Best bid price × 1e8 (0 if absent) |
+| `bid_qty_raw` | `int64_t` | Best bid quantity × 1e8 |
+| `ask_price_raw` | `int64_t` | Best ask price × 1e8 (0 if absent) |
+| `ask_qty_raw` | `int64_t` | Best ask quantity × 1e8 |
+| `mid_raw` | `int64_t` | Mid price × 1e8 (0 if absent) |
+| `spread_raw` | `int64_t` | Spread × 1e8 (0 if absent) |
+
+### `FloxBookData`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `symbol` | `uint32_t` | Symbol ID |
+| `exchange_ts_ns` | `int64_t` | Exchange timestamp (ns) |
+| `snapshot` | `FloxBookSnapshot` | Top-of-book snapshot |
+
+### `FloxSymbolContext`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `symbol_id` | `uint32_t` | Symbol ID |
+| `position_raw` | `int64_t` | Position × 1e8 |
+| `avg_entry_price_raw` | `int64_t` | Average entry price × 1e8 |
+| `last_trade_price_raw` | `int64_t` | Last trade price × 1e8 |
+| `last_update_ns` | `int64_t` | Last update timestamp (ns) |
+| `book` | `FloxBookSnapshot` | Top-of-book snapshot |
+
+### `FloxStrategyCallbacks`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `on_trade` | `FloxOnTradeCallback` | Trade event callback |
+| `on_book` | `FloxOnBookCallback` | Book update callback |
+| `on_bar` | `FloxOnBarCallback` | Closed OHLC bar callback (`FloxBarData`) |
+| `on_start` | `FloxOnStartCallback` | Strategy start callback |
+| `on_stop` | `FloxOnStopCallback` | Strategy stop callback |
+| `user_data` | `void*` | Passed to all callbacks |
+
+### `FloxSignal`
+
+Emitted by strategies, received by the order backend.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `order_id` | `uint64_t` | Order ID |
+| `symbol` | `uint32_t` | Symbol ID |
+| `side` | `uint8_t` | 0 = buy, 1 = sell |
+| `order_type` | `uint8_t` | 0=market, 1=limit, 2=stop_market, 3=stop_limit, 4=tp_market, 5=tp_limit, 6=trailing_stop, 7=cancel, 8=cancel_all, 9=modify |
+| `price` | `double` | Limit price (0 for market orders) |
+| `quantity` | `double` | Order quantity |
+| `trigger_price` | `double` | Stop/take-profit trigger |
+| `trailing_offset` | `double` | Trailing stop absolute offset |
+| `trailing_bps` | `int32_t` | Trailing stop callback rate (basis points) |
+| `new_price` | `double` | Modify: updated price |
+| `new_quantity` | `double` | Modify: updated quantity |
+
+### `FloxBar`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `start_time_ns` | `int64_t` | Bar open time (ns) |
+| `end_time_ns` | `int64_t` | Bar close time (ns) |
+| `open_raw` | `int64_t` | Open × 1e8 |
+| `high_raw` | `int64_t` | High × 1e8 |
+| `low_raw` | `int64_t` | Low × 1e8 |
+| `close_raw` | `int64_t` | Close × 1e8 |
+| `volume_raw` | `int64_t` | Volume × 1e8 |
+| `buy_volume_raw` | `int64_t` | Buy-side volume × 1e8 |
+| `trade_count` | `uint32_t` | Number of trades |
+
+### `FloxFill`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `order_id` | `uint64_t` | Order ID |
+| `symbol` | `uint32_t` | Symbol ID |
+| `side` | `uint8_t` | 0 = buy, 1 = sell |
+| `price_raw` | `int64_t` | Fill price × 1e8 |
+| `quantity_raw` | `int64_t` | Fill quantity × 1e8 |
+| `timestamp_ns` | `int64_t` | Fill timestamp (ns) |
+
+### `FloxBacktestStats`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalTrades` | `uint64_t` | Round-trip trade count |
+| `winningTrades` | `uint64_t` | Winning trades |
+| `losingTrades` | `uint64_t` | Losing trades |
+| `maxConsecutiveWins` | `uint64_t` | Max consecutive wins |
+| `maxConsecutiveLosses` | `uint64_t` | Max consecutive losses |
+| `initialCapital` | `double` | Starting capital |
+| `finalCapital` | `double` | Ending capital |
+| `totalPnl` | `double` | Gross PnL |
+| `totalFees` | `double` | Total fees paid |
+| `netPnl` | `double` | Net PnL after fees |
+| `grossProfit` | `double` | Sum of winning trades |
+| `grossLoss` | `double` | Sum of losing trades |
+| `maxDrawdown` | `double` | Max drawdown (absolute) |
+| `maxDrawdownPct` | `double` | Max drawdown (%) |
+| `winRate` | `double` | Winning trade ratio |
+| `profitFactor` | `double` | Gross profit / gross loss |
+| `avgWin` | `double` | Average winning trade |
+| `avgLoss` | `double` | Average losing trade |
+| `avgWinLossRatio` | `double` | avgWin / avgLoss |
+| `avgTradeDurationNs` | `double` | Average trade duration (ns) |
+| `medianTradeDurationNs` | `double` | Median trade duration (ns) |
+| `maxTradeDurationNs` | `double` | Longest trade (ns) |
+| `sharpeRatio` | `double` | Annualized Sharpe ratio |
+| `sortinoRatio` | `double` | Sortino ratio |
+| `calmarRatio` | `double` | Calmar ratio |
+| `timeWeightedReturn` | `double` | Time-weighted return |
+| `returnPct` | `double` | Net return (%) |
+| `startTimeNs` | `int64_t` | Backtest start timestamp (ns) |
+| `endTimeNs` | `int64_t` | Backtest end timestamp (ns) |
+
+### `FloxEquityPoint`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp_ns` | `int64_t` | Timestamp (ns) |
+| `equity` | `double` | Equity at this point |
+| `drawdown_pct` | `double` | Drawdown (%) at this point |
+
+---
+
+## Callback types
+
+```c
+typedef void (*FloxOnTradeCallback)(void* user_data, const FloxSymbolContext* ctx,
+                                    const FloxTradeData* trade);
+typedef void (*FloxOnBookCallback)(void* user_data, const FloxSymbolContext* ctx,
+                                   const FloxBookData* book);
+typedef void (*FloxOnStartCallback)(void* user_data);
+typedef void (*FloxOnStopCallback)(void* user_data);
+typedef void (*FloxOnSignalCallback)(void* user_data, const FloxSignal* signal);
+```
+
+---
+
+## Symbol registry
+
+```c
+FloxRegistryHandle flox_registry_create(void);
+void               flox_registry_destroy(FloxRegistryHandle registry);
+
+uint32_t flox_registry_add_symbol(FloxRegistryHandle registry,
+                                  const char* exchange, const char* name,
+                                  double tick_size);
+
+uint8_t  flox_registry_get_symbol_id(FloxRegistryHandle registry,
+                                     const char* exchange, const char* name,
+                                     uint32_t* id_out);
+uint8_t  flox_registry_get_symbol_name(FloxRegistryHandle registry,
+                                       uint32_t symbol_id,
+                                       char* exchange_out, size_t exchange_len,
+                                       char* name_out, size_t name_len);
+uint32_t flox_registry_symbol_count(FloxRegistryHandle registry);
+```
+
+---
+
+## Strategy
+
+```c
+FloxStrategyHandle flox_strategy_create(uint32_t id,
+                                        const uint32_t* symbols, uint32_t num_symbols,
+                                        FloxRegistryHandle registry,
+                                        FloxStrategyCallbacks callbacks);
+void flox_strategy_destroy(FloxStrategyHandle strategy);
+```
+
+---
+
+## StrategyRunner
+
+Synchronous strategy host. Strategy callbacks fire in the caller's thread before the push call returns.
+
+```c
+FloxRunnerHandle flox_runner_create(FloxRegistryHandle registry,
+                                    FloxOnSignalCallback on_signal,
+                                    void* user_data);
+void flox_runner_destroy(FloxRunnerHandle runner);
+
+void flox_runner_add_strategy(FloxRunnerHandle runner, FloxStrategyHandle strategy);
+void flox_runner_start(FloxRunnerHandle runner);
+void flox_runner_stop(FloxRunnerHandle runner);
+
+void flox_runner_on_trade(FloxRunnerHandle runner, uint32_t symbol,
+                          double price, double qty, uint8_t is_buy,
+                          int64_t exchange_ts_ns);
+void flox_runner_on_book_snapshot(FloxRunnerHandle runner, uint32_t symbol,
+                                  const double* bid_prices, const double* bid_qtys,
+                                  uint32_t n_bids,
+                                  const double* ask_prices, const double* ask_qtys,
+                                  uint32_t n_asks, int64_t exchange_ts_ns);
+```
+
+---
+
+## LiveEngine
+
+Disruptor-based live trading engine. Each strategy runs in its own consumer thread. Publish calls are lock-free and return immediately.
+
+```c
+FloxLiveEngineHandle flox_live_engine_create(FloxRegistryHandle registry);
+void                 flox_live_engine_destroy(FloxLiveEngineHandle engine);
+
+void flox_live_engine_add_strategy(FloxLiveEngineHandle engine,
+                                   FloxStrategyHandle strategy,
+                                   FloxOnSignalCallback on_signal,
+                                   void* user_data);
+
+void flox_live_engine_start(FloxLiveEngineHandle engine);
+void flox_live_engine_stop(FloxLiveEngineHandle engine);
+
+void flox_live_engine_publish_trade(FloxLiveEngineHandle engine,
+                                    uint32_t symbol,
+                                    double price, double qty, uint8_t is_buy,
+                                    int64_t exchange_ts_ns);
+void flox_live_engine_publish_book_snapshot(FloxLiveEngineHandle engine,
+                                            uint32_t symbol,
+                                            const double* bid_prices,
+                                            const double* bid_qtys, uint32_t n_bids,
+                                            const double* ask_prices,
+                                            const double* ask_qtys, uint32_t n_asks,
+                                            int64_t exchange_ts_ns);
+```
+
+---
+
+## BacktestRunner
+
+Replays OHLCV data through a strategy and returns statistics.
+
+```c
+FloxBacktestRunnerHandle flox_backtest_runner_create(FloxRegistryHandle registry,
+                                                     double fee_rate,
+                                                     double initial_capital);
+void flox_backtest_runner_destroy(FloxBacktestRunnerHandle runner);
+
+void flox_backtest_runner_set_strategy(FloxBacktestRunnerHandle runner,
+                                       FloxStrategyHandle strategy);
+
+// Replay a CSV file (columns: timestamp, open, high, low, close, volume).
+// Returns 1 on success, 0 on error.
+int flox_backtest_runner_run_csv(FloxBacktestRunnerHandle runner,
+                                 const char* path, const char* symbol,
+                                 FloxBacktestStats* stats_out);
+
+// Replay raw OHLCV arrays (timestamps in nanoseconds).
+// Returns 1 on success, 0 on error.
+int flox_backtest_runner_run_ohlcv(FloxBacktestRunnerHandle runner,
+                                   const int64_t* timestamps_ns,
+                                   const double* close_prices, uint32_t n,
+                                   const char* symbol,
+                                   FloxBacktestStats* stats_out);
+```
+
+---
+
+## Signal emission
+
+All return `OrderId` (`uint64_t`), 0 on failure. `cancel` and `modify` return void.
+
+| Function | Description |
+|----------|-------------|
+| `flox_emit_market_buy(s, sym, qty_raw)` | Market buy |
+| `flox_emit_market_sell(s, sym, qty_raw)` | Market sell |
+| `flox_emit_limit_buy(s, sym, px_raw, qty_raw)` | Limit buy |
+| `flox_emit_limit_sell(s, sym, px_raw, qty_raw)` | Limit sell |
+| `flox_emit_limit_buy_tif(s, sym, px_raw, qty_raw, tif)` | Limit buy with time-in-force |
+| `flox_emit_limit_sell_tif(s, sym, px_raw, qty_raw, tif)` | Limit sell with time-in-force |
+| `flox_emit_stop_market(s, sym, side, trigger_raw, qty_raw)` | Stop market |
+| `flox_emit_stop_limit(s, sym, side, trigger_raw, limit_raw, qty_raw)` | Stop limit |
+| `flox_emit_take_profit_market(s, sym, side, trigger_raw, qty_raw)` | Take-profit market |
+| `flox_emit_take_profit_limit(s, sym, side, trigger_raw, limit_raw, qty_raw)` | Take-profit limit |
+| `flox_emit_trailing_stop(s, sym, side, offset_raw, qty_raw)` | Trailing stop (absolute) |
+| `flox_emit_trailing_stop_percent(s, sym, side, bps, qty_raw)` | Trailing stop (basis points) |
+| `flox_emit_close_position(s, sym)` | Close position (reduce-only) |
+| `flox_emit_cancel(s, order_id)` | Cancel order |
+| `flox_emit_cancel_all(s, sym)` | Cancel all orders for symbol |
+| `flox_emit_modify(s, order_id, new_price_raw, new_qty_raw)` | Modify order |
+
+---
+
+## Context queries
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `flox_position_raw(s, sym)` | `int64_t` | Position × 1e8 |
+| `flox_last_trade_price_raw(s, sym)` | `int64_t` | Last trade price × 1e8 |
+| `flox_best_bid_raw(s, sym)` | `int64_t` | Best bid × 1e8 |
+| `flox_best_ask_raw(s, sym)` | `int64_t` | Best ask × 1e8 |
+| `flox_mid_price_raw(s, sym)` | `int64_t` | Mid price × 1e8 |
+| `flox_get_symbol_context(s, sym, out)` | `void` | Fill `FloxSymbolContext` |
+| `flox_get_order_status(s, order_id)` | `int32_t` | Order status (-1 = not found) |
+
+---
+
+## Simulated executor
+
+Used in backtesting to fill orders from simulated market data.
+
+```c
+FloxExecutorHandle flox_executor_create(void);
+void               flox_executor_destroy(FloxExecutorHandle executor);
+
+void flox_executor_submit_order(FloxExecutorHandle executor,
+                                uint64_t id, uint8_t side, double price,
+                                double quantity, uint8_t order_type, uint32_t symbol);
+void flox_executor_cancel_order(FloxExecutorHandle executor, uint64_t order_id);
+void flox_executor_cancel_all(FloxExecutorHandle executor, uint32_t symbol);
+
+// Feed market data
+void flox_executor_on_bar(FloxExecutorHandle executor, uint32_t symbol, double close_price);
+void flox_executor_on_trade(FloxExecutorHandle executor, uint32_t symbol,
+                            double price, uint8_t is_buy);
+void flox_executor_on_trade_qty(FloxExecutorHandle executor, uint32_t symbol,
+                                double price, double quantity, uint8_t is_buy);
+void flox_executor_on_best_levels(FloxExecutorHandle executor, uint32_t symbol,
+                                  double bid_price, double bid_qty,
+                                  double ask_price, double ask_qty);
+void flox_executor_on_book_snapshot(FloxExecutorHandle executor, uint32_t symbol,
+                                    const double* bid_prices, const double* bid_qtys,
+                                    uint32_t n_bids,
+                                    const double* ask_prices, const double* ask_qtys,
+                                    uint32_t n_asks);
+void flox_executor_advance_clock(FloxExecutorHandle executor, int64_t timestamp_ns);
+
+// Fills
+uint32_t flox_executor_fill_count(FloxExecutorHandle executor);
+uint32_t flox_executor_get_fills(FloxExecutorHandle executor,
+                                 FloxFill* fills_out, uint32_t max_fills);
+```
+
+### Slippage configuration
+
+```c
+typedef enum {
+    FLOX_SLIPPAGE_NONE         = 0,
+    FLOX_SLIPPAGE_FIXED_TICKS  = 1,
+    FLOX_SLIPPAGE_FIXED_BPS    = 2,
+    FLOX_SLIPPAGE_VOLUME_IMPACT = 3
+} FloxSlippageModel;
+
+void flox_executor_set_default_slippage(FloxExecutorHandle executor,
+                                        int32_t model, int32_t ticks,
+                                        double tick_size, double bps,
+                                        double impact_coeff);
+void flox_executor_set_symbol_slippage(FloxExecutorHandle executor, uint32_t symbol,
+                                       int32_t model, int32_t ticks,
+                                       double tick_size, double bps,
+                                       double impact_coeff);
+```
+
+### Queue simulation
+
+```c
+typedef enum {
+    FLOX_QUEUE_NONE = 0,
+    FLOX_QUEUE_TOB  = 1,
+    FLOX_QUEUE_FULL = 2
+} FloxQueueModel;
+
+void flox_executor_set_queue_model(FloxExecutorHandle executor,
+                                   int32_t model, uint32_t depth);
+```
+
+---
+
+## BacktestResult
+
+Aggregates fills into trades, statistics, and equity curve.
+
+```c
+FloxBacktestResultHandle flox_backtest_result_create(double initial_capital,
+                                                     double fee_rate,
+                                                     uint8_t use_percentage_fee,
+                                                     double fixed_fee_per_trade,
+                                                     double risk_free_rate,
+                                                     double annualization_factor);
+void flox_backtest_result_destroy(FloxBacktestResultHandle result);
+
+void flox_backtest_result_record_fill(FloxBacktestResultHandle result,
+                                      uint64_t order_id, uint32_t symbol, uint8_t side,
+                                      double price, double quantity, int64_t timestamp_ns);
+void flox_backtest_result_ingest_executor(FloxBacktestResultHandle result,
+                                          FloxExecutorHandle executor);
+
+void     flox_backtest_result_stats(FloxBacktestResultHandle result, FloxBacktestStats* out);
+uint32_t flox_backtest_result_equity_curve(FloxBacktestResultHandle result,
+                                           FloxEquityPoint* points_out, uint32_t max_points);
+uint8_t  flox_backtest_result_write_equity_curve_csv(FloxBacktestResultHandle result,
+                                                     const char* path);
+```
+
+---
+
+## Indicators
+
+Stateless, array-in / array-out.
+
+| Function | Description |
+|----------|-------------|
+| `flox_indicator_ema(input, len, period, output)` | EMA |
+| `flox_indicator_sma(input, len, period, output)` | SMA |
+| `flox_indicator_rsi(input, len, period, output)` | RSI |
+| `flox_indicator_rma(input, len, period, output)` | Wilder's moving average |
+| `flox_indicator_dema(input, len, period, output)` | Double EMA |
+| `flox_indicator_tema(input, len, period, output)` | Triple EMA |
+| `flox_indicator_kama(input, len, period, fast, slow, output)` | Kaufman adaptive MA |
+| `flox_indicator_slope(input, len, length, output)` | Linear slope |
+| `flox_indicator_atr(high, low, close, len, period, output)` | ATR |
+| `flox_indicator_adx(high, low, close, len, period, adx, +di, -di)` | ADX |
+| `flox_indicator_macd(input, len, fast, slow, signal, macd, signal, hist)` | MACD |
+| `flox_indicator_bollinger(input, len, period, mult, upper, middle, lower)` | Bollinger Bands |
+| `flox_indicator_cci(high, low, close, len, period, output)` | CCI |
+| `flox_indicator_stochastic(high, low, close, len, k, d, k_out, d_out)` | Stochastic |
+| `flox_indicator_chop(high, low, close, len, period, output)` | Choppiness |
+| `flox_indicator_obv(close, volume, len, output)` | On-balance volume |
+| `flox_indicator_vwap(close, volume, len, window, output)` | Rolling VWAP |
+| `flox_indicator_cvd(open, high, low, close, volume, len, output)` | Cumulative volume delta |
+
+---
+
+## Bar aggregation
+
+All functions return the number of bars written.
+
+| Function | Description |
+|----------|-------------|
+| `flox_aggregate_time_bars(..., interval_seconds, bars_out, max)` | Time bars |
+| `flox_aggregate_tick_bars(..., tick_count, bars_out, max)` | Tick bars |
+| `flox_aggregate_volume_bars(..., volume_threshold, bars_out, max)` | Volume bars |
+| `flox_aggregate_range_bars(..., range_size, bars_out, max)` | Range bars |
+| `flox_aggregate_renko_bars(..., brick_size, bars_out, max)` | Renko bars |
+| `flox_aggregate_heikin_ashi_bars(..., interval_seconds, bars_out, max)` | Heikin-Ashi |
+
+All take the same input signature: `(timestamps, prices, quantities, is_buy, len, ...)`.
+
+---
+
+## L2 Order book
+
+```c
+FloxBookHandle flox_book_create(double tick_size);
+void           flox_book_destroy(FloxBookHandle book);
+
+void    flox_book_apply_snapshot(FloxBookHandle book,
+                                 const double* bid_prices, const double* bid_qtys, size_t bid_len,
+                                 const double* ask_prices, const double* ask_qtys, size_t ask_len);
+void    flox_book_apply_delta(FloxBookHandle book,
+                              const double* bid_prices, const double* bid_qtys, size_t bid_len,
+                              const double* ask_prices, const double* ask_qtys, size_t ask_len);
+
+uint8_t flox_book_best_bid(FloxBookHandle book, double* price_out);
+uint8_t flox_book_best_ask(FloxBookHandle book, double* price_out);
+uint8_t flox_book_mid(FloxBookHandle book, double* price_out);
+uint8_t flox_book_spread(FloxBookHandle book, double* spread_out);
+double  flox_book_bid_at_price(FloxBookHandle book, double price);
+double  flox_book_ask_at_price(FloxBookHandle book, double price);
+uint8_t flox_book_is_crossed(FloxBookHandle book);
+void    flox_book_clear(FloxBookHandle book);
+
+uint32_t flox_book_get_bids(FloxBookHandle book, double* prices_out,
+                            double* qtys_out, uint32_t max_levels);
+uint32_t flox_book_get_asks(FloxBookHandle book, double* prices_out,
+                            double* qtys_out, uint32_t max_levels);
+```
+
+---
+
+## L3 Order book
+
+```c
+FloxL3BookHandle flox_l3_book_create(void);
+void             flox_l3_book_destroy(FloxL3BookHandle book);
+
+int32_t flox_l3_book_add_order(FloxL3BookHandle book,
+                               uint64_t order_id, double price,
+                               double quantity, uint8_t side);
+int32_t flox_l3_book_remove_order(FloxL3BookHandle book, uint64_t order_id);
+int32_t flox_l3_book_modify_order(FloxL3BookHandle book,
+                                  uint64_t order_id, double new_qty);
+
+uint8_t flox_l3_book_best_bid(FloxL3BookHandle book, double* price_out);
+uint8_t flox_l3_book_best_ask(FloxL3BookHandle book, double* price_out);
+double  flox_l3_book_bid_at_price(FloxL3BookHandle book, double price);
+double  flox_l3_book_ask_at_price(FloxL3BookHandle book, double price);
+```
+
+---
+
+## Composite book
+
+Aggregates books across multiple exchanges per symbol.
+
+```c
+FloxCompositeBookHandle flox_composite_book_create(void);
+void                    flox_composite_book_destroy(FloxCompositeBookHandle book);
+
+uint8_t flox_composite_book_best_bid(FloxCompositeBookHandle book, uint32_t symbol,
+                                     double* price_out, double* qty_out);
+uint8_t flox_composite_book_best_ask(FloxCompositeBookHandle book, uint32_t symbol,
+                                     double* price_out, double* qty_out);
+uint8_t flox_composite_book_has_arb(FloxCompositeBookHandle book, uint32_t symbol);
+void    flox_composite_book_mark_stale(FloxCompositeBookHandle book,
+                                       uint32_t exchange, uint32_t symbol);
+void    flox_composite_book_check_staleness(FloxCompositeBookHandle book,
+                                            int64_t now_ns, int64_t threshold_ns);
+```
+
+---
+
+## Position tracker
+
+FIFO/average cost position tracking.
+
+```c
+FloxPositionTrackerHandle flox_position_tracker_create(uint8_t cost_basis); // 0 = FIFO
+void                      flox_position_tracker_destroy(FloxPositionTrackerHandle tracker);
+
+void   flox_position_tracker_on_fill(FloxPositionTrackerHandle tracker,
+                                     uint32_t symbol, uint8_t side,
+                                     double price, double quantity);
+double flox_position_tracker_position(FloxPositionTrackerHandle tracker, uint32_t symbol);
+double flox_position_tracker_avg_entry(FloxPositionTrackerHandle tracker, uint32_t symbol);
+double flox_position_tracker_realized_pnl(FloxPositionTrackerHandle tracker, uint32_t symbol);
+double flox_position_tracker_total_pnl(FloxPositionTrackerHandle tracker);
+```
+
+---
+
+## Position group
+
+Tracks individual named positions (open/partial-close/close).
+
+```c
+FloxPositionGroupHandle flox_position_group_create(void);
+void                    flox_position_group_destroy(FloxPositionGroupHandle tracker);
+
+uint64_t flox_position_group_open(FloxPositionGroupHandle tracker,
+                                  uint64_t order_id, uint32_t symbol,
+                                  uint8_t side, double price, double qty);
+void     flox_position_group_close(FloxPositionGroupHandle tracker,
+                                   uint64_t position_id, double exit_price);
+void     flox_position_group_partial_close(FloxPositionGroupHandle tracker,
+                                           uint64_t position_id,
+                                           double qty, double exit_price);
+
+double   flox_position_group_net_position(FloxPositionGroupHandle tracker, uint32_t symbol);
+double   flox_position_group_realized_pnl(FloxPositionGroupHandle tracker, uint32_t symbol);
+double   flox_position_group_total_pnl(FloxPositionGroupHandle tracker);
+uint32_t flox_position_group_open_count(FloxPositionGroupHandle tracker, uint32_t symbol);
+void     flox_position_group_prune(FloxPositionGroupHandle tracker);
+```
+
+---
+
+## Order tracker
+
+Tracks submitted/filled/canceled orders.
+
+```c
+FloxOrderTrackerHandle flox_order_tracker_create(void);
+void                   flox_order_tracker_destroy(FloxOrderTrackerHandle tracker);
+
+uint8_t  flox_order_tracker_on_submitted(FloxOrderTrackerHandle tracker,
+                                         uint64_t order_id, uint32_t symbol,
+                                         uint8_t side, double price, double qty);
+uint8_t  flox_order_tracker_on_filled(FloxOrderTrackerHandle tracker,
+                                      uint64_t order_id, double fill_qty);
+uint8_t  flox_order_tracker_on_canceled(FloxOrderTrackerHandle tracker, uint64_t order_id);
+uint8_t  flox_order_tracker_is_active(FloxOrderTrackerHandle tracker, uint64_t order_id);
+uint32_t flox_order_tracker_active_count(FloxOrderTrackerHandle tracker);
+uint32_t flox_order_tracker_total_count(FloxOrderTrackerHandle tracker);
+void     flox_order_tracker_prune(FloxOrderTrackerHandle tracker);
+```
+
+---
+
+## Volume profile
+
+```c
+FloxVolumeProfileHandle flox_volume_profile_create(double tick_size);
+void                    flox_volume_profile_destroy(FloxVolumeProfileHandle profile);
+
+void     flox_volume_profile_add_trade(FloxVolumeProfileHandle profile,
+                                       double price, double quantity, uint8_t is_buy);
+double   flox_volume_profile_poc(FloxVolumeProfileHandle profile);
+double   flox_volume_profile_vah(FloxVolumeProfileHandle profile);
+double   flox_volume_profile_val(FloxVolumeProfileHandle profile);
+double   flox_volume_profile_total_volume(FloxVolumeProfileHandle profile);
+double   flox_volume_profile_total_delta(FloxVolumeProfileHandle profile);
+uint32_t flox_volume_profile_num_levels(FloxVolumeProfileHandle profile);
+void     flox_volume_profile_clear(FloxVolumeProfileHandle profile);
+```
+
+---
+
+## Market profile
+
+Tracks TPO-style market profile with initial balance.
+
+```c
+FloxMarketProfileHandle flox_market_profile_create(double tick_size,
+                                                   uint32_t period_minutes,
+                                                   int64_t session_start_ns);
+void flox_market_profile_destroy(FloxMarketProfileHandle profile);
+
+void     flox_market_profile_add_trade(FloxMarketProfileHandle profile,
+                                       int64_t timestamp_ns, double price,
+                                       double qty, uint8_t is_buy);
+double   flox_market_profile_poc(FloxMarketProfileHandle profile);
+double   flox_market_profile_vah(FloxMarketProfileHandle profile);
+double   flox_market_profile_val(FloxMarketProfileHandle profile);
+double   flox_market_profile_ib_high(FloxMarketProfileHandle profile);
+double   flox_market_profile_ib_low(FloxMarketProfileHandle profile);
+uint8_t  flox_market_profile_is_poor_high(FloxMarketProfileHandle profile);
+uint8_t  flox_market_profile_is_poor_low(FloxMarketProfileHandle profile);
+uint32_t flox_market_profile_num_levels(FloxMarketProfileHandle profile);
+void     flox_market_profile_clear(FloxMarketProfileHandle profile);
+```
+
+---
+
+## Footprint
+
+Per-price buy/sell delta at bar resolution.
+
+```c
+FloxFootprintHandle flox_footprint_create(double tick_size);
+void                flox_footprint_destroy(FloxFootprintHandle footprint);
+
+void     flox_footprint_add_trade(FloxFootprintHandle footprint,
+                                  double price, double quantity, uint8_t is_buy);
+double   flox_footprint_total_delta(FloxFootprintHandle footprint);
+double   flox_footprint_total_volume(FloxFootprintHandle footprint);
+uint32_t flox_footprint_num_levels(FloxFootprintHandle footprint);
+void     flox_footprint_clear(FloxFootprintHandle footprint);
+```
+
+---
+
+## Statistics
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `flox_stat_correlation(x, y, len)` | `double` | Pearson correlation |
+| `flox_stat_profit_factor(pnl, len)` | `double` | Gross profit / gross loss |
+| `flox_stat_win_rate(pnl, len)` | `double` | Winning trade ratio |
+| `flox_stat_permutation_test(g1, l1, g2, l2, n)` | `double` | Two-sample permutation p-value |
+| `flox_stat_bootstrap_ci(data, len, conf, n, &lo, &med, &hi)` | `void` | Bootstrap confidence interval |
+
+---
+
+## Data writer
+
+Writes trades to binary log segments.
+
+```c
+FloxDataWriterHandle flox_data_writer_create(const char* output_dir,
+                                             uint64_t max_segment_mb,
+                                             uint8_t exchange_id);
+void flox_data_writer_destroy(FloxDataWriterHandle writer);
+
+uint8_t flox_data_writer_write_trade(FloxDataWriterHandle writer,
+                                     int64_t exchange_ts_ns, int64_t recv_ts_ns,
+                                     double price, double qty,
+                                     uint64_t trade_id, uint32_t symbol_id, uint8_t side);
+void flox_data_writer_flush(FloxDataWriterHandle writer);
+void flox_data_writer_close(FloxDataWriterHandle writer);
+void flox_data_writer_stats_p(FloxDataWriterHandle writer, void* out); // → FloxWriterStats
+```
+
+---
+
+## Data reader
+
+Reads binary log segments.
+
+```c
+FloxDataReaderHandle flox_data_reader_create(const char* data_dir);
+FloxDataReaderHandle flox_data_reader_create_filtered(const char* data_dir,
+                                                       int64_t from_ns, int64_t to_ns,
+                                                       const uint32_t* symbols,
+                                                       uint32_t num_symbols);
+void flox_data_reader_destroy(FloxDataReaderHandle reader);
+
+uint64_t flox_data_reader_count(FloxDataReaderHandle reader);
+void     flox_data_reader_summary_p(FloxDataReaderHandle reader, void* out); // → FloxDatasetSummary
+void     flox_data_reader_stats_p(FloxDataReaderHandle reader, void* out);   // → FloxReaderStats
+
+// Returns number of trades read. If trades_out is NULL, counts only.
+uint64_t flox_data_reader_read_trades(FloxDataReaderHandle reader,
+                                      FloxTradeRecord* trades_out, uint64_t max_trades);
+
+// Top-of-book per book update event. If bbos_out is NULL, counts only.
+uint64_t flox_data_reader_read_bbo(FloxDataReaderHandle reader,
+                                   FloxBBO* bbos_out, uint64_t max_events);
+
+// Counts events and total levels in one pass. *total_levels_out may be NULL.
+uint64_t flox_data_reader_count_book_updates(FloxDataReaderHandle reader,
+                                             uint64_t* total_levels_out);
+
+// Reads book updates into pre-sized headers and a single flat levels array.
+// Caller sizes both via flox_data_reader_count_book_updates() first.
+// Each header carries level_offset, bid_count, ask_count for slicing the
+// levels array. Bids are written before asks for each event.
+uint64_t flox_data_reader_read_book_updates(FloxDataReaderHandle reader,
+                                            FloxBookUpdateHeader* headers_out,
+                                            uint64_t max_events,
+                                            FloxLevel* levels_out,
+                                            uint64_t max_levels);
+```
+
+`FloxTradeRecord` fields: `exchange_ts_ns`, `recv_ts_ns`, `price_raw`, `qty_raw`, `trade_id`, `symbol_id`, `side`.
+
+`FloxBBO` fields (size: 64 B): `exchange_ts_ns`, `recv_ts_ns`, `seq`, `bid_price_raw`, `bid_qty_raw`, `ask_price_raw`, `ask_qty_raw`, `symbol_id`, `event_type` (2=snapshot, 3=delta).
+
+`FloxBookUpdateHeader` fields (size: 48 B): `exchange_ts_ns`, `recv_ts_ns`, `seq`, `level_offset`, `symbol_id`, `bid_count`, `ask_count`, `event_type`.
+
+`FloxLevel` fields (size: 24 B): `price_raw`, `qty_raw`, `side` (0=bid, 1=ask).
+
+Layout sizes are pinned with `static_assert`; language bindings (Codon, QuickJS) parse these structs from raw byte buffers and depend on exact offsets.
+
+Live segments are safe to read while a writer is still appending. Compressed segments whose header has not yet been finalized (`event_count == 0`) are recovered by walking block headers and decompressing the first / last viable block; the very last block is often truncated, so the scan iterates backwards until one decompresses successfully. The same recovery is used by `summary()` / `inspect()`.
+
+---
+
+## Data recorder
+
+Records live market data to disk.
+
+```c
+FloxDataRecorderHandle flox_data_recorder_create(const char* output_dir,
+                                                  const char* exchange_name,
+                                                  uint64_t max_segment_mb);
+void flox_data_recorder_destroy(FloxDataRecorderHandle recorder);
+
+void    flox_data_recorder_add_symbol(FloxDataRecorderHandle recorder,
+                                      uint32_t symbol_id, const char* name,
+                                      const char* base, const char* quote,
+                                      int8_t price_precision, int8_t qty_precision);
+void    flox_data_recorder_start(FloxDataRecorderHandle recorder);
+void    flox_data_recorder_stop(FloxDataRecorderHandle recorder);
+void    flox_data_recorder_flush(FloxDataRecorderHandle recorder);
+uint8_t flox_data_recorder_is_recording(FloxDataRecorderHandle recorder);
+```
+
+---
+
+## Segment operations
+
+```c
+// Quick validate/merge
+uint8_t flox_segment_validate(const char* path);
+uint8_t flox_segment_merge(const char* input_dir, const char* output_path);
+
+// Full API (results written to out pointer, see struct definitions in header)
+void flox_segment_merge_full_p(const char* input_paths, size_t num_paths,
+                                const char* output_dir, const char* output_name,
+                                uint8_t sort, void* out);         // → FloxMergeResult
+void flox_segment_merge_dir_p(const char* input_dir,
+                               const char* output_dir, void* out); // → FloxMergeResult
+void flox_segment_split_p(const char* input_path, const char* output_dir,
+                           uint8_t mode, int64_t time_interval_ns,
+                           uint64_t events_per_file, void* out);   // → FloxSplitResult
+void flox_segment_export_p(const char* input_path, const char* output_path,
+                            uint8_t format, int64_t from_ns, int64_t to_ns,
+                            const uint32_t* symbols, uint32_t num_symbols,
+                            void* out);                            // → FloxExportResult
+
+uint8_t  flox_segment_recompress(const char* input_path, const char* output_path,
+                                 uint8_t compression);
+uint64_t flox_segment_extract_symbols(const char* input_path, const char* output_path,
+                                      const uint32_t* symbols, uint32_t num_symbols);
+uint64_t flox_segment_extract_time_range(const char* input_path, const char* output_path,
+                                         int64_t from_ns, int64_t to_ns);
+
+// Validation
+void flox_segment_validate_full_p(const char* path, uint8_t verify_crc,
+                                   uint8_t verify_timestamps, void* out); // → FloxSegmentValidation
+void flox_dataset_validate_p(const char* data_dir, void* out);            // → FloxDatasetValidation
+```
+
+---
+
+## Partitioner
+
+Splits a dataset into time or event-count partitions for parallel backtesting.
+
+```c
+FloxPartitionerHandle flox_partitioner_create(const char* data_dir);
+void                  flox_partitioner_destroy(FloxPartitionerHandle partitioner);
+
+// All return number of partitions. If partitions_out is NULL, counts only.
+uint32_t flox_partitioner_by_time(FloxPartitionerHandle p, uint32_t num_partitions,
+                                   int64_t warmup_ns,
+                                   FloxPartition* partitions_out, uint32_t max);
+uint32_t flox_partitioner_by_duration(FloxPartitionerHandle p, int64_t duration_ns,
+                                       int64_t warmup_ns,
+                                       FloxPartition* partitions_out, uint32_t max);
+uint32_t flox_partitioner_by_calendar(FloxPartitionerHandle p, uint8_t unit,
+                                       int64_t warmup_ns,
+                                       FloxPartition* partitions_out, uint32_t max);
+uint32_t flox_partitioner_by_symbol(FloxPartitionerHandle p, uint32_t num_partitions,
+                                     FloxPartition* partitions_out, uint32_t max);
+uint32_t flox_partitioner_per_symbol(FloxPartitionerHandle p,
+                                      FloxPartition* partitions_out, uint32_t max);
+uint32_t flox_partitioner_by_event_count(FloxPartitionerHandle p, uint32_t num_partitions,
+                                          FloxPartition* partitions_out, uint32_t max);
+```
+
+`FloxPartition` fields: `partition_id`, `from_ns`, `to_ns`, `warmup_from_ns`, `estimated_events`, `estimated_bytes`.
+
+---
+
+## Fixed-point conversion
+
+```c
+int64_t flox_price_from_double(double value);
+double  flox_price_to_double(int64_t raw);
+int64_t flox_quantity_from_double(double value);
+double  flox_quantity_to_double(int64_t raw);
+```
+
+Scale factor is 1e8 for both price and quantity.
+
+==============================================================================
+# Section: Concepts (explanation)
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/explanation/README.md
+# URL: https://flox-foundation.github.io/flox/explanation/
+------------------------------------------------------------------------------
+
+# Explanation
+
+Understand concepts and design decisions behind FLOX. These pages are language-agnostic; code samples use tabs where they help.
+
+## Overview
+
+| Topic | What You'll Learn |
+|-------|-------------------|
+| [Architecture](architecture.md) | How components fit together |
+| [Bar Types](bar-types.md) | Time, tick, volume, range, Renko, Heikin-Ashi — when to use which |
+| [Disruptor Pattern](disruptor.md) | Why we use ring buffers (system-level, C++ internals) |
+| [Memory Model](memory-model.md) | Zero-allocation event delivery (system-level, C++ internals) |
+| [Integration Flow](integration-flow.md) | End-to-end data flow through the system |
+| [Indicators](indicators.md) | What each indicator measures and when to use it |
+
+## When to read these
+
+- **Before** diving deep into customization
+- **When** you want to understand design trade-offs
+- **If** you're debugging performance issues
+
+## A note on language
+
+Some explanation pages — Disruptor Pattern, Memory Model — describe internals of the C++ engine itself. Code in those pages is C++ because that *is* the implementation. If you only use the Python, Node.js, or Codon bindings you can read them as background; the bindings expose the relevant behaviour through their own APIs without you needing to touch C++.
+
+------------------------------------------------------------------------------
+# Source: docs/explanation/architecture.md
+# URL: https://flox-foundation.github.io/flox/explanation/architecture/
+------------------------------------------------------------------------------
+
+# Architecture Overview
+
+How FLOX components fit together. The diagrams below describe the runtime engine — the same architecture you get from every binding (Python, Node.js, Codon, C++). Bindings are thin wrappers; the engine layout is identical.
+
+## System Layers
+
+```mermaid
+flowchart TB
+    subgraph L3["Application Layer"]
+        strategy[Your Strategy]
+    end
+
+    subgraph L2["Core Layer"]
+        eventbus[EventBus]
+        execution[Order Execution]
+        risk[Risk Management]
+    end
+
+    subgraph L1["Infrastructure Layer"]
+        connectors[Connectors]
+        orderbooks[Order Books]
+        registry[Symbol Registry]
+        replay[Replay]
+    end
+
+    L1 --> L2
+    L2 --> L3
+```
+
+| Layer | Components | Purpose |
+|-------|------------|---------|
+| **Infrastructure** | Connectors, Replay, Symbol Registry, Order Books | Low-level I/O and data management |
+| **Core** | EventBus, Order Execution, Risk Management | Event routing and order flow |
+| **Application** | Your Strategy | Trading logic |
+
+## Data Flow
+
+```mermaid
+flowchart TD
+    subgraph External
+        EX[Exchange API]
+    end
+
+    subgraph Connectors
+        CONN[IExchangeConnector]
+    end
+
+    subgraph EventBuses[Event Buses - Disruptor Ring Buffers]
+        TB[TradeBus]
+        BB[BookUpdateBus]
+        CB[BarBus]
+    end
+
+    subgraph Aggregators
+        CA[BarAggregator]
+    end
+
+    subgraph Strategies
+        ST[IStrategy]
+    end
+
+    subgraph Execution
+        OEB[OrderExecutionBus]
+        EXE[IOrderExecutor]
+        RM[IRiskManager]
+        KS[IKillSwitch]
+    end
+
+    EX --> CONN
+    CONN --> TB
+    CONN --> BB
+    TB --> ST
+    BB --> ST
+    TB --> CA
+    CA --> CB
+    CB --> ST
+    ST -->|Order| RM
+    RM -->|Allowed| KS
+    KS -->|Not Triggered| EXE
+    EXE --> OEB
+```
+
+## Core Components
+
+### Engine
+
+The `Engine` class orchestrates the system lifecycle:
+
+```cpp
+class Engine : public ISubsystem
+{
+public:
+  Engine(const EngineConfig& config,
+         std::vector<std::unique_ptr<ISubsystem>> subsystems,
+         std::vector<std::shared_ptr<IExchangeConnector>> connectors);
+
+  void start() override;
+  void stop() override;
+};
+```
+
+- Takes ownership of all subsystems
+- Starts subsystems first, then connectors
+- Stops connectors first, then subsystems
+- No configuration file parsing — you wire components manually
+
+### Event Buses
+
+All buses use the Disruptor pattern (see [The Disruptor Pattern](disruptor.md)):
+
+| Bus | Event Type | Purpose |
+|-----|------------|---------|
+| `TradeBus` | `TradeEvent` | Individual trades |
+| `BookUpdateBus` | `pool::Handle<BookUpdateEvent>` | Order book snapshots/deltas |
+| `BarBus` | `BarEvent` | OHLCV bars |
+| `OrderExecutionBus` | `OrderEvent` | Order state changes |
+
+Key characteristics:
+
+- Lock-free ring buffer
+- Single producer, multiple consumers
+- Consumers run in dedicated threads
+- Backpressure via sequence gating
+
+### Connectors
+
+`IExchangeConnector` interface:
+
+```cpp
+class IExchangeConnector
+{
+public:
+  virtual ~IExchangeConnector() = default;
+  virtual void start() = 0;
+  virtual void stop() = 0;
+  virtual std::string exchangeId() const = 0;
+};
+```
+
+Connectors:
+
+- Parse exchange-specific wire protocols
+- Convert to FLOX event types
+- Publish to event buses
+- Run their own network threads
+
+### Strategies
+
+`IStrategy` combines `ISubsystem` + `IMarketDataSubscriber`:
+
+```cpp
+class IStrategy : public ISubsystem, public IMarketDataSubscriber
+{
+public:
+  virtual ~IStrategy() = default;
+};
+```
+
+From `IMarketDataSubscriber`:
+
+- `onTrade(const TradeEvent&)`
+- `onBookUpdate(const BookUpdateEvent&)`
+- `onBar(const BarEvent&)`
+
+From `ISubsystem`:
+
+- `start()`
+- `stop()`
+
+## Subsystem Interface
+
+Everything that participates in engine lifecycle implements:
+
+```cpp
+class ISubsystem
+{
+public:
+  virtual ~ISubsystem() = default;
+  virtual void start() = 0;
+  virtual void stop() = 0;
+};
+```
+
+Subsystems include:
+
+- Event buses
+- Strategies
+- Aggregators (e.g., BarAggregator)
+- Execution trackers
+- Custom components
+
+## Symbol Management
+
+Symbols are identified by `SymbolId` (`uint32_t`):
+
+```cpp
+SymbolRegistry registry;
+registry.registerSymbol("binance", "BTCUSDT");  // Returns SymbolId
+auto id = registry.getSymbolId("binance", "BTCUSDT");
+```
+
+Benefits:
+
+- Fast comparison (integer vs string)
+- Compact event structures
+- Consistent across components
+
+## Type System
+
+FLOX uses strong types to prevent unit confusion:
+
+| Type | Underlying | Purpose |
+|------|------------|---------|
+| `Price` | Fixed-point | Prices (avoid floating-point) |
+| `Quantity` | Fixed-point | Quantities |
+| `SymbolId` | `uint32_t` | Symbol identifier |
+| `OrderId` | `uint64_t` | Order identifier |
+| `UnixNanos` | `int64_t` | Nanosecond timestamp |
+
+## Threading Model
+
+```mermaid
+flowchart TB
+    subgraph main["Main Thread"]
+        engine["Engine lifecycle<br/>Subsystem start/stop"]
+    end
+
+    subgraph connectors["Connector Threads"]
+        c1["Connector 1<br/>Network I/O, Parsing"]
+        c2["Connector 2<br/>Network I/O, Parsing"]
+        c3["Connector N<br/>Network I/O, Parsing"]
+    end
+
+    subgraph consumers["Bus Consumer Threads"]
+        s1["Strategy A"]
+        s2["Strategy B"]
+        agg["Aggregator"]
+    end
+
+    engine --> connectors
+    engine --> consumers
+    c1 --> s1
+    c2 --> s2
+    c3 --> agg
+```
+
+- Each connector manages its own threads
+- Each bus consumer gets a dedicated thread
+- Consumer threads can be pinned to isolated CPU cores
+
+## CPU Affinity (Optional)
+
+With `FLOX_ENABLE_CPU_AFFINITY=ON`:
+
+```cpp
+bus.setupOptimalConfiguration(EventBus::ComponentType::MARKET_DATA);
+```
+
+This:
+
+- Pins consumer threads to isolated cores
+- Sets real-time scheduling priority
+- Enables NUMA-aware core assignment
+
+See [Configure CPU Affinity](../how-to/cpu-affinity.md).
+
+## Next Steps
+
+- [The Disruptor Pattern](disruptor.md) — Deep dive into event delivery
+- [Memory Model](memory-model.md) — Zero-allocation design
+- [First Strategy](../tutorials/first-strategy.md) — Write your first strategy
+
+------------------------------------------------------------------------------
+# Source: docs/explanation/integration-flow.md
+# URL: https://flox-foundation.github.io/flox/explanation/integration-flow/
+------------------------------------------------------------------------------
+
+# Integration Flow
+
+!!! info "C++ engine integration"
+    This page walks through wiring up the C++ engine end-to-end (registry → buses → strategies → executor → connector). If you use Python, Node.js, or Codon, all of this is hidden behind `Runner` and `BacktestRunner` — you don't wire buses by hand. Read this if you embed FLOX in a C++ host or want to understand what happens beneath the bindings.
+
+Step-by-step guide to integrating FLOX components into a complete trading system.
+
+## Overview
+
+```mermaid
+flowchart TD
+    subgraph Setup
+        A[1. Register Symbols] --> B[2. Create Core Components]
+        B --> C[3. Create Executors & Connectors]
+        C --> D[4. Wire Event Delivery]
+    end
+
+    subgraph Runtime
+        D --> E[5. Launch Components]
+        E --> F[6. Handle Execution Feedback]
+    end
+
+    subgraph Teardown
+        F --> G[7. Shutdown]
+    end
+```
+
+## 1. Register Symbols
+
+Before anything else, define which trading instruments the system will operate on. Each symbol is registered with an internal registry, which assigns a unique identifier and stores metadata.
+
+```cpp
+#include "flox/engine/symbol_registry.h"
+
+SymbolRegistry registry;
+
+// Register symbols with exchange and instrument info
+auto btcId = registry.registerSymbol("binance", "BTCUSDT", InstrumentType::PERPETUAL);
+auto ethId = registry.registerSymbol("binance", "ETHUSDT", InstrumentType::PERPETUAL);
+
+// Retrieve later by name
+auto symbolId = registry.getSymbolId("binance", "BTCUSDT");
+```
+
+**Key points:**
+
+- `SymbolId` is a compact integer for fast comparison
+- Registry maps `(exchange, symbol)` pairs to `SymbolId`
+- Metadata includes instrument type, tick size, lot size
+
+## 2. Create Core Components
+
+Several core components must be created and wired together:
+
+```cpp
+#include "flox/book/bus/trade_bus.h"
+#include "flox/book/bus/book_update_bus.h"
+#include "flox/execution/bus/order_execution_bus.h"
+#include "flox/execution/order_tracker.h"
+
+// Event buses for market data
+auto tradeBus = std::make_unique<TradeBus>();
+auto bookBus = std::make_unique<BookUpdateBus>();
+
+// Execution infrastructure
+auto execBus = std::make_unique<OrderExecutionBus>();
+auto orderTracker = std::make_unique<OrderTracker>();
+```
+
+**Component responsibilities:**
+
+| Component | Purpose |
+|-----------|---------|
+| `SymbolRegistry` | Resolve and map symbols |
+| `OrderTracker` | Monitor orders and maintain state |
+| `TradeBus` | Distribute trade events |
+| `BookUpdateBus` | Distribute order book updates |
+| `OrderExecutionBus` | Distribute execution events |
+
+## 3. Create Executors and Connectors
+
+```cpp
+#include "flox/execution/abstract_executor.h"
+#include "flox/connector/abstract_exchange_connector.h"
+
+// Order executor sends orders to exchange
+auto executor = std::make_unique<BinanceExecutor>(
+    transport,
+    registry,
+    orderTracker.get()
+);
+
+// Connector receives market data
+auto connector = std::make_shared<BinanceConnector>(
+    registry,
+    *tradeBus,
+    *bookBus
+);
+```
+
+**Executor responsibilities:**
+
+- Send orders to exchange
+- Report order status updates
+- Update order tracker
+
+**Connector responsibilities:**
+
+- Connect to exchange (WebSocket, REST, FIX)
+- Parse wire protocol
+- Publish events to buses
+
+## 4. Wire Event Delivery
+
+Configure buses to distribute events to subscribers:
+
+```cpp
+#include "flox/strategy/istrategy.h"
+
+// Create strategy
+auto strategy = std::make_unique<MyStrategy>(executor.get());
+
+// Subscribe to market data
+tradeBus->subscribe(strategy.get());
+bookBus->subscribe(strategy.get());
+
+// Subscribe to execution events
+execBus->subscribe(strategy.get());
+
+// Add optional subscribers
+tradeBus->subscribe(logger.get(), /*optional=*/true);
+tradeBus->subscribe(metrics.get(), /*optional=*/true);
+```
+
+**Subscriber types:**
+
+| Type | Behavior |
+|------|----------|
+| Required | System waits for slow consumers |
+| Optional | May miss events if too slow |
+
+**Common subscribers:**
+
+- Trading strategies
+- Data aggregators (bars, VWAP)
+- Metric collectors
+- Risk modules
+- Loggers
+
+## 5. Launch Components
+
+Start components in the correct order:
+
+```cpp
+#include "flox/engine/engine.h"
+
+// Collect all subsystems
+std::vector<std::unique_ptr<ISubsystem>> subsystems;
+subsystems.push_back(std::move(tradeBus));
+subsystems.push_back(std::move(bookBus));
+subsystems.push_back(std::move(execBus));
+subsystems.push_back(std::move(strategy));
+
+// Collect connectors
+std::vector<std::shared_ptr<IExchangeConnector>> connectors;
+connectors.push_back(connector);
+
+// Create and start engine
+EngineConfig config = loadConfig("config.json");
+Engine engine(config, std::move(subsystems), std::move(connectors));
+
+engine.start();  // Blocks until shutdown signal
+```
+
+**Startup sequence:**
+
+1. Event buses start threads
+2. Connectors establish connections
+3. Strategies begin processing
+4. Executors ready to handle orders
+
+## 6. Handle Execution Feedback
+
+When orders are submitted, the system maintains consistency:
+
+```cpp
+// In your executor implementation
+void MyExecutor::onOrderFill(const FillMessage& msg) {
+    // Update tracker
+    _orderTracker->updateOrder(msg.orderId, OrderStatus::FILLED);
+
+    // Emit event
+    OrderEvent event;
+    event.order.orderId = msg.orderId;
+    event.order.status = OrderStatus::FILLED;
+    event.order.filledQty = msg.quantity;
+    event.order.avgPrice = msg.price;
+
+    _execBus->publish(event);
+}
+```
+
+**Order lifecycle:**
+
+```mermaid
+stateDiagram-v2
+    [*] --> NEW
+    NEW --> SUBMITTED: send to exchange
+    SUBMITTED --> ACCEPTED: exchange confirms
+    SUBMITTED --> REJECTED: validation failed
+
+    ACCEPTED --> PARTIALLY_FILLED: partial execution
+    ACCEPTED --> FILLED: full execution
+    ACCEPTED --> PENDING_CANCEL: cancel requested
+    ACCEPTED --> EXPIRED: time-in-force expired
+    ACCEPTED --> REPLACED: modify accepted
+
+    PARTIALLY_FILLED --> PARTIALLY_FILLED: more fills
+    PARTIALLY_FILLED --> FILLED: complete
+    PARTIALLY_FILLED --> PENDING_CANCEL: cancel remaining
+
+    PENDING_CANCEL --> CANCELED: cancel confirmed
+
+    FILLED --> [*]
+    CANCELED --> [*]
+    REJECTED --> [*]
+    EXPIRED --> [*]
+```
+
+**Conditional order states** (stop-loss, take-profit, trailing stop):
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING_TRIGGER: conditional order created
+    PENDING_TRIGGER --> TRIGGERED: price condition met
+    PENDING_TRIGGER --> TRAILING_UPDATED: trailing stop adjusted
+    TRAILING_UPDATED --> PENDING_TRIGGER: continue monitoring
+    TRIGGERED --> SUBMITTED: becomes regular order
+```
+
+**OrderEventStatus values:**
+
+| Status | Description |
+|--------|-------------|
+| `NEW` | Order created locally |
+| `SUBMITTED` | Sent to exchange |
+| `ACCEPTED` | Exchange acknowledged |
+| `PARTIALLY_FILLED` | Partial execution |
+| `FILLED` | Fully executed |
+| `PENDING_CANCEL` | Cancel request sent |
+| `CANCELED` | Successfully canceled |
+| `EXPIRED` | Time-in-force expired |
+| `REJECTED` | Exchange rejected |
+| `REPLACED` | Order modified (price/qty) |
+| `PENDING_TRIGGER` | Conditional order waiting |
+| `TRIGGERED` | Condition met, converting to market/limit |
+| `TRAILING_UPDATED` | Trailing stop price adjusted |
+
+## 7. Shutdown Procedure
+
+Graceful shutdown ensures no data loss:
+
+```cpp
+// Signal shutdown (e.g., from signal handler)
+engine.stop();
+
+// Or programmatically
+void gracefulShutdown() {
+    // Stop accepting new orders
+    executor->stop();
+
+    // Stop connectors (no new market data)
+    for (auto& conn : connectors) {
+        conn->stop();
+    }
+
+    // Stop buses (drains queues)
+    tradeBus->stop();
+    bookBus->stop();
+    execBus->stop();
+
+    // Stop strategies
+    strategy->stop();
+}
+```
+
+**Shutdown order:**
+
+1. Stop connectors (no new data)
+2. Drain event buses
+3. Stop strategies
+4. Complete in-flight orders
+5. Clean up resources
+
+## Complete Example
+
+```cpp
+#include "flox/flox.h"
+
+int main() {
+    // 1. Registry
+    SymbolRegistry registry;
+    registry.registerSymbol("binance", "BTCUSDT");
+
+    // 2. Core components
+    auto tradeBus = std::make_unique<TradeBus>();
+    auto bookBus = std::make_unique<BookUpdateBus>();
+    auto execBus = std::make_unique<OrderExecutionBus>();
+
+    // 3. Executor and connector
+    auto executor = createExecutor(registry);
+    auto connector = createConnector(registry, *tradeBus, *bookBus);
+
+    // 4. Strategy
+    auto strategy = std::make_unique<MyStrategy>(executor.get());
+    tradeBus->subscribe(strategy.get());
+    bookBus->subscribe(strategy.get());
+
+    // 5. Engine
+    std::vector<std::unique_ptr<ISubsystem>> subsystems;
+    subsystems.push_back(std::move(tradeBus));
+    subsystems.push_back(std::move(bookBus));
+    subsystems.push_back(std::move(execBus));
+    subsystems.push_back(std::move(strategy));
+
+    std::vector<std::shared_ptr<IExchangeConnector>> connectors;
+    connectors.push_back(connector);
+
+    Engine engine(loadConfig(), std::move(subsystems), std::move(connectors));
+    engine.start();
+
+    return 0;
+}
+```
+
+## Design Principles
+
+| Principle | Implementation |
+|-----------|----------------|
+| **Modularity** | Components can be swapped independently |
+| **Thread safety** | Lock-free constructs in hot paths |
+| **Zero allocation** | Pre-allocated pools and ring buffers |
+| **Determinism** | Sync mode available for backtesting |
+
+## See Also
+
+- [Architecture](architecture.md) — Component overview
+- [Run the Demo](../tutorials/demo.md) — See integration in action
+- [Configuration](../how-to/configuration.md) — Configure the system
+
+------------------------------------------------------------------------------
+# Source: docs/explanation/bar-types.md
+# URL: https://flox-foundation.github.io/flox/explanation/bar-types/
+------------------------------------------------------------------------------
+
+# Understanding Bar Types
+
+This document explains the different bar types available in Flox and when to use each one. Examples are shown in C++ because that's where the aggregator templates live, but every binding can produce and consume each bar type — see [Bar aggregation](../how-to/bar-aggregation.md) for the binding-level API.
+
+## The Problem with Time Bars
+
+Traditional time-based bars (1-minute, hourly, daily) have a fundamental issue: **information content varies with market activity**.
+
+- During high activity: bars pack lots of information
+- During low activity: bars contain little information (noise)
+
+This inconsistency creates problems:
+
+- Indicators behave differently at different times
+- Backtests may not reflect live performance
+- Overnight gaps distort analysis
+
+Alternative bar types address this by normalizing **what** closes a bar rather than **when**.
+
+## Bar Types Overview
+
+| Type | Closes When | Best For |
+|------|-------------|----------|
+| **Time** | Fixed time interval | Traditional analysis, backtesting |
+| **Tick** | N trades occur | HFT, eliminating time bias |
+| **Volume** | Notional volume threshold | Volume-weighted analysis |
+| **Renko** | Price moves by brick size | Trend following, noise elimination |
+| **Range** | High-low exceeds threshold | Volatility-based analysis |
+| **Heikin-Ashi** | Fixed time interval (smoothed) | Trend clarity, noise reduction |
+
+## Time Bars
+
+```cpp
+TimeBarAggregator aggregator(TimeBarPolicy(std::chrono::seconds(60)), &bus);
+```
+
+**How it works**: Close after a fixed time interval (e.g., 1 minute).
+
+**Pros**:
+
+- Familiar, widely used
+- Easy to compare across instruments
+- Works with most existing tools
+
+**Cons**:
+
+- Information content varies
+- Overnight gaps create distortions
+- Low-activity periods add noise
+
+**Use when**:
+
+- Backtesting strategies designed for time bars
+- Comparing to external data sources
+- Building indicators that expect regular intervals
+
+## Tick Bars
+
+```cpp
+TickBarAggregator aggregator(TickBarPolicy(100), &bus);  // 100 trades per bar
+```
+
+**How it works**: Close after N trades occur, regardless of time.
+
+**Pros**:
+
+- Consistent information per bar
+- No time-based distortions
+- Better for statistical analysis
+
+**Cons**:
+
+- Bar duration varies wildly
+- Can't easily compare across instruments
+- May produce many bars during high activity
+
+**Use when**:
+
+- High-frequency strategies
+- Statistical arbitrage
+- Eliminating time-of-day effects
+
+**Example insight**: A 100-tick bar during high volatility might span 1 second; during quiet periods, 10 minutes. But each bar represents the same amount of "market activity."
+
+## Volume Bars
+
+```cpp
+VolumeBarAggregator aggregator(VolumeBarPolicy::fromDouble(1000000.0), &bus);
+```
+
+**How it works**: Close after notional volume (price × quantity) reaches threshold.
+
+**Pros**:
+
+- Normalizes for trade size variation
+- Better represents institutional activity
+- Consistent economic significance per bar
+
+**Cons**:
+
+- Threshold needs tuning per instrument
+- Price changes affect bar frequency
+
+**Use when**:
+
+- Analyzing institutional flow
+- Volume-weighted strategies
+- Markets with varying trade sizes
+
+**Example**: $1M volume bars on BTC might close every few seconds during active trading, but take hours overnight.
+
+## Renko Bars
+
+```cpp
+RenkoBarAggregator aggregator(RenkoBarPolicy::fromDouble(10.0), &bus);
+```
+
+**How it works**: New bar only when price moves by "brick size" from previous close.
+
+**Pros**:
+
+- Eliminates noise
+- Clear trend visualization
+- No time or volume dependency
+
+**Cons**:
+
+- Loses timing information
+- Can miss reversals within brick
+- Gaps create multiple bricks
+
+**Use when**:
+
+- Trend following strategies
+- Support/resistance identification
+- Filtering out market noise
+
+**Unique property**: Renko bars only move one direction until reversal. A series of up-bricks means consistent upward movement without significant pullbacks.
+
+## Range Bars
+
+```cpp
+RangeBarAggregator aggregator(RangeBarPolicy::fromDouble(5.0), &bus);
+```
+
+**How it works**: Close when high-low range exceeds threshold.
+
+**Pros**:
+
+- Consistent volatility per bar
+- Adapts to market conditions
+- Good for breakout detection
+
+**Cons**:
+
+- Can produce many small bars in trending markets
+- Range threshold needs tuning
+
+**Use when**:
+
+- Volatility-based strategies
+- Breakout trading
+- Options-related strategies
+
+**Example**: $5 range bars will close quickly during volatile periods (many bars) and slowly during consolidation (fewer bars).
+
+## Heikin-Ashi Bars
+
+```cpp
+HeikinAshiBarAggregator aggregator(HeikinAshiBarPolicy(std::chrono::seconds(60)), &bus);
+```
+
+**How it works**: Uses smoothed OHLC calculations based on previous bar:
+
+- HA_Close = (Open + High + Low + Close) / 4
+- HA_Open = (prev_HA_Open + prev_HA_Close) / 2
+- HA_High = max(High, HA_Open, HA_Close)
+- HA_Low = min(Low, HA_Open, HA_Close)
+
+**Pros**:
+
+- Smoother trends, easier to identify
+- Reduces noise from individual bars
+- Bullish bars always have close > open
+- Great for visual trend analysis
+
+**Cons**:
+
+- Loses exact price information
+- Not suitable for precise entries
+- Lags behind actual price
+- Requires previous bar for calculation
+
+**Use when**:
+
+- Trend following strategies
+- Visual trend confirmation
+- Reducing false signals in choppy markets
+- Swing trading with trend filters
+
+**Unique property**: In a strong uptrend, Heikin-Ashi bars will show no lower wicks (or very small ones). Conversely, strong downtrends show no upper wicks. This makes trend strength immediately visible.
+
+**Multi-symbol support**: The Heikin-Ashi aggregator maintains independent state per symbol, so a single aggregator instance can correctly handle multiple symbols simultaneously.
+
+## Choosing the Right Bar Type
+
+### Decision Framework
+
+```
+What matters most for your strategy?
+
+├── Time consistency?
+│   └── Use TIME bars
+│
+├── Trade activity?
+│   └── Use TICK bars
+│
+├── Dollar volume?
+│   └── Use VOLUME bars
+│
+├── Price movement?
+│   ├── Trend direction → Use RENKO bars
+│   └── Volatility → Use RANGE bars
+```
+
+### By Strategy Type
+
+| Strategy | Recommended Bar Type |
+|----------|---------------------|
+| Mean reversion | Time or Volume |
+| Momentum | Time, Renko, or Heikin-Ashi |
+| Scalping/HFT | Tick |
+| Trend following | Renko, Heikin-Ashi, or Time |
+| Volatility trading | Range |
+| Statistical arb | Tick or Volume |
+| Swing trading | Time (H1, D1) or Heikin-Ashi |
+
+### By Market Condition
+
+| Condition | Better Choice |
+|-----------|--------------|
+| High volatility | Range or Renko |
+| Low liquidity | Volume |
+| 24/7 markets | Tick or Volume |
+| Session-based | Time |
+| Trending | Renko or Heikin-Ashi |
+| Ranging | Time or Range |
+| Noisy markets | Heikin-Ashi |
+
+## Multi-Timeframe with Mixed Types
+
+Combine bar types for better analysis:
+
+```cpp
+MultiTimeframeAggregator<4> aggregator(&bus);
+aggregator.addTimeInterval(std::chrono::seconds(60));   // M1 for timing
+aggregator.addTimeInterval(std::chrono::seconds(3600)); // H1 for trend
+aggregator.addTickInterval(100);                         // Tick for activity
+aggregator.addVolumeInterval(1000000.0);                 // Volume for flow
+```
+
+**Strategy example**:
+
+- H1 time bars for trend direction
+- Volume bars for institutional activity
+- Tick bars for precise entry timing
+
+## Performance Comparison
+
+All bar types have similar computational cost:
+
+| Operation | Time | Tick | Volume | Renko | Range | Heikin-Ashi |
+|-----------|------|------|--------|-------|-------|-------------|
+| shouldClose() | O(1) | O(1) | O(1) | O(1) | O(1) | O(1) |
+| update() | O(1) | O(1) | O(1) | O(1) | O(1) | O(1) |
+
+The main difference is **bar frequency**, not computational overhead.
+
+## Summary
+
+- **Time bars**: Traditional, familiar, but information-inconsistent
+- **Tick bars**: Consistent activity, good for HFT
+- **Volume bars**: Consistent economic significance
+- **Renko bars**: Noise-free trend visualization
+- **Range bars**: Volatility-normalized
+- **Heikin-Ashi bars**: Smoothed trends, noise reduction
+
+Choose based on what your strategy needs to hold constant: **time**, **activity**, **volume**, **price movement**, **volatility**, or **trend clarity**.
+
+## See Also
+
+- [Bar Aggregator Reference](../reference/api/aggregator/bar_aggregator.md)
+- [How to Create Custom Bar Policy](../how-to/custom-bar-policy.md)
+- [Multi-Timeframe Strategy Tutorial](../tutorials/multi-timeframe-strategy.md)
+
+------------------------------------------------------------------------------
+# Source: docs/explanation/indicators.md
+# URL: https://flox-foundation.github.io/flox/explanation/indicators/
+------------------------------------------------------------------------------
+
+# Indicators
+
+FLOX has around 25 indicators, split across moving averages, oscillators, volatility, volume, and statistics. Each works in two modes: batch (pass an array, get an array back) and streaming (call `.update()` each tick, check `.ready` before reading `.value`). The same indicator set is exposed by every binding — Python, Node.js, Codon, and the C++ core all share one implementation.
+
+This page covers what each one actually measures and when you'd want it.
+
+---
+
+## Moving averages
+
+### SMA
+
+Arithmetic mean over a sliding window. Every bar gets equal weight.
+
+```
+SMA(n) = (x₁ + x₂ + ... + xₙ) / n
+```
+
+Responds slowly to recent price movement — which makes it less useful for short-term signals but reasonable for long-term trend reference. If you need a baseline to compare against, this is the simplest one.
+
+### EMA
+
+Weighted average where recent bars count more. Smoothing factor: `α = 2/(period+1)`.
+
+```
+EMA = α × price + (1 − α) × EMA_prev
+```
+
+Responds faster than SMA. MACD, ATR smoothing, and most other indicators build on it. The default choice when you need a moving average and have no strong reason to pick something else.
+
+### RMA
+
+Same structure as EMA but `α = 1/period` — slower. RSI and ATR use it internally (it's Wilder's smoothing).
+
+You probably won't use RMA directly unless you're reimplementing RSI/ATR from scratch or need exact TradingView parity.
+
+### DEMA
+
+```
+DEMA = 2 × EMA − EMA(EMA)
+```
+
+Less lag than EMA. Warmup takes `2 × period` bars. Worth trying when EMA crossover signals are consistently arriving a bar or two late.
+
+### TEMA
+
+```
+TEMA = 3 × EMA − 3 × EMA(EMA) + EMA(EMA(EMA))
+```
+
+More lag reduction than DEMA. Warmup is `3 × period`. Very reactive — expect more false signals in choppy markets.
+
+### KAMA
+
+Kaufman Adaptive Moving Average. Adjusts the smoothing factor based on an "efficiency ratio": how much price moved versus how much it oscillated. Goes fast in trending markets, slow in sideways ones.
+
+Useful if you want one MA that self-adjusts across regimes rather than manually switching between a fast and a slow EMA.
+
+### Slope
+
+Linear regression slope over a rolling window. Not exactly a moving average, but used in similar ways.
+
+```
+slope = Σ(x − x̄)(y − ȳ) / Σ(x − x̄)²
+```
+
+Positive = upward trend. Magnitude is the steepness. Good for momentum filtering.
+
+---
+
+## Oscillators
+
+### RSI
+
+Ratio of average gains to average losses over `period` bars, scaled to 0–100.
+
+```
+RSI = 100 − 100 / (1 + RS)
+RS  = avg_gain / avg_loss   (Wilder's RMA)
+```
+
+The classic levels (70 = overbought, 30 = oversold) work well in ranging markets. In a strong trend, RSI can stay above 70 for a long time — which is a feature, not a bug, depending on your strategy. Period 14 is standard; shorter periods make it noisier.
+
+### MACD
+
+Difference between a fast EMA and a slow EMA, with a signal line on top.
+
+```
+MACD line   = EMA(fast) − EMA(slow)    [default: 12, 26]
+signal line = EMA(MACD line, 9)
+histogram   = MACD line − signal line
+```
+
+Crossing zero signals a momentum shift. The histogram slope shows whether momentum is accelerating or fading. Watching the histogram flatten before the line crossover is a common entry filter.
+
+### Stochastic
+
+Where is the close relative to the recent high-low range?
+
+```
+%K = 100 × (close − lowest_low) / (highest_high − lowest_low)
+%D = SMA(%K, d_period)
+```
+
+Ranges 0–100. Common levels: 80 overbought, 20 oversold. The %D line smooths %K. Main signals are the %K/%D crossover and divergence between price and the indicator.
+
+### CCI
+
+Distance of the typical price from its SMA, divided by mean absolute deviation.
+
+```
+TP  = (high + low + close) / 3
+CCI = (TP − SMA(TP)) / (0.015 × mean_deviation)
+```
+
+Scaled so roughly 70% of values fall between −100 and +100. Values outside that band signal unusual strength or weakness. Often used as a momentum filter rather than a primary entry signal.
+
+### Bollinger Bands
+
+SMA with bands at ±N standard deviations.
+
+```
+middle = SMA(price, period)
+upper  = middle + multiplier × std(price, period)
+lower  = middle − multiplier × std(price, period)
+```
+
+Bands widen in volatile markets and contract when price quiets down. The squeeze — when bands get unusually narrow — often comes before a directional move. Price touching a band is context, not a signal by itself.
+
+---
+
+## Trend
+
+### ADX
+
+Measures trend strength, not direction. Comes with two directional indicators.
+
+```
++DI  = Wilder(upward movement, period)
+−DI  = Wilder(downward movement, period)
+ADX  = Wilder(|+DI − −DI| / (+DI + −DI), period)
+```
+
+ADX above 25 typically means there's a trend worth following. Below 20 is choppy. +DI and −DI tell you direction; ADX tells you whether to care.
+
+### CHOP
+
+How much price moved as a fraction of the maximum possible range over the period.
+
+```
+CHOP = 100 × log₁₀(Σ ATR / (highest_high − lowest_low)) / log₁₀(period)
+```
+
+High CHOP (near 100) means directionless. Low (near 0) means trending. More useful for switching between strategy modes than as a signal itself.
+
+---
+
+## Volatility
+
+### ATR
+
+Average range per bar, accounting for gaps.
+
+```
+true_range = max(high − low, |high − prev_close|, |low − prev_close|)
+ATR        = RMA(true_range, period)
+```
+
+Not directional. Standard use: position sizing (stop = N × ATR from entry) and filtering signals by volatility regime.
+
+### Parkinson volatility
+
+Uses high-low ranges instead of close-to-close returns.
+
+```
+σ = sqrt(mean(ln(H/L)²) / (4 × ln(2)))
+```
+
+More efficient than close-to-close when you have intraday OHLC data. Underestimates if the market gaps frequently, since gaps don't show in the H-L range.
+
+### Rogers-Satchell volatility
+
+OHLC volatility estimator designed to handle drift (trending markets) without bias.
+
+```
+σ² = mean(ln(H/C) × ln(H/O) + ln(L/C) × ln(L/O))
+```
+
+Better than Parkinson for trending assets. Both can be annualized by multiplying by `sqrt(periods_per_year)`.
+
+---
+
+## Volume
+
+### OBV
+
+Running total: add volume on up bars, subtract on down bars.
+
+```
+OBV = OBV_prev + (close > prev_close ? +volume : −volume)
+```
+
+The absolute value is meaningless — you're looking at the trend of OBV and divergences from price. Price makes a new high but OBV doesn't: the rally may not have conviction.
+
+### VWAP
+
+Average price weighted by volume, over a rolling window.
+
+```
+VWAP = Σ(price × volume) / Σ(volume)
+```
+
+Price above VWAP = buyers have been in control over that window. Used as a fair-value reference and order execution benchmark. Institutions care about VWAP when filling large orders.
+
+### CVD
+
+Running total of buying minus selling volume, inferred from OHLCV.
+
+```
+CVD = CVD_prev + buy_volume − sell_volume
+```
+
+Similar to OBV but directional. Divergence between CVD and price is one of the more reliable short-term signals when it appears.
+
+---
+
+## Statistical
+
+### Rolling z-score
+
+How many standard deviations is the current value from the rolling mean?
+
+```
+z = (x − mean(x, period)) / std(x, period)
+```
+
+Standard use is mean-reversion signals: z > 2 or < −2 marks statistically unusual levels. Returns NaN when std = 0.
+
+### Skewness
+
+Fisher-Pearson skewness of a rolling window — measures distribution asymmetry.
+
+```
+skew = (n / ((n−1)(n−2))) × Σ((x − mean) / std)³
+```
+
+Positive = right tail (large gains skew the distribution). Negative = left tail. Common in volatility forecasting and regime detection. Requires period ≥ 3; NaN if std = 0.
+
+### Kurtosis
+
+Tail heaviness relative to a normal distribution (Fisher excess kurtosis, so a normal distribution = 0).
+
+High kurtosis means fat tails — more outliers than a normal distribution would predict. Used in risk models to understand tail exposure. Requires period ≥ 4; NaN if std = 0.
+
+### Shannon entropy
+
+How random is the recent price distribution? Normalized to [0, 1] using histogram binning.
+
+```
+H = −Σ p(x) × ln(p(x)) / ln(bins)
+```
+
+1 = uniform distribution (maximum uncertainty). 0 = all values identical. Entropy tends to drop before trends develop and rise in choppy, uncertain markets — useful as a regime filter.
+
+### Correlation
+
+Rolling Pearson correlation between two series.
+
+```
+r = Σ(x − x̄)(y − ȳ) / sqrt(Σ(x − x̄)² × Σ(y − ȳ)²)
+```
+
+Range [−1, 1]. Used for pairs construction, cross-asset filters, or detecting when a relationship is breaking down. Returns NaN when either series is constant within the window.
+
+------------------------------------------------------------------------------
+# Source: docs/explanation/disruptor.md
+# URL: https://flox-foundation.github.io/flox/explanation/disruptor/
+------------------------------------------------------------------------------
+
+# The Disruptor Pattern
+
+!!! info "Internals — for context only"
+    This page describes how the C++ engine delivers events between threads. If you write strategies in Python, Node.js, or Codon, you don't see any of this directly — you just receive events in your callbacks. Read this if you want to understand *why* FLOX scales the way it does, not because you need it to write code.
+
+Why FLOX uses ring buffers for event delivery.
+
+## The Problem
+
+Traditional publish-subscribe systems have bottlenecks:
+
+```mermaid
+flowchart LR
+    P[Producer] --> Q[Queue]
+    Q --> C[Consumer]
+    Q -.->|Contention| X[Locks<br/>Allocations<br/>Cache misses]
+```
+
+For each event:
+
+1. **Lock acquisition** — Wait for mutex
+2. **Memory allocation** — Create queue node
+3. **Cache invalidation** — Producer and consumer fight over cache lines
+
+At millions of events per second, these costs add up.
+
+## The Disruptor Solution
+
+The Disruptor pattern (from LMAX Exchange) eliminates these costs:
+
+```
+              Ring Buffer (pre-allocated)
+
+  [0] [1] [2] [3] [4] [5] [6] [7]
+       ↑               ↑
+    Consumer       Producer
+    Sequence       Sequence
+```
+
+Key insights:
+
+1. **Pre-allocated array** — No allocation during publishing
+2. **Sequence numbers** — Atomic counters replace locks
+3. **Cache-line padding** — False sharing eliminated
+4. **Batching** — Consumers can process multiple events
+
+## FLOX Implementation
+
+FLOX's `EventBus` implements a Disruptor-style ring buffer:
+
+```cpp
+template <typename Event,
+          size_t CapacityPow2 = config::DEFAULT_EVENTBUS_CAPACITY,
+          size_t MaxConsumers = config::DEFAULT_EVENTBUS_MAX_CONSUMERS>
+class EventBus : public ISubsystem;
+```
+
+### Publishing
+
+```cpp
+// Producer claims slot via atomic increment
+int64_t seq = _next.fetch_add(1);
+
+// Wait for consumers to free the slot
+while (seq - CapacityPow2 > minConsumerSequence()) {
+  backoff.pause();
+}
+
+// Write event directly into ring buffer
+_storage[seq & Mask] = event;
+_published[seq & Mask].store(seq);  // Signal consumers
+```
+
+### Consuming
+
+Each consumer runs in a dedicated thread:
+
+```cpp
+while (running) {
+  // Wait for next sequence
+  while (_published[seq & Mask] != seq) {
+    backoff.pause();
+  }
+
+  // Process event
+  listener->onTrade(_storage[seq & Mask]);
+
+  // Advance sequence
+  _consumers[i].seq.store(seq);
+}
+```
+
+## Sequence Gating
+
+Producers wait for the slowest consumer before overwriting slots:
+
+```mermaid
+sequenceDiagram
+    participant P as Producer
+    participant RB as Ring Buffer
+    participant CA as Consumer A
+    participant CB as Consumer B
+
+    Note over RB: Capacity = 8
+
+    P->>RB: publish(seq=107)
+    RB-->>P: Wait! Slot 99 (107-8) not consumed
+
+    Note over CA: seq = 105
+    Note over CB: seq = 102 (slowest)
+
+    CB->>RB: consume(seq=103)
+    Note over CB: seq = 103
+
+    RB-->>P: Slot 99 free, continue
+    P->>RB: write event at slot 107
+```
+
+**Gating Logic:**
+```
+Producer Sequence: 107
+Consumer A Sequence: 105
+Consumer B Sequence: 102  ← Slowest (gating sequence)
+Ring Buffer Size: 8
+
+Producer can advance to: 102 + 8 = 110
+```
+
+This provides **backpressure** — fast producers can't overwhelm slow consumers.
+
+## Cache-Line Optimization
+
+The Disruptor uses padding to prevent false sharing:
+
+```cpp
+// Without padding: False sharing
+struct Bad {
+  std::atomic<int64_t> producer_seq;
+  std::atomic<int64_t> consumer_seq;  // Same cache line!
+};
+
+// With padding: No false sharing
+alignas(64) std::atomic<int64_t> producer_seq;
+alignas(64) std::atomic<int64_t> consumer_seq;
+```
+
+FLOX uses `alignas(64)` throughout `EventBus`:
+
+```cpp
+alignas(64) std::atomic<bool> _running{false};
+alignas(64) std::atomic<int64_t> _next{-1};
+alignas(64) std::atomic<int64_t> _cachedMin{-1};
+// ...
+alignas(64) std::array<ConsumerSlot, MaxConsumers> _consumers{};
+alignas(64) std::array<std::atomic<int64_t>, MaxConsumers> _gating{};
+```
+
+## Busy-Spin vs. Blocking
+
+Consumers use configurable backoff with three modes:
+
+```cpp
+enum class BackoffMode {
+  AGGRESSIVE,  // Dedicated colo: busy-spin with CPU pause, minimal yields
+  RELAXED,     // Shared VPS/cloud: early sleep, minimal CPU burn
+  ADAPTIVE     // Auto-adjust: starts aggressive, backs off under contention
+};
+
+BusyBackoff backoff(BackoffMode::ADAPTIVE);  // Default
+```
+
+**AGGRESSIVE** — for dedicated hardware with isolated cores:
+
+- 2048 spins with CPU pause
+- Then yield, reset at 4096
+
+**RELAXED** — for shared VPS/cloud environments:
+
+- 8 spins, then yield
+- Sleep 100μs after 16 spins
+- Sleep 500μs for sustained idle
+
+**ADAPTIVE** (default) — auto-adjusts based on contention:
+
+- 128 spins with CPU pause (low-latency burst handling)
+- 512 spins with yield (medium contention)
+- Sleep 10μs up to 2048 spins
+- Sleep 100μs and reset to medium level
+
+This balances latency (busy-spin) with CPU usage (sleep) based on deployment environment.
+
+## Multiple Consumers
+
+FLOX supports multiple consumers per bus:
+
+```mermaid
+flowchart LR
+    subgraph Producer
+        P[Connector Thread]
+    end
+
+    subgraph RB[Ring Buffer]
+        direction LR
+        S0[E0] --- S1[E1] --- S2[E2] --- S3[E3]
+    end
+
+    subgraph Consumers[Consumer Threads]
+        C1[Strategy A<br/>seq=5]
+        C2[Strategy B<br/>seq=3]
+        C3[Logger<br/>seq=2]
+    end
+
+    P -->|publish| RB
+    RB -->|deliver| C1
+    RB -->|deliver| C2
+    RB -->|deliver| C3
+
+    style C3 fill:#fdd
+```
+
+```cpp
+tradeBus->subscribe(strategyA.get());
+tradeBus->subscribe(strategyB.get());
+tradeBus->subscribe(logger.get());
+```
+
+Each consumer:
+
+- Gets a dedicated thread
+- Maintains its own sequence
+- Processes events independently
+
+The producer waits for the **slowest** consumer before overwriting.
+
+## Required vs. Optional Consumers
+
+```cpp
+// Required (default): affects backpressure
+tradeBus->subscribe(strategyA.get(), /*required=*/true);
+
+// Optional: doesn't gate the producer
+tradeBus->subscribe(logger.get(), /*required=*/false);
+```
+
+Optional consumers:
+
+- Won't slow down the system if they fall behind
+- May miss events if too slow
+- Useful for monitoring, logging, metrics
+
+## Performance Characteristics
+
+| Metric | Notes |
+|--------|-------|
+| Publish latency | Lock-free atomic operations only |
+| Consume latency | Depends on backoff strategy and load |
+| Throughput | Limited by slowest consumer |
+| Memory overhead | Fixed: `sizeof(Event) × Capacity` |
+
+Actual numbers depend heavily on:
+- CPU architecture and cache hierarchy
+- Whether cores are isolated
+- Event size and consumer callback complexity
+- System load
+
+Run benchmarks on your target hardware to establish baseline.
+
+## When Disruptor Shines
+
+**Good fit:**
+
+- High-throughput, low-latency requirements
+- Predictable memory usage
+- Single producer, multiple consumers
+- Events are processed in order
+
+**Not ideal for:**
+
+- Multiple producers (requires coordination)
+- Unbounded queues
+- Very uneven consumer speeds
+
+## Configuration
+
+```cpp
+// Custom capacity and consumer limit
+using MyBus = EventBus<TradeEvent,
+                       /*CapacityPow2=*/16384,
+                       /*MaxConsumers=*/32>;
+```
+
+Capacity must be a power of 2 (for fast modulo via bitmask).
+
+## Further Reading
+
+- [LMAX Disruptor Paper](https://lmax-exchange.github.io/disruptor/disruptor.html)
+- [Memory Model](memory-model.md) — How FLOX handles event ownership
+- [Architecture Overview](architecture.md) — Full system design
+
+------------------------------------------------------------------------------
+# Source: docs/explanation/memory-model.md
+# URL: https://flox-foundation.github.io/flox/explanation/memory-model/
+------------------------------------------------------------------------------
+
+# Memory Model
+
+!!! info "Internals — for context only"
+    This page explains how the C++ engine avoids heap allocation on the hot path. Bindings (Python, Node.js, Codon) inherit this behaviour automatically — there's no per-language API to manage pools. Read this if you care about the latency story; skip if you just want to ship a strategy.
+
+Zero-allocation event delivery in FLOX.
+
+## The Problem
+
+Dynamic memory allocation is slow and unpredictable:
+
+```cpp
+// This allocates memory — bad in hot path
+auto event = std::make_shared<TradeEvent>();
+tradeBus.publish(event);
+```
+
+Each allocation:
+
+- May trigger system calls
+- Causes unpredictable latency
+- Fragments the heap
+- Increases cache misses
+
+## FLOX's Solution
+
+FLOX eliminates allocations in the hot path through:
+
+1. **Pre-allocated ring buffers** — Events stored directly in `EventBus`
+2. **Object pools** — Reusable event objects for large events
+3. **Reference counting** — Automatic lifetime management without smart pointer overhead
+
+## Small Events: Direct Storage
+
+For small events like `TradeEvent`, the Disruptor stores them directly:
+
+```cpp
+// EventBus internal storage
+std::array<Storage, CapacityPow2> _storage{};
+
+// Publishing: placement new directly into ring buffer
+::new (slot_ptr(idx)) Event(std::forward<Ev>(ev));
+```
+
+No allocation happens — the event is copied into pre-allocated storage.
+
+## Large Events: Object Pools
+
+For large events like `BookUpdateEvent` (contains vectors of bid/ask levels), FLOX uses pools:
+
+```cpp
+// Pool pre-allocates N objects at startup
+pool::Pool<BookUpdateEvent, 128> bookPool;
+
+// Acquire returns a Handle (reference-counted smart pointer)
+auto handle = bookPool.acquire();
+if (handle) {
+  (*handle)->update.symbol = symbolId;
+  (*handle)->update.bids = {...};
+
+  // Publish the handle, not the event
+  bookBus.publish(std::move(handle));
+}
+```
+
+### Pool Design
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                         Pool<T, N>                           │
+├──────────────────────────────────────────────────────────────┤
+│  Pre-allocated slots: [T] [T] [T] [T] [T] [T] ... [T]       │
+│                                                              │
+│  Free queue: → [ptr] → [ptr] → [ptr] →                      │
+│                                                              │
+│  acquire(): pop from free queue, return Handle<T>           │
+│  release(): push back to free queue                         │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Key properties:
+
+- All objects allocated at pool construction
+- `acquire()` is O(1) — pops from lock-free queue
+- `release()` is O(1) — pushes back
+- No heap allocation during operation
+
+### The Handle Class
+
+`pool::Handle<T>` is a reference-counted smart pointer:
+
+```cpp
+template <typename T>
+class Handle {
+  T* _ptr;
+
+  // Copy: increment ref count
+  Handle(const Handle& other) : _ptr(other._ptr) {
+    retain(_ptr);
+  }
+
+  // Move: transfer ownership
+  Handle(Handle&& other) : _ptr(other._ptr) {
+    other._ptr = nullptr;
+  }
+
+  // Destructor: decrement ref count, maybe return to pool
+  ~Handle() {
+    if (_ptr && _ptr->release()) {
+      _ptr->releaseToPool();  // Returns to pool when refcount hits 0
+    }
+  }
+};
+```
+
+Benefits:
+
+- Automatic lifetime management
+- Can be safely copied to multiple consumers
+- Returns to pool when last reference dies
+- No `shared_ptr` overhead (no control block allocation)
+
+### PoolableBase
+
+Events that use pools inherit from `PoolableBase`:
+
+```cpp
+struct BookUpdateEvent : public pool::PoolableBase<BookUpdateEvent> {
+  BookUpdate update;
+
+  void clear() {
+    update.bids.clear();
+    update.asks.clear();
+    // ... reset other fields
+  }
+};
+```
+
+The `clear()` method resets the object for reuse.
+
+## Event Flow with Pools
+
+```mermaid
+sequenceDiagram
+    participant Pool
+    participant Conn as Connector
+    participant Bus as EventBus
+    participant Cons as Consumer
+
+    Note over Pool: Pre-allocated objects
+
+    Conn->>Pool: acquire()
+    Pool-->>Conn: Handle (refcount=1)
+
+    Note over Conn: Populate event data
+
+    Conn->>Bus: publish(move(handle))
+    Note over Bus: refcount=1
+
+    Bus->>Cons: dispatch(handle)
+    Note over Cons: refcount=2 (copied)
+
+    Cons-->>Bus: callback returns
+    Note over Bus: refcount=1
+
+    Bus->>Bus: slot reclaimed
+    Note over Bus: refcount=0
+
+    Bus->>Pool: releaseToPool()
+    Note over Pool: Object ready for reuse
+```
+
+**Text representation:**
+```
+Pool → Connector (acquire) → EventBus (publish) → Consumer (dispatch) → Pool (release)
+```
+
+## PMR (Polymorphic Memory Resources)
+
+For events with variable-size data (like vectors), FLOX uses PMR:
+
+```cpp
+// In Pool constructor
+std::array<std::byte, 128 * 1024> _buffer;         // Stack buffer
+std::pmr::monotonic_buffer_resource _arena;        // Fast bump allocator
+std::pmr::unsynchronized_pool_resource _pool;      // Pool allocator
+```
+
+When `BookUpdateEvent` allocates vectors for bids/asks:
+
+1. Memory comes from the pre-allocated buffer
+2. `monotonic_buffer_resource` provides fast bump-pointer allocation
+3. No system calls, no heap fragmentation
+
+## RefCountable Interface
+
+```cpp
+class RefCountable {
+  std::atomic<uint32_t> _refCount{1};
+
+public:
+  void retain() {
+    _refCount.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  bool release() {
+    return _refCount.fetch_sub(1, std::memory_order_acq_rel) == 1;
+  }
+
+  void resetRefCount() {
+    _refCount.store(1, std::memory_order_relaxed);
+  }
+};
+```
+
+Atomic operations ensure thread safety across bus consumers.
+
+## Best Practices
+
+### Do
+
+```cpp
+// Acquire from pool, move into bus
+if (auto handle = bookPool.acquire()) {
+  (*handle)->update = buildUpdate();
+  bookBus.publish(std::move(handle));
+}
+
+// Handle pool exhaustion
+if (!handle) {
+  // Log warning, skip event, or use fallback
+}
+```
+
+### Don't
+
+```cpp
+// Don't hold handles longer than necessary
+pool::Handle<BookUpdateEvent> cachedHandle;  // Bad: blocks pool slot
+
+// Don't allocate in callbacks
+void onTrade(const TradeEvent& ev) {
+  auto data = std::make_unique<BigData>();  // Bad: allocation in hot path
+}
+
+// Don't store event pointers
+void onBookUpdate(const BookUpdateEvent& ev) {
+  _cachedEvent = &ev;  // Bad: event will be recycled
+}
+```
+
+## Sizing Pools
+
+Pool size = max concurrent uses + headroom:
+
+```cpp
+// If 3 consumers each take ~10ms to process, and events arrive at 1000/sec:
+// In-flight events ≈ 3 consumers × 10ms × 1000/sec = 30
+// Add headroom: 64 or 128
+
+pool::Pool<BookUpdateEvent, 128> bookPool;
+```
+
+Signs your pool is too small:
+
+- `acquire()` returns `nullopt`
+- High latency spikes
+- Dropped events
+
+## Memory Layout
+
+FLOX optimizes for cache efficiency:
+
+```cpp
+// Cache-line aligned atomics
+alignas(64) std::atomic<int64_t> _next{-1};
+
+// Contiguous event storage
+std::array<Storage, CapacityPow2> _storage{};
+```
+
+This ensures:
+
+- No false sharing between atomics
+- Sequential access patterns for events
+- Minimal cache misses
+
+## Summary
+
+| Component | Strategy | Allocation |
+|-----------|----------|------------|
+| `TradeBus` | Direct storage | Zero (ring buffer) |
+| `BookUpdateBus` | Pool + Handle | Zero (pre-allocated) |
+| Small events | Copy into bus | Zero |
+| Large events | Pool acquire/release | Zero (at runtime) |
+| Event vectors | PMR | Zero (from buffer) |
+
+## Next Steps
+
+- [The Disruptor Pattern](disruptor.md) — How the ring buffer works
+- [Optimize Performance](../how-to/optimize-performance.md) — Tune for latency

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,133 @@
+# FLOX
+
+> FLOX is a C++23 high-performance trading framework with first-class bindings for Python, Node.js, Codon, and embedded JavaScript. Use it to build strategies, backtest on historical data, and run live trading from any of these languages — the same C++ core powers all of them, so behavior is identical across runtimes.
+
+Documentation is grouped below by Diátaxis category — pick the section matching the task. The companion `llms-full.txt` contains the full body of every page listed here, in the same order, for agents that prefer one large context dump.
+
+## Overview
+
+- [Project overview](https://flox-foundation.github.io/flox/): What FLOX is and how the pieces fit
+- [Bindings overview](https://flox-foundation.github.io/flox/bindings/): Pick a language: Python, Node, Codon, JavaScript, C
+
+## Bindings (language entry points)
+
+- [Python binding](https://flox-foundation.github.io/flox/bindings/python/): pybind11 module: install, import, lifecycle
+- [Node.js binding](https://flox-foundation.github.io/flox/bindings/node/): NAPI addon: install, require, lifecycle
+- [Codon binding](https://flox-foundation.github.io/flox/bindings/codon/): Codon strategy module and runner
+- [Embedded JavaScript](https://flox-foundation.github.io/flox/bindings/javascript/): QuickJS runner for in-process JS strategies
+- [C API](https://flox-foundation.github.io/flox/bindings/capi/): ABI-stable C surface for FFI from any language
+
+## Quickstart tutorials
+
+- [Tutorials index](https://flox-foundation.github.io/flox/tutorials/): Learning-oriented walkthroughs
+- [Python quickstart](https://flox-foundation.github.io/flox/tutorials/python-quickstart/): First Python strategy in ~10 minutes
+- [Node.js quickstart](https://flox-foundation.github.io/flox/tutorials/node-quickstart/): First Node strategy
+- [Codon quickstart](https://flox-foundation.github.io/flox/tutorials/codon-strategy/): First Codon strategy
+- [C++ quickstart](https://flox-foundation.github.io/flox/tutorials/quickstart/): First C++ strategy
+- [First strategy walkthrough](https://flox-foundation.github.io/flox/tutorials/first-strategy/): End-to-end strategy structure
+- [Multi-timeframe strategy](https://flox-foundation.github.io/flox/tutorials/multi-timeframe-strategy/): Aggregating multiple bar intervals
+- [Recording market data](https://flox-foundation.github.io/flox/tutorials/recording-data/): Capture trades and books for replay
+- [Backtesting tutorial](https://flox-foundation.github.io/flox/tutorials/backtesting/): Replay recorded data through a strategy
+- [Run the demo](https://flox-foundation.github.io/flox/tutorials/demo/): Bundled end-to-end demo
+
+## Working examples
+
+- [Examples index](https://flox-foundation.github.io/flox/examples/): Complete runnable examples
+- [Python: backtest and live](https://flox-foundation.github.io/flox/examples/python-backtest-vs-live/): Same strategy, two runners
+- [Python: multi-symbol](https://flox-foundation.github.io/flox/examples/python-multi-symbol/): Strategy across multiple symbols
+- [Python: live via CCXT](https://flox-foundation.github.io/flox/examples/python-ccxt-live/): CCXT-backed live execution
+- [Node: backtest and live](https://flox-foundation.github.io/flox/examples/node-backtest-vs-live/): Same strategy in Node
+- [Codon: backtest and live](https://flox-foundation.github.io/flox/examples/codon-backtest-vs-live/): Same strategy in Codon
+- [Codon: full backtest API](https://flox-foundation.github.io/flox/examples/codon-full-backtest/): All Codon backtest pieces wired
+- [C++: SMA backtest](https://flox-foundation.github.io/flox/examples/cpp-sma-backtest/): Plain C++ backtest of an SMA crossover
+
+## How-to: strategy and backtest
+
+- [How-to index](https://flox-foundation.github.io/flox/how-to/): Task-oriented recipes
+- [Strategy class shapes](https://flox-foundation.github.io/flox/how-to/strategy-classes/): Strategy, SignalStrategy, when to pick which
+- [Run a backtest](https://flox-foundation.github.io/flox/how-to/backtest/): Replay-driven backtest setup
+- [Realistic fills](https://flox-foundation.github.io/flox/how-to/backtest-realistic-fills/): Slippage and queue simulation
+- [Interactive backtest](https://flox-foundation.github.io/flox/how-to/interactive-backtest/): Step through a backtest
+- [Grid search](https://flox-foundation.github.io/flox/how-to/grid-search/): Parameter sweep with the optimizer
+- [Advanced orders](https://flox-foundation.github.io/flox/how-to/advanced-orders/): Bracket, OCO, and conditional orders
+- [Multi-exchange trading](https://flox-foundation.github.io/flox/how-to/multi-exchange-trading/): Route across venues
+
+## How-to: indicators and aggregation
+
+- [Indicator graph](https://flox-foundation.github.io/flox/how-to/indicator-graph/): Wire indicators into the engine
+- [Multi-symbol indicators](https://flox-foundation.github.io/flox/how-to/multi-symbol-indicators/): Per-symbol state isolation
+- [Bar aggregation](https://flox-foundation.github.io/flox/how-to/bar-aggregation/): Aggregate trades into bars
+- [Custom bar policy](https://flox-foundation.github.io/flox/how-to/custom-bar-policy/): Build your own bar trigger
+- [Volume profile](https://flox-foundation.github.io/flox/how-to/use-volume-profile/): Volume-by-price analysis
+
+## How-to: performance and extension (C++)
+
+- [Optimize performance](https://flox-foundation.github.io/flox/how-to/optimize-performance/): System-level performance guide
+- [CPU affinity](https://flox-foundation.github.io/flox/how-to/cpu-affinity/): Pin threads for latency
+- [Add a new indicator](https://flox-foundation.github.io/flox/how-to/add-an-indicator/): Add an indicator to the C++ registry
+- [Custom connector](https://flox-foundation.github.io/flox/how-to/custom-connector/): Add a new exchange connector
+
+## How-to: project ops
+
+- [Configuration](https://flox-foundation.github.io/flox/how-to/configuration/): Engine and strategy configuration
+- [CI configuration](https://flox-foundation.github.io/flox/how-to/ci/): Continuous integration setup
+- [Contributing](https://flox-foundation.github.io/flox/how-to/contributing/): How to contribute
+
+## Reference: Python
+
+- [Python reference index](https://flox-foundation.github.io/flox/reference/python/): All Python binding modules
+- [Engine and Backtest](https://flox-foundation.github.io/flox/reference/python/engine/): Engine + backtest entry points
+- [Strategy class](https://flox-foundation.github.io/flox/reference/python/strategy/): Base Strategy from Python
+- [Indicators](https://flox-foundation.github.io/flox/reference/python/indicators/): Indicator wrappers
+- [Aggregators](https://flox-foundation.github.io/flox/reference/python/aggregators/): Bar aggregators
+- [Order books](https://flox-foundation.github.io/flox/reference/python/books/): Order book wrappers
+- [Profiles](https://flox-foundation.github.io/flox/reference/python/profiles/): Volume profile, market profile
+- [Positions](https://flox-foundation.github.io/flox/reference/python/positions/): Position tracking
+- [Replay](https://flox-foundation.github.io/flox/reference/python/replay/): Binary log replay
+- [Segment ops](https://flox-foundation.github.io/flox/reference/python/segment_ops/): Segment manipulation
+- [Backtest components](https://flox-foundation.github.io/flox/reference/python/backtest/): Slippage, simulated executor, etc.
+- [Optimizer](https://flox-foundation.github.io/flox/reference/python/optimizer/): Backtest optimizer
+
+## Reference: Node.js
+
+- [Node reference index](https://flox-foundation.github.io/flox/reference/node/): All Node binding modules
+- [Strategy and Runner](https://flox-foundation.github.io/flox/reference/node/strategy/): Base Strategy from Node
+- [Backtest components](https://flox-foundation.github.io/flox/reference/node/backtest/): Backtest pieces
+- [Indicators](https://flox-foundation.github.io/flox/reference/node/indicators/): Indicator wrappers
+- [Bar aggregation](https://flox-foundation.github.io/flox/reference/node/aggregators/): Bar aggregators
+- [Order books](https://flox-foundation.github.io/flox/reference/node/books/): Order book wrappers
+- [Position tracking](https://flox-foundation.github.io/flox/reference/node/positions/): Position trackers
+- [Profiles and stats](https://flox-foundation.github.io/flox/reference/node/profiles/): Volume profile, statistics
+- [Data I/O](https://flox-foundation.github.io/flox/reference/node/data/): Loading and recording data
+
+## Reference: Codon
+
+- [Codon reference index](https://flox-foundation.github.io/flox/reference/codon/): All Codon modules
+- [Strategy](https://flox-foundation.github.io/flox/reference/codon/strategy/): Codon Strategy class
+- [Types](https://flox-foundation.github.io/flox/reference/codon/types/): Core Codon types
+- [Indicators](https://flox-foundation.github.io/flox/reference/codon/indicators/): Codon indicators
+- [Runner and BacktestRunner](https://flox-foundation.github.io/flox/reference/codon/runner/): Codon runners
+- [Backtest components](https://flox-foundation.github.io/flox/reference/codon/backtest/): Codon backtest pieces
+- [Tools](https://flox-foundation.github.io/flox/reference/codon/tools/): Codon tooling
+
+## Reference: embedded JavaScript
+
+- [QuickJS reference index](https://flox-foundation.github.io/flox/reference/quickjs/): All embedded-JS APIs
+- [Strategy](https://flox-foundation.github.io/flox/reference/quickjs/strategy/): JS Strategy
+- [Indicators](https://flox-foundation.github.io/flox/reference/quickjs/indicators/): JS indicators
+- [Tools](https://flox-foundation.github.io/flox/reference/quickjs/tools/): JS tools
+- [Backtest and runtime](https://flox-foundation.github.io/flox/reference/quickjs/backtest/): JS backtest entry points
+
+## Reference: C API
+
+- [C API surface](https://flox-foundation.github.io/flox/reference/api/capi/flox_capi/): ABI-stable C symbols and lifecycle
+
+## Concepts (explanation)
+
+- [Explanation index](https://flox-foundation.github.io/flox/explanation/): Conceptual background
+- [Architecture](https://flox-foundation.github.io/flox/explanation/architecture/): How the engine is structured
+- [Integration flow](https://flox-foundation.github.io/flox/explanation/integration-flow/): Data flow end-to-end
+- [Bar types](https://flox-foundation.github.io/flox/explanation/bar-types/): Time, tick, volume, dollar bars
+- [Indicators concept](https://flox-foundation.github.io/flox/explanation/indicators/): How indicators participate in the graph
+- [Disruptor pattern](https://flox-foundation.github.io/flox/explanation/disruptor/): Single-producer ringbuffer model
+- [Memory model](https://flox-foundation.github.io/flox/explanation/memory-model/): Pools, refcounting, lifetime

--- a/scripts/gen_llms_txt.py
+++ b/scripts/gen_llms_txt.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+scripts/gen_llms_txt.py
+
+Generate `docs/llms.txt` and `docs/llms-full.txt` per the llmstxt.org spec
+so AI agents (Cursor, Claude Code, Cline, etc.) can ground themselves in
+FLOX docs.
+
+`llms.txt` is a short curated map (sections + links). `llms-full.txt` is
+the concatenated body of the same curated set — small enough to fit a
+modern model's context window. Auto-generated C++ core API reference
+(`docs/reference/api/{aggregator,backtest,book,...}`) is intentionally
+excluded: it adds bulk without helping binding users write valid code,
+and C++ extension authors will read the headers anyway.
+
+CI gate: run this before push; if `git diff docs/llms*.txt` is non-empty
+after running, the files are stale.
+
+Usage:
+    python3 scripts/gen_llms_txt.py            # write
+    python3 scripts/gen_llms_txt.py --check    # verify in sync, exit 1 if not
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DOCS = REPO / "docs"
+DOCS_BASE_URL = "https://flox-foundation.github.io/flox"
+
+LLMS_TXT_PATH = DOCS / "llms.txt"
+LLMS_FULL_PATH = DOCS / "llms-full.txt"
+
+PROJECT_SUMMARY = (
+    "FLOX is a C++23 high-performance trading framework with first-class "
+    "bindings for Python, Node.js, Codon, and embedded JavaScript. Use it "
+    "to build strategies, backtest on historical data, and run live trading "
+    "from any of these languages — the same C++ core powers all of them, "
+    "so behavior is identical across runtimes."
+)
+
+# (relative path, link title, short description)
+Entry = tuple[str, str, str]
+
+# Single source of truth: an ordered list of sections, each with entries.
+# llms.txt lists titles+descriptions; llms-full.txt concatenates the bodies
+# in the same order. C++ core API reference is omitted on purpose — see
+# the module docstring.
+SECTIONS: list[tuple[str, list[Entry]]] = [
+    ("Overview", [
+        ("docs/index.md", "Project overview", "What FLOX is and how the pieces fit"),
+        ("docs/bindings/README.md", "Bindings overview", "Pick a language: Python, Node, Codon, JavaScript, C"),
+    ]),
+    ("Bindings (language entry points)", [
+        ("docs/bindings/python.md", "Python binding", "pybind11 module: install, import, lifecycle"),
+        ("docs/bindings/node.md", "Node.js binding", "NAPI addon: install, require, lifecycle"),
+        ("docs/bindings/codon.md", "Codon binding", "Codon strategy module and runner"),
+        ("docs/bindings/javascript.md", "Embedded JavaScript", "QuickJS runner for in-process JS strategies"),
+        ("docs/bindings/capi.md", "C API", "ABI-stable C surface for FFI from any language"),
+    ]),
+    ("Quickstart tutorials", [
+        ("docs/tutorials/README.md", "Tutorials index", "Learning-oriented walkthroughs"),
+        ("docs/tutorials/python-quickstart.md", "Python quickstart", "First Python strategy in ~10 minutes"),
+        ("docs/tutorials/node-quickstart.md", "Node.js quickstart", "First Node strategy"),
+        ("docs/tutorials/codon-strategy.md", "Codon quickstart", "First Codon strategy"),
+        ("docs/tutorials/quickstart.md", "C++ quickstart", "First C++ strategy"),
+        ("docs/tutorials/first-strategy.md", "First strategy walkthrough", "End-to-end strategy structure"),
+        ("docs/tutorials/multi-timeframe-strategy.md", "Multi-timeframe strategy", "Aggregating multiple bar intervals"),
+        ("docs/tutorials/recording-data.md", "Recording market data", "Capture trades and books for replay"),
+        ("docs/tutorials/backtesting.md", "Backtesting tutorial", "Replay recorded data through a strategy"),
+        ("docs/tutorials/demo.md", "Run the demo", "Bundled end-to-end demo"),
+    ]),
+    ("Working examples", [
+        ("docs/examples/index.md", "Examples index", "Complete runnable examples"),
+        ("docs/examples/python-backtest-vs-live.md", "Python: backtest and live", "Same strategy, two runners"),
+        ("docs/examples/python-multi-symbol.md", "Python: multi-symbol", "Strategy across multiple symbols"),
+        ("docs/examples/python-ccxt-live.md", "Python: live via CCXT", "CCXT-backed live execution"),
+        ("docs/examples/node-backtest-vs-live.md", "Node: backtest and live", "Same strategy in Node"),
+        ("docs/examples/codon-backtest-vs-live.md", "Codon: backtest and live", "Same strategy in Codon"),
+        ("docs/examples/codon-full-backtest.md", "Codon: full backtest API", "All Codon backtest pieces wired"),
+        ("docs/examples/cpp-sma-backtest.md", "C++: SMA backtest", "Plain C++ backtest of an SMA crossover"),
+    ]),
+    ("How-to: strategy and backtest", [
+        ("docs/how-to/README.md", "How-to index", "Task-oriented recipes"),
+        ("docs/how-to/strategy-classes.md", "Strategy class shapes", "Strategy, SignalStrategy, when to pick which"),
+        ("docs/how-to/backtest.md", "Run a backtest", "Replay-driven backtest setup"),
+        ("docs/how-to/backtest-realistic-fills.md", "Realistic fills", "Slippage and queue simulation"),
+        ("docs/how-to/interactive-backtest.md", "Interactive backtest", "Step through a backtest"),
+        ("docs/how-to/grid-search.md", "Grid search", "Parameter sweep with the optimizer"),
+        ("docs/how-to/advanced-orders.md", "Advanced orders", "Bracket, OCO, and conditional orders"),
+        ("docs/how-to/multi-exchange-trading.md", "Multi-exchange trading", "Route across venues"),
+    ]),
+    ("How-to: indicators and aggregation", [
+        ("docs/how-to/indicator-graph.md", "Indicator graph", "Wire indicators into the engine"),
+        ("docs/how-to/multi-symbol-indicators.md", "Multi-symbol indicators", "Per-symbol state isolation"),
+        ("docs/how-to/bar-aggregation.md", "Bar aggregation", "Aggregate trades into bars"),
+        ("docs/how-to/custom-bar-policy.md", "Custom bar policy", "Build your own bar trigger"),
+        ("docs/how-to/use-volume-profile.md", "Volume profile", "Volume-by-price analysis"),
+    ]),
+    ("How-to: performance and extension (C++)", [
+        ("docs/how-to/optimize-performance.md", "Optimize performance", "System-level performance guide"),
+        ("docs/how-to/cpu-affinity.md", "CPU affinity", "Pin threads for latency"),
+        ("docs/how-to/add-an-indicator.md", "Add a new indicator", "Add an indicator to the C++ registry"),
+        ("docs/how-to/custom-connector.md", "Custom connector", "Add a new exchange connector"),
+    ]),
+    ("How-to: project ops", [
+        ("docs/how-to/configuration.md", "Configuration", "Engine and strategy configuration"),
+        ("docs/how-to/ci.md", "CI configuration", "Continuous integration setup"),
+        ("docs/how-to/contributing.md", "Contributing", "How to contribute"),
+    ]),
+    ("Reference: Python", [
+        ("docs/reference/python/index.md", "Python reference index", "All Python binding modules"),
+        ("docs/reference/python/engine.md", "Engine and Backtest", "Engine + backtest entry points"),
+        ("docs/reference/python/strategy.md", "Strategy class", "Base Strategy from Python"),
+        ("docs/reference/python/indicators.md", "Indicators", "Indicator wrappers"),
+        ("docs/reference/python/aggregators.md", "Aggregators", "Bar aggregators"),
+        ("docs/reference/python/books.md", "Order books", "Order book wrappers"),
+        ("docs/reference/python/profiles.md", "Profiles", "Volume profile, market profile"),
+        ("docs/reference/python/positions.md", "Positions", "Position tracking"),
+        ("docs/reference/python/replay.md", "Replay", "Binary log replay"),
+        ("docs/reference/python/segment_ops.md", "Segment ops", "Segment manipulation"),
+        ("docs/reference/python/backtest.md", "Backtest components", "Slippage, simulated executor, etc."),
+        ("docs/reference/python/optimizer.md", "Optimizer", "Backtest optimizer"),
+    ]),
+    ("Reference: Node.js", [
+        ("docs/reference/node/index.md", "Node reference index", "All Node binding modules"),
+        ("docs/reference/node/strategy.md", "Strategy and Runner", "Base Strategy from Node"),
+        ("docs/reference/node/backtest.md", "Backtest components", "Backtest pieces"),
+        ("docs/reference/node/indicators.md", "Indicators", "Indicator wrappers"),
+        ("docs/reference/node/aggregators.md", "Bar aggregation", "Bar aggregators"),
+        ("docs/reference/node/books.md", "Order books", "Order book wrappers"),
+        ("docs/reference/node/positions.md", "Position tracking", "Position trackers"),
+        ("docs/reference/node/profiles.md", "Profiles and stats", "Volume profile, statistics"),
+        ("docs/reference/node/data.md", "Data I/O", "Loading and recording data"),
+    ]),
+    ("Reference: Codon", [
+        ("docs/reference/codon/index.md", "Codon reference index", "All Codon modules"),
+        ("docs/reference/codon/strategy.md", "Strategy", "Codon Strategy class"),
+        ("docs/reference/codon/types.md", "Types", "Core Codon types"),
+        ("docs/reference/codon/indicators.md", "Indicators", "Codon indicators"),
+        ("docs/reference/codon/runner.md", "Runner and BacktestRunner", "Codon runners"),
+        ("docs/reference/codon/backtest.md", "Backtest components", "Codon backtest pieces"),
+        ("docs/reference/codon/tools.md", "Tools", "Codon tooling"),
+    ]),
+    ("Reference: embedded JavaScript", [
+        ("docs/reference/quickjs/index.md", "QuickJS reference index", "All embedded-JS APIs"),
+        ("docs/reference/quickjs/strategy.md", "Strategy", "JS Strategy"),
+        ("docs/reference/quickjs/indicators.md", "Indicators", "JS indicators"),
+        ("docs/reference/quickjs/tools.md", "Tools", "JS tools"),
+        ("docs/reference/quickjs/backtest.md", "Backtest and runtime", "JS backtest entry points"),
+    ]),
+    ("Reference: C API", [
+        ("docs/reference/api/capi/flox_capi.md", "C API surface", "ABI-stable C symbols and lifecycle"),
+    ]),
+    ("Concepts (explanation)", [
+        ("docs/explanation/README.md", "Explanation index", "Conceptual background"),
+        ("docs/explanation/architecture.md", "Architecture", "How the engine is structured"),
+        ("docs/explanation/integration-flow.md", "Integration flow", "Data flow end-to-end"),
+        ("docs/explanation/bar-types.md", "Bar types", "Time, tick, volume, dollar bars"),
+        ("docs/explanation/indicators.md", "Indicators concept", "How indicators participate in the graph"),
+        ("docs/explanation/disruptor.md", "Disruptor pattern", "Single-producer ringbuffer model"),
+        ("docs/explanation/memory-model.md", "Memory model", "Pools, refcounting, lifetime"),
+    ]),
+]
+
+
+def page_url(rel_path: str) -> str:
+    """Convert `docs/foo/bar.md` to the deployed mkdocs URL."""
+    p = rel_path.removeprefix("docs/").removesuffix(".md")
+    if p in ("index", "README"):
+        return f"{DOCS_BASE_URL}/"
+    if p.endswith("/README") or p.endswith("/index"):
+        p = p.rsplit("/", 1)[0]
+    return f"{DOCS_BASE_URL}/{p}/"
+
+
+def render_llms_txt() -> str:
+    out: list[str] = []
+    out.append("# FLOX")
+    out.append("")
+    out.append(f"> {PROJECT_SUMMARY}")
+    out.append("")
+    out.append(
+        "Documentation is grouped below by Diátaxis category — pick the "
+        "section matching the task. The companion `llms-full.txt` contains "
+        "the full body of every page listed here, in the same order, for "
+        "agents that prefer one large context dump."
+    )
+    out.append("")
+    for section, entries in SECTIONS:
+        out.append(f"## {section}")
+        out.append("")
+        for path, title, desc in entries:
+            out.append(f"- [{title}]({page_url(path)}): {desc}")
+        out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+def render_llms_full_txt() -> str:
+    out: list[str] = []
+    out.append("# FLOX — full documentation bundle")
+    out.append("")
+    out.append(PROJECT_SUMMARY)
+    out.append("")
+    out.append(
+        "This file concatenates the curated documentation set listed in "
+        "`llms.txt`. Each page is preceded by a `# Source: <path>` header "
+        "and a horizontal rule so an agent can locate the original file."
+    )
+    out.append("")
+    for section, entries in SECTIONS:
+        out.append("=" * 78)
+        out.append(f"# Section: {section}")
+        out.append("=" * 78)
+        out.append("")
+        for path, _title, _desc in entries:
+            file = REPO / path
+            if not file.exists():
+                raise FileNotFoundError(f"Manifest references missing file: {path}")
+            body = file.read_text().rstrip()
+            out.append("-" * 78)
+            out.append(f"# Source: {path}")
+            out.append(f"# URL: {page_url(path)}")
+            out.append("-" * 78)
+            out.append("")
+            out.append(body)
+            out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if existing files differ from generated content.",
+    )
+    args = parser.parse_args()
+
+    new_short = render_llms_txt()
+    new_full = render_llms_full_txt()
+
+    if args.check:
+        ok = True
+        for path, new in ((LLMS_TXT_PATH, new_short), (LLMS_FULL_PATH, new_full)):
+            current = path.read_text() if path.exists() else ""
+            if current != new:
+                print(f"::error::{path.relative_to(REPO)} is out of sync", file=sys.stderr)
+                ok = False
+        if not ok:
+            print("Run: python3 scripts/gen_llms_txt.py", file=sys.stderr)
+            return 1
+        return 0
+
+    LLMS_TXT_PATH.write_text(new_short)
+    LLMS_FULL_PATH.write_text(new_full)
+    print(f"wrote {LLMS_TXT_PATH.relative_to(REPO)} ({len(new_short):,} bytes)")
+    print(f"wrote {LLMS_FULL_PATH.relative_to(REPO)} ({len(new_full):,} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds [llmstxt.org](https://llmstxt.org)-style entry points so Cursor / Claude Code / Cline / ChatGPT can ground themselves in FLOX docs without crawling the site.

- `scripts/gen_llms_txt.py` — single-source manifest, supports `--check`
- `docs/llms.txt` — short curated map (~10 KB)
- `docs/llms-full.txt` — concatenated curated bundle (~450 KB / ~113K tokens, fits Sonnet/Opus 200K context)
- `ci.yml` — `verify-docs-current` now also runs the `--check` sync gate, so PRs that touch curated docs without regenerating fail

## Scope decision

The manifest **excludes** auto-generated C++ core API reference under `docs/reference/api/{aggregator,backtest,book,...}`. Including it would inflate the full bundle to multi-megabyte size for content that:
- adds noise for binding users (they don't write C++)
- is not what C++ extension authors reach for anyway (they read the headers)

Curated set covers: index, all bindings, all tutorials, all examples, all how-to, all explanation, full Python/Node/Codon/QuickJS reference, C API reference.

## Publishing

mkdocs copies `.txt` files in `docs/` to `site/` verbatim — confirmed locally with `mkdocs build`. After this PR merges and `docs.yml` runs, the files will be live at:
- https://flox-foundation.github.io/flox/llms.txt
- https://flox-foundation.github.io/flox/llms-full.txt

## Test plan

- [ ] `python3 scripts/gen_llms_txt.py --check` passes on this branch
- [ ] `verify-docs-current` job is green in CI
- [ ] After merge: both URLs return 200 with the expected content

W2-T001

🤖 Generated with [Claude Code](https://claude.com/claude-code)