### PR TITLE
feat(codegen): emit-codon + emit-llms (T014 emitters)

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -25,18 +25,23 @@ jobs:
           # discovery; ubuntu-latest ships it. clang-format is needed by
           # emit_capi for format-stable output.
 
-      - name: Verify codegen output matches spec
+      - name: Verify all generated artifacts match the spec
         env:
           PYTHONPATH: tools/codegen
         run: |
-          python -m flox_codegen.cli emit-capi \
-            --spec include/flox/capi/flox_capi_spec.hpp \
-            --out /tmp/flox_capi.h
-          if ! diff -u tools/codegen/golden/flox_capi.h /tmp/flox_capi.h; then
-            echo "::error::tools/codegen/golden/flox_capi.h is out of date"
-            echo "Run: bash tools/codegen/scripts/regenerate.sh"
-            exit 1
-          fi
+          set -euo pipefail
+          for pair in "emit-capi:flox_capi.h" "emit-codon:flox_capi.codon" "emit-llms:flox_capi.md"; do
+            sub="${pair%%:*}"
+            file="${pair#*:}"
+            python -m flox_codegen.cli "$sub" \
+              --spec include/flox/capi/flox_capi_spec.hpp \
+              --out "/tmp/$file"
+            if ! diff -u "tools/codegen/golden/$file" "/tmp/$file"; then
+              echo "::error::tools/codegen/golden/$file is out of date"
+              echo "Run: bash tools/codegen/scripts/regenerate.sh"
+              exit 1
+            fi
+          done
 
       - name: Verify full-coverage signature equivalence with live flox_capi.h
         env:

--- a/tools/codegen/README.md
+++ b/tools/codegen/README.md
@@ -1,13 +1,22 @@
 # tools/codegen — IDL-driven code generation for the FLOX C API
 
-Generates `flox_capi.h` and (in a follow-up PR) per-binding stub artifacts
-(`.pyi`, `.d.ts`, Codon, llms.txt) from a single annotated source of truth
-in `include/flox/capi/flox_capi_spec.hpp`.
+Generates `flox_capi.h`, Codon `from C import` declarations, and a Markdown
+C-API reference for AI agents from a single annotated source of truth in
+`include/flox/capi/flox_capi_spec.hpp`.
 
-Status: **full coverage**. Spec covers all 290 functions, 22 handles,
-25 structs, 7 callback typedefs, and 2 enums in the live `flox_capi.h`.
-The CI gate enforces full signature equivalence (`--require-full-coverage`).
-Per-binding emitters land in a follow-up PR.
+Status: **full coverage** + three emitters
+(`emit-capi`, `emit-codon`, `emit-llms`). Spec covers all 290 functions,
+22 handles, 25 structs, 7 callback typedefs, and 2 enums in the live
+`flox_capi.h`. The CI gate enforces full signature equivalence
+(`--require-full-coverage`) and committed-vs-fresh equality across all
+three golden artifacts.
+
+The pybind11 (Python) and NAPI (Node) bindings expose richer
+language-native APIs and are not yet codegen-driven; their stubs
+(`.pyi`, `.d.ts`) still come from binding-side tooling
+(`scripts/gen_pyi_stubs.py`, hand-written `node/index.d.ts`). Codegen
+focuses on FFI consumers that mirror the C surface 1:1 — Codon, QuickJS,
+Rust FFI, Go cgo, Python ctypes.
 
 Design rationale: see `.notes/api-idl-rfc.md`.
 

--- a/tools/codegen/flox_codegen/cli.py
+++ b/tools/codegen/flox_codegen/cli.py
@@ -14,7 +14,7 @@ import json
 import sys
 from pathlib import Path
 
-from . import check_signatures, emit_capi, extractor
+from . import check_signatures, emit_capi, emit_codon, emit_llms, extractor
 
 
 def _cmd_emit_capi(args: argparse.Namespace) -> int:
@@ -34,6 +34,30 @@ def _cmd_emit_capi(args: argparse.Namespace) -> int:
         out.write_text(text)
         print(f"wrote {out} ({len(module.functions)} functions, "
               f"{len(module.handles)} handles, {len(module.structs)} structs)")
+    return 0
+
+
+def _emit_to_path(text: str, out: str, kind: str, count: int) -> None:
+    if out == "-":
+        sys.stdout.write(text)
+    else:
+        out_path = Path(out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(text)
+        print(f"wrote {out_path} ({count} functions, {kind})")
+
+
+def _cmd_emit_codon(args: argparse.Namespace) -> int:
+    module = extractor.parse_spec(Path(args.spec))
+    text = emit_codon.emit(module)
+    _emit_to_path(text, args.out, "codon FFI", len(module.functions))
+    return 0
+
+
+def _cmd_emit_llms(args: argparse.Namespace) -> int:
+    module = extractor.parse_spec(Path(args.spec))
+    text = emit_llms.emit(module)
+    _emit_to_path(text, args.out, "llms reference", len(module.functions))
     return 0
 
 
@@ -109,6 +133,20 @@ def build_parser() -> argparse.ArgumentParser:
     pe.add_argument("--no-format", action="store_true",
                     help="Skip the clang-format post-pass (debugging only).")
     pe.set_defaults(func=_cmd_emit_capi)
+
+    pco = sub.add_parser("emit-codon",
+                         help="Generate Codon `from C import` declarations.")
+    pco.add_argument("--spec", required=True)
+    pco.add_argument("--out", required=True,
+                     help="Output path (use '-' for stdout)")
+    pco.set_defaults(func=_cmd_emit_codon)
+
+    pll = sub.add_parser("emit-llms",
+                         help="Generate Markdown C-API reference for AI agents.")
+    pll.add_argument("--spec", required=True)
+    pll.add_argument("--out", required=True,
+                     help="Output path (use '-' for stdout)")
+    pll.set_defaults(func=_cmd_emit_llms)
 
     pc = sub.add_parser("check", help="Diff signatures across two C headers.")
     pc.add_argument("--expected", required=True,

--- a/tools/codegen/flox_codegen/emit_codon.py
+++ b/tools/codegen/flox_codegen/emit_codon.py
@@ -1,0 +1,148 @@
+"""IR → Codon `from C import ...` stub emitter.
+
+Produces a Codon source file with one `from C import name(args) -> ret` line
+per exported C function. Handles, structs, and function-pointers all collapse
+to `cobj` on the Codon side because Codon FFI doesn't model opaque C types
+beyond the byte level — callers are expected to know the lifecycle.
+
+The generated file is a flat reference: bindings under `codon/flox/*.codon`
+import only the functions they actually use, and may layer richer Codon
+classes on top. This emitter does NOT produce those wrapper classes; it
+only declares the FFI surface so they don't drift from `flox_capi.h`.
+"""
+from __future__ import annotations
+
+import re
+from io import StringIO
+from typing import List
+
+from . import ir
+
+
+# ── Type mapping ─────────────────────────────────────────────────────
+
+# Canonical-form C type → Codon type. Order matters: more specific patterns
+# come first.
+_PRIMITIVE_MAP = {
+    "void": None,  # only valid as return type
+    "uint8_t": "u8",
+    "uint16_t": "u16",
+    "uint32_t": "u32",
+    "uint64_t": "u64",
+    "int8_t": "i8",
+    "int16_t": "i16",
+    "int32_t": "i32",
+    "int64_t": "i64",
+    "size_t": "int",
+    "ssize_t": "int",
+    "double": "float",
+    "float": "float32",
+    "char": "byte",
+    "int": "int",
+    "long": "int",
+    "unsigned int": "u32",
+    "unsigned long": "u64",
+    "_Bool": "bool",
+    "bool": "bool",
+}
+
+# Match a single "*"-ended pointer; the body is the pointee. Keep `const`
+# since pointers to const T have the same Codon representation as T*.
+_POINTER_RE = re.compile(r"^\s*(?:const\s+)?(?P<inner>.*?)\s*\*\s*$")
+
+
+def _strip_consts(s: str) -> str:
+    """Drop `const` qualifiers anywhere in the type spelling.
+
+    Codon's FFI doesn't represent const at all; `const T*` and `T*` are the
+    same Codon shape. This makes type matching independent of where the
+    const sits.
+    """
+    return re.sub(r"\bconst\b", "", s).strip()
+
+
+def map_type(c_type: str, *, is_return: bool = False) -> str:
+    """Map a canonical C type spelling to the Codon FFI type spelling.
+
+    Pointer-to-aggregate / pointer-to-handle → `cobj`. Pointer-to-scalar →
+    `Ptr[T]` where T is the scalar's Codon name. void → empty string in
+    return position, treated as no return type.
+    """
+    # Drop every `const` keyword regardless of position. The remaining
+    # spelling is a const-free type with optional whitespace; we then
+    # collapse runs of whitespace.
+    s = re.sub(r"\s+", " ", _strip_consts(c_type)).strip()
+
+    if s in _PRIMITIVE_MAP:
+        prim = _PRIMITIVE_MAP[s]
+        if prim is None:
+            return ""  # void
+        return prim
+
+    # Strip a single trailing `*` and recurse for the pointee.
+    m = _POINTER_RE.match(s)
+    if m:
+        inner = m.group("inner").strip()
+
+        # `void *` → `cobj`.
+        if inner == "void":
+            return "cobj"
+
+        # `char *` (typically `const char*` after const-stripping) → `cobj` —
+        # matches the existing codon binding convention. Callers pass
+        # `.c_str()` from a Codon str.
+        if inner == "char":
+            return "cobj"
+
+        # Pointer-to-pointer: `const char* const*` collapses to `Ptr[cobj]`.
+        if inner.endswith("*"):
+            inner_codon = map_type(inner)
+            return f"Ptr[{inner_codon}]"
+
+        if inner in _PRIMITIVE_MAP:
+            prim = _PRIMITIVE_MAP[inner]
+            return f"Ptr[{prim}]" if prim is not None else "cobj"
+
+        # Pointer-to-aggregate (struct, opaque handle, callback typedef, etc.).
+        # Codon erases these to `cobj` — the wrapper layer reconstructs typing.
+        return "cobj"
+
+    # Bare aggregate (Flox*Handle, FloxXCallbacks, FloxBar): cobj.
+    if s.startswith("Flox"):
+        return "cobj"
+
+    # Unknown — leave as-is so the developer can patch the emitter.
+    return s
+
+
+def _emit_function(out: StringIO, fn: ir.Function) -> None:
+    arg_types = [map_type(p.type) for p in fn.params]
+    ret = map_type(fn.return_type, is_return=True)
+
+    arg_list = ", ".join(arg_types)
+    if ret:
+        out.write(f"from C import {fn.name}({arg_list}) -> {ret}\n")
+    else:
+        out.write(f"from C import {fn.name}({arg_list})\n")
+
+
+def emit(module: ir.Module) -> str:
+    """Render the IR as a Codon FFI declaration file."""
+    out = StringIO()
+    out.write("# GENERATED — do not edit by hand.\n")
+    out.write("# Source: include/flox/capi/flox_capi_spec.hpp\n")
+    out.write("# Tool:   tools/codegen/flox_codegen/emit_codon.py\n")
+    out.write("#\n")
+    out.write("# Codon `from C import ...` declarations for the FLOX C API.\n")
+    out.write("# Re-exported through `codon/flox/<module>.codon` files; this\n")
+    out.write("# file is the flat reference, not directly imported by user code.\n")
+    out.write("\n")
+
+    grouped = module.functions_by_group()
+    for group_name in sorted(grouped):
+        out.write(f"# ── {group_name} ──\n")
+        for fn in grouped[group_name]:
+            _emit_function(out, fn)
+        out.write("\n")
+
+    return out.getvalue()

--- a/tools/codegen/flox_codegen/emit_llms.py
+++ b/tools/codegen/flox_codegen/emit_llms.py
@@ -1,0 +1,99 @@
+"""IR → llms.txt-style C-API summary for AI agents.
+
+Produces a Markdown file summarizing the FLOX C API surface: handles,
+enums, structs, callback typedefs, and functions grouped by their `group=`
+annotation. Keeps the doc small enough to fit a context window and machine-
+readable enough that an LLM can ground answers about the C API without
+parsing the actual header.
+
+Lives next to the existing `scripts/gen_llms_txt.py` (which curates the
+broader Markdown docs); this emitter focuses specifically on the C API
+surface so AI agents writing code against the C ABI can be authoritative.
+"""
+from __future__ import annotations
+
+from io import StringIO
+from typing import List
+
+from . import ir
+
+
+def _format_function_signature(fn: ir.Function) -> str:
+    """Render `int flox_x(double y, size_t n)` from an IR Function."""
+    if fn.params:
+        param_strs = [
+            (f"{p.type} {p.name}".rstrip() if p.name else p.type)
+            for p in fn.params
+        ]
+    else:
+        param_strs = ["void"]
+    return f"{fn.return_type} {fn.name}({', '.join(param_strs)})"
+
+
+def emit(module: ir.Module) -> str:
+    """Render the IR as a Markdown summary."""
+    out = StringIO()
+    out.write("# FLOX C API Reference\n\n")
+    out.write(
+        "Generated from `include/flox/capi/flox_capi_spec.hpp`. "
+        "Source of truth for FFI consumers (Codon, QuickJS, Rust, Go cgo, "
+        "Python ctypes). The pybind11 (Python) and NAPI (Node) bindings "
+        "wrap this surface but expose richer language-native APIs that "
+        "live in `python/` and `node/` respectively — see those for the "
+        "Python/TS-flavored interfaces.\n\n"
+    )
+
+    grouped = module.functions_by_group()
+    out.write(f"**Surface:** {len(module.functions)} functions, "
+              f"{len(module.handles)} handles, {len(module.structs)} structs, "
+              f"{len(module.function_pointers)} callback typedefs, "
+              f"{len(module.enums)} enums, "
+              f"{len(grouped)} groups.\n\n")
+
+    if module.handles:
+        out.write("## Opaque handles\n\n")
+        out.write("All handles are typedef'd `void*`. Treat them as opaque; "
+                  "manage lifetime via the matching `_create` / `_destroy` "
+                  "pair.\n\n")
+        for h in module.handles:
+            if h.alias_of is None:
+                out.write(f"- `{h.name}`\n")
+            else:
+                out.write(f"- `{h.name}` (alias of `{h.alias_of}`)\n")
+        out.write("\n")
+
+    if module.enums:
+        out.write("## Enums\n\n")
+        for enum in module.enums:
+            out.write(f"### `{enum.name}`\n\n")
+            for v in enum.values:
+                if v.value is not None:
+                    out.write(f"- `{v.name}` = `{v.value}`\n")
+                else:
+                    out.write(f"- `{v.name}`\n")
+            out.write("\n")
+
+    if module.function_pointers:
+        out.write("## Callback typedefs\n\n")
+        for fp in module.function_pointers:
+            params = ", ".join(p.type for p in fp.params) or "void"
+            out.write(f"- `typedef {fp.return_type} (*{fp.name})({params});`\n")
+        out.write("\n")
+
+    if module.structs:
+        out.write("## Structs\n\n")
+        for s in module.structs:
+            out.write(f"### `{s.name}`\n\n")
+            out.write("| field | type |\n|---|---|\n")
+            for f in s.fields:
+                out.write(f"| `{f.name}` | `{f.type}` |\n")
+            out.write("\n")
+
+    out.write("## Functions\n\n")
+    for group_name in sorted(grouped):
+        out.write(f"### {group_name}\n\n")
+        for fn in grouped[group_name]:
+            out.write(f"- `{_format_function_signature(fn)}`\n")
+        out.write("\n")
+
+    return out.getvalue()

--- a/tools/codegen/golden/flox_capi.codon
+++ b/tools/codegen/golden/flox_capi.codon
@@ -1,0 +1,372 @@
+# GENERATED — do not edit by hand.
+# Source: include/flox/capi/flox_capi_spec.hpp
+# Tool:   tools/codegen/flox_codegen/emit_codon.py
+#
+# Codon `from C import ...` declarations for the FLOX C API.
+# Re-exported through `codon/flox/<module>.codon` files; this
+# file is the flat reference, not directly imported by user code.
+
+# ── additional_bar ──
+from C import flox_aggregate_range_bars(Ptr[i64], Ptr[float], Ptr[float], Ptr[u8], int, float, cobj, u32) -> u32
+from C import flox_aggregate_renko_bars(Ptr[i64], Ptr[float], Ptr[float], Ptr[u8], int, float, cobj, u32) -> u32
+
+# ── additional_stats ──
+from C import flox_stat_permutation_test(Ptr[float], int, Ptr[float], int, u32) -> float
+from C import flox_stat_bootstrap_ci(Ptr[float], int, float, u32, Ptr[float], Ptr[float], Ptr[float])
+
+# ── backtest_slippage ──
+from C import flox_executor_set_default_slippage(cobj, i32, i32, float, float, float)
+from C import flox_executor_set_symbol_slippage(cobj, u32, i32, i32, float, float, float)
+from C import flox_executor_set_queue_model(cobj, i32, u32)
+from C import flox_executor_on_trade_qty(cobj, u32, float, float, u8)
+from C import flox_executor_on_best_levels(cobj, u32, float, float, float, float)
+from C import flox_executor_on_book_snapshot(cobj, u32, Ptr[float], Ptr[float], u32, Ptr[float], Ptr[float], u32)
+from C import flox_backtest_result_create(float, float, u8, float, float, float) -> cobj
+from C import flox_backtest_result_destroy(cobj)
+from C import flox_backtest_result_record_fill(cobj, u64, u32, u8, float, float, i64)
+from C import flox_backtest_result_ingest_executor(cobj, cobj)
+from C import flox_backtest_result_stats(cobj, cobj)
+from C import flox_backtest_result_equity_curve(cobj, cobj, u32) -> u32
+from C import flox_backtest_result_write_equity_curve_csv(cobj, cobj) -> u8
+
+# ── backtestrunner_replay ──
+from C import flox_backtest_runner_create(cobj, float, float) -> cobj
+from C import flox_backtest_runner_destroy(cobj)
+from C import flox_backtest_runner_set_strategy(cobj, cobj)
+from C import flox_backtest_runner_run_csv(cobj, cobj, cobj, cobj) -> int
+from C import flox_backtest_runner_run_ohlcv(cobj, Ptr[i64], Ptr[float], u32, cobj, cobj) -> int
+from C import flox_backtest_runner_run_bars(cobj, Ptr[i64], Ptr[i64], Ptr[float], Ptr[float], Ptr[float], Ptr[float], Ptr[float], u32, cobj, u8, u64, cobj) -> int
+
+# ── bar_aggregation ──
+from C import flox_aggregate_time_bars(Ptr[i64], Ptr[float], Ptr[float], Ptr[u8], int, float, cobj, u32) -> u32
+from C import flox_aggregate_tick_bars(Ptr[i64], Ptr[float], Ptr[float], Ptr[u8], int, u32, cobj, u32) -> u32
+from C import flox_aggregate_volume_bars(Ptr[i64], Ptr[float], Ptr[float], Ptr[u8], int, float, cobj, u32) -> u32
+
+# ── composite_book ──
+from C import flox_composite_book_create() -> cobj
+from C import flox_composite_book_destroy(cobj)
+from C import flox_composite_book_best_bid(cobj, u32, Ptr[float], Ptr[float]) -> u8
+from C import flox_composite_book_best_ask(cobj, u32, Ptr[float], Ptr[float]) -> u8
+from C import flox_composite_book_has_arb(cobj, u32) -> u8
+from C import flox_composite_book_mark_stale(cobj, u32, u32)
+from C import flox_composite_book_check_staleness(cobj, i64, i64)
+
+# ── context_queries ──
+from C import flox_position_raw(cobj, u32) -> i64
+from C import flox_last_trade_price_raw(cobj, u32) -> i64
+from C import flox_best_bid_raw(cobj, u32) -> i64
+from C import flox_best_ask_raw(cobj, u32) -> i64
+from C import flox_mid_price_raw(cobj, u32) -> i64
+from C import flox_get_symbol_context(cobj, u32, cobj)
+from C import flox_get_order_status(cobj, u64) -> i32
+
+# ── data_reader ──
+from C import flox_data_reader_create(cobj) -> cobj
+from C import flox_data_reader_destroy(cobj)
+from C import flox_data_reader_count(cobj) -> u64
+
+# ── data_writer ──
+from C import flox_data_writer_create(cobj, u64, u8) -> cobj
+from C import flox_data_writer_destroy(cobj)
+from C import flox_data_writer_write_trade(cobj, i64, i64, float, float, u64, u32, u8) -> u8
+from C import flox_data_writer_flush(cobj)
+from C import flox_data_writer_close(cobj)
+
+# ── datareader ──
+from C import flox_data_reader_create_filtered(cobj, i64, i64, Ptr[u32], u32) -> cobj
+from C import flox_data_reader_summary(cobj) -> cobj
+from C import flox_data_reader_stats(cobj) -> cobj
+from C import flox_data_reader_read_trades(cobj, cobj, u64) -> u64
+from C import flox_data_reader_read_bbo(cobj, cobj, u64) -> u64
+from C import flox_data_reader_count_book_updates(cobj, Ptr[u64]) -> u64
+from C import flox_data_reader_read_book_updates(cobj, cobj, u64, cobj, u64) -> u64
+from C import flox_data_reader_read_trades_from(cobj, i64, cobj, u64) -> u64
+from C import flox_data_reader_read_bbo_from(cobj, i64, cobj, u64) -> u64
+from C import flox_data_reader_count_book_updates_from(cobj, i64, Ptr[u64]) -> u64
+from C import flox_data_reader_read_book_updates_from(cobj, i64, cobj, u64, cobj, u64) -> u64
+
+# ── datarecorder ──
+from C import flox_data_recorder_create(cobj, cobj, u64) -> cobj
+from C import flox_data_recorder_destroy(cobj)
+from C import flox_data_recorder_add_symbol(cobj, u32, cobj, cobj, cobj, i8, i8)
+from C import flox_data_recorder_start(cobj)
+from C import flox_data_recorder_stop(cobj)
+from C import flox_data_recorder_flush(cobj)
+from C import flox_data_recorder_is_recording(cobj) -> u8
+
+# ── datawriter ──
+from C import flox_data_writer_stats(cobj) -> cobj
+
+# ── executor_fill ──
+from C import flox_executor_get_fills(cobj, cobj, u32) -> u32
+
+# ── fixed_point ──
+from C import flox_price_from_double(float) -> i64
+from C import flox_price_to_double(i64) -> float
+from C import flox_quantity_from_double(float) -> i64
+from C import flox_quantity_to_double(i64) -> float
+
+# ── floxliveengine_disruptor ──
+from C import flox_live_engine_create(cobj) -> cobj
+from C import flox_live_engine_destroy(cobj)
+from C import flox_live_engine_add_strategy(cobj, cobj, cobj, cobj)
+from C import flox_live_engine_start(cobj)
+from C import flox_live_engine_stop(cobj)
+from C import flox_live_engine_publish_trade(cobj, u32, float, float, u8, i64)
+from C import flox_live_engine_publish_book_snapshot(cobj, u32, Ptr[float], Ptr[float], u32, Ptr[float], Ptr[float], u32, i64)
+from C import flox_live_engine_publish_bar(cobj, u32, u8, u64, float, float, float, float, float, float, i64, i64, u8)
+
+# ── footprint_bar ──
+from C import flox_footprint_create(float) -> cobj
+from C import flox_footprint_destroy(cobj)
+from C import flox_footprint_add_trade(cobj, float, float, u8)
+from C import flox_footprint_total_delta(cobj) -> float
+from C import flox_footprint_total_volume(cobj) -> float
+from C import flox_footprint_num_levels(cobj) -> u32
+from C import flox_footprint_clear(cobj)
+
+# ── heikin_ashi ──
+from C import flox_aggregate_heikin_ashi_bars(Ptr[i64], Ptr[float], Ptr[float], Ptr[u8], int, float, cobj, u32) -> u32
+
+# ── indicator_functions ──
+from C import flox_indicator_ema(Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_sma(Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_rsi(Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_atr(Ptr[float], Ptr[float], Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_macd(Ptr[float], int, int, int, int, Ptr[float], Ptr[float], Ptr[float])
+from C import flox_indicator_bollinger(Ptr[float], int, int, float, Ptr[float], Ptr[float], Ptr[float])
+from C import flox_indicator_rma(Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_dema(Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_tema(Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_kama(Ptr[float], int, int, int, int, Ptr[float])
+from C import flox_indicator_slope(Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_adx(Ptr[float], Ptr[float], Ptr[float], int, int, Ptr[float], Ptr[float], Ptr[float])
+from C import flox_indicator_cci(Ptr[float], Ptr[float], Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_stochastic(Ptr[float], Ptr[float], Ptr[float], int, int, int, Ptr[float], Ptr[float])
+from C import flox_indicator_chop(Ptr[float], Ptr[float], Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_obv(Ptr[float], Ptr[float], int, Ptr[float])
+from C import flox_indicator_vwap(Ptr[float], Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_cvd(Ptr[float], Ptr[float], Ptr[float], Ptr[float], Ptr[float], int, Ptr[float])
+from C import flox_indicator_skewness(Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_kurtosis(Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_parkinson_vol(Ptr[float], Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_rogers_satchell_vol(Ptr[float], Ptr[float], Ptr[float], Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_rolling_zscore(Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_shannon_entropy(Ptr[float], int, int, int, Ptr[float])
+from C import flox_indicator_correlation(Ptr[float], Ptr[float], int, int, Ptr[float])
+from C import flox_indicator_adf(Ptr[float], int, int, cobj, Ptr[float], Ptr[float], Ptr[int])
+from C import flox_indicator_autocorrelation(Ptr[float], int, int, int, Ptr[float])
+
+# ── indicatorgraph ──
+from C import flox_indicator_graph_create() -> cobj
+from C import flox_indicator_graph_destroy(cobj)
+from C import flox_indicator_graph_set_bars(cobj, u32, Ptr[float], Ptr[float], Ptr[float], Ptr[float], int)
+from C import flox_indicator_graph_add_node(cobj, cobj, Ptr[cobj], int, cobj, cobj)
+from C import flox_indicator_graph_require(cobj, u32, cobj, Ptr[int]) -> Ptr[float]
+from C import flox_indicator_graph_get(cobj, u32, cobj, Ptr[int]) -> Ptr[float]
+from C import flox_indicator_graph_close(cobj, u32, Ptr[int]) -> Ptr[float]
+from C import flox_indicator_graph_high(cobj, u32, Ptr[int]) -> Ptr[float]
+from C import flox_indicator_graph_low(cobj, u32, Ptr[int]) -> Ptr[float]
+from C import flox_indicator_graph_volume(cobj, u32, Ptr[int]) -> Ptr[float]
+from C import flox_indicator_graph_invalidate(cobj, u32)
+from C import flox_indicator_graph_invalidate_all(cobj)
+from C import flox_indicator_graph_step(cobj, u32, float, float, float, float, float)
+from C import flox_indicator_graph_current(cobj, u32, cobj) -> float
+from C import flox_indicator_graph_bar_count(cobj, u32) -> u32
+from C import flox_indicator_graph_reset(cobj, u32)
+from C import flox_indicator_graph_reset_all(cobj)
+from C import flox_streaming_graph_create() -> cobj
+from C import flox_streaming_graph_destroy(cobj)
+from C import flox_streaming_graph_add_node(cobj, cobj, Ptr[cobj], int, cobj, cobj)
+from C import flox_streaming_graph_step(cobj, u32, float, float, float, float, float)
+from C import flox_streaming_graph_current(cobj, u32, cobj) -> float
+from C import flox_streaming_graph_bar_count(cobj, u32) -> u32
+from C import flox_streaming_graph_reset(cobj, u32)
+from C import flox_streaming_graph_reset_all(cobj)
+from C import flox_streaming_graph_close(cobj, u32, Ptr[int]) -> Ptr[float]
+from C import flox_streaming_graph_high(cobj, u32, Ptr[int]) -> Ptr[float]
+from C import flox_streaming_graph_low(cobj, u32, Ptr[int]) -> Ptr[float]
+from C import flox_streaming_graph_volume(cobj, u32, Ptr[int]) -> Ptr[float]
+
+# ── l3_order ──
+from C import flox_l3_book_create() -> cobj
+from C import flox_l3_book_destroy(cobj)
+from C import flox_l3_book_add_order(cobj, u64, float, float, u8) -> i32
+from C import flox_l3_book_remove_order(cobj, u64) -> i32
+from C import flox_l3_book_modify_order(cobj, u64, float) -> i32
+from C import flox_l3_book_best_bid(cobj, Ptr[float]) -> u8
+from C import flox_l3_book_best_ask(cobj, Ptr[float]) -> u8
+from C import flox_l3_book_bid_at_price(cobj, float) -> float
+from C import flox_l3_book_ask_at_price(cobj, float) -> float
+
+# ── market_profile ──
+from C import flox_market_profile_create(float, u32, i64) -> cobj
+from C import flox_market_profile_destroy(cobj)
+from C import flox_market_profile_add_trade(cobj, i64, float, float, u8)
+from C import flox_market_profile_poc(cobj) -> float
+from C import flox_market_profile_vah(cobj) -> float
+from C import flox_market_profile_val(cobj) -> float
+from C import flox_market_profile_ib_high(cobj) -> float
+from C import flox_market_profile_ib_low(cobj) -> float
+from C import flox_market_profile_is_poor_high(cobj) -> u8
+from C import flox_market_profile_is_poor_low(cobj) -> u8
+from C import flox_market_profile_num_levels(cobj) -> u32
+from C import flox_market_profile_clear(cobj)
+
+# ── order_book ──
+from C import flox_book_create(float) -> cobj
+from C import flox_book_destroy(cobj)
+from C import flox_book_apply_snapshot(cobj, Ptr[float], Ptr[float], int, Ptr[float], Ptr[float], int)
+from C import flox_book_apply_delta(cobj, Ptr[float], Ptr[float], int, Ptr[float], Ptr[float], int)
+from C import flox_book_best_bid(cobj, Ptr[float]) -> u8
+from C import flox_book_best_ask(cobj, Ptr[float]) -> u8
+from C import flox_book_mid(cobj, Ptr[float]) -> u8
+from C import flox_book_spread(cobj, Ptr[float]) -> u8
+from C import flox_book_bid_at_price(cobj, float) -> float
+from C import flox_book_ask_at_price(cobj, float) -> float
+from C import flox_book_is_crossed(cobj) -> u8
+from C import flox_book_clear(cobj)
+from C import flox_book_get_bids(cobj, Ptr[float], Ptr[float], u32) -> u32
+from C import flox_book_get_asks(cobj, Ptr[float], Ptr[float], u32) -> u32
+
+# ── order_tracker ──
+from C import flox_order_tracker_create() -> cobj
+from C import flox_order_tracker_destroy(cobj)
+from C import flox_order_tracker_on_submitted(cobj, u64, u32, u8, float, float) -> u8
+from C import flox_order_tracker_on_filled(cobj, u64, float) -> u8
+from C import flox_order_tracker_on_canceled(cobj, u64) -> u8
+from C import flox_order_tracker_is_active(cobj, u64) -> u8
+from C import flox_order_tracker_active_count(cobj) -> u32
+from C import flox_order_tracker_total_count(cobj) -> u32
+from C import flox_order_tracker_prune(cobj)
+
+# ── partitioner ──
+from C import flox_partitioner_create(cobj) -> cobj
+from C import flox_partitioner_destroy(cobj)
+from C import flox_partitioner_by_time(cobj, u32, i64, cobj, u32) -> u32
+from C import flox_partitioner_by_duration(cobj, i64, i64, cobj, u32) -> u32
+from C import flox_partitioner_by_calendar(cobj, u8, i64, cobj, u32) -> u32
+from C import flox_partitioner_by_symbol(cobj, u32, cobj, u32) -> u32
+from C import flox_partitioner_per_symbol(cobj, cobj, u32) -> u32
+from C import flox_partitioner_by_event_count(cobj, u32, cobj, u32) -> u32
+
+# ── pointer_out ──
+from C import flox_data_reader_summary_p(cobj, cobj)
+from C import flox_data_reader_stats_p(cobj, cobj)
+from C import flox_data_writer_stats_p(cobj, cobj)
+from C import flox_segment_merge_full_p(cobj, int, cobj, cobj, u8, cobj)
+from C import flox_segment_merge_dir_p(cobj, cobj, cobj)
+from C import flox_segment_split_p(cobj, cobj, u8, i64, u64, cobj)
+from C import flox_segment_export_p(cobj, cobj, u8, i64, i64, Ptr[u32], u32, cobj)
+from C import flox_segment_validate_full_p(cobj, u8, u8, cobj)
+from C import flox_dataset_validate_p(cobj, cobj)
+
+# ── position ──
+from C import flox_position_tracker_create(u8) -> cobj
+from C import flox_position_tracker_destroy(cobj)
+from C import flox_position_tracker_on_fill(cobj, u32, u8, float, float)
+from C import flox_position_tracker_position(cobj, u32) -> float
+from C import flox_position_tracker_avg_entry(cobj, u32) -> float
+from C import flox_position_tracker_realized_pnl(cobj, u32) -> float
+from C import flox_position_tracker_total_pnl(cobj) -> float
+
+# ── position_group ──
+from C import flox_position_group_create() -> cobj
+from C import flox_position_group_destroy(cobj)
+from C import flox_position_group_open(cobj, u64, u32, u8, float, float) -> u64
+from C import flox_position_group_close(cobj, u64, float)
+from C import flox_position_group_partial_close(cobj, u64, float, float)
+from C import flox_position_group_net_position(cobj, u32) -> float
+from C import flox_position_group_realized_pnl(cobj, u32) -> float
+from C import flox_position_group_total_pnl(cobj) -> float
+from C import flox_position_group_open_count(cobj, u32) -> u32
+from C import flox_position_group_prune(cobj)
+
+# ── segment ──
+from C import flox_segment_validate(cobj) -> u8
+from C import flox_segment_merge(cobj, cobj) -> u8
+from C import flox_segment_merge_full(cobj, int, cobj, cobj, u8) -> cobj
+from C import flox_segment_merge_dir(cobj, cobj) -> cobj
+from C import flox_segment_split(cobj, cobj, u8, i64, u64) -> cobj
+from C import flox_segment_export(cobj, cobj, u8, i64, i64, Ptr[u32], u32) -> cobj
+from C import flox_segment_recompress(cobj, cobj, u8) -> u8
+from C import flox_segment_extract_symbols(cobj, cobj, Ptr[u32], u32) -> u64
+from C import flox_segment_extract_time_range(cobj, cobj, i64, i64) -> u64
+
+# ── signal_emission ──
+from C import flox_emit_market_buy(cobj, u32, i64) -> u64
+from C import flox_emit_market_sell(cobj, u32, i64) -> u64
+from C import flox_emit_limit_buy(cobj, u32, i64, i64) -> u64
+from C import flox_emit_limit_sell(cobj, u32, i64, i64) -> u64
+from C import flox_emit_cancel(cobj, u64)
+from C import flox_emit_cancel_all(cobj, u32)
+from C import flox_emit_modify(cobj, u64, i64, i64)
+from C import flox_emit_stop_market(cobj, u32, u8, i64, i64) -> u64
+from C import flox_emit_stop_limit(cobj, u32, u8, i64, i64, i64) -> u64
+from C import flox_emit_take_profit_market(cobj, u32, u8, i64, i64) -> u64
+from C import flox_emit_trailing_stop(cobj, u32, u8, i64, i64) -> u64
+from C import flox_emit_trailing_stop_percent(cobj, u32, u8, i32, i64) -> u64
+from C import flox_emit_take_profit_limit(cobj, u32, u8, i64, i64, i64) -> u64
+from C import flox_emit_limit_buy_tif(cobj, u32, i64, i64, u8) -> u64
+from C import flox_emit_limit_sell_tif(cobj, u32, i64, i64, u8) -> u64
+from C import flox_emit_close_position(cobj, u32) -> u64
+
+# ── simulated_executor ──
+from C import flox_executor_create() -> cobj
+from C import flox_executor_destroy(cobj)
+from C import flox_executor_submit_order(cobj, u64, u8, float, float, u8, u32)
+from C import flox_executor_cancel_order(cobj, u64)
+from C import flox_executor_cancel_all(cobj, u32)
+from C import flox_executor_on_bar(cobj, u32, float)
+from C import flox_executor_on_trade(cobj, u32, float, u8)
+from C import flox_executor_advance_clock(cobj, i64)
+from C import flox_executor_fill_count(cobj) -> u32
+
+# ── statistics ──
+from C import flox_stat_correlation(Ptr[float], Ptr[float], int) -> float
+from C import flox_stat_profit_factor(Ptr[float], int) -> float
+from C import flox_stat_win_rate(Ptr[float], int) -> float
+
+# ── strategy_lifecycle ──
+from C import flox_strategy_create(u32, Ptr[u32], u32, cobj, cobj) -> cobj
+from C import flox_strategy_destroy(cobj)
+
+# ── strategyrunner_synchronous ──
+from C import flox_runner_create(cobj, cobj, cobj) -> cobj
+from C import flox_runner_destroy(cobj)
+from C import flox_runner_add_strategy(cobj, cobj)
+from C import flox_runner_start(cobj)
+from C import flox_runner_stop(cobj)
+from C import flox_runner_on_trade(cobj, u32, float, float, u8, i64)
+from C import flox_runner_on_book_snapshot(cobj, u32, Ptr[float], Ptr[float], u32, Ptr[float], Ptr[float], u32, i64)
+from C import flox_runner_on_bar(cobj, u32, u8, u64, float, float, float, float, float, float, i64, i64, u8)
+
+# ── symbol_registry ──
+from C import flox_registry_create() -> cobj
+from C import flox_registry_destroy(cobj)
+from C import flox_registry_add_symbol(cobj, cobj, cobj, float) -> u32
+from C import flox_registry_get_symbol_id(cobj, cobj, cobj, Ptr[u32]) -> u8
+from C import flox_registry_get_symbol_name(cobj, u32, cobj, int, cobj, int) -> u8
+from C import flox_registry_symbol_count(cobj) -> u32
+
+# ── targets ──
+from C import flox_target_future_return(Ptr[float], int, int, Ptr[float])
+from C import flox_target_future_ctc_volatility(Ptr[float], int, int, Ptr[float])
+from C import flox_target_future_linear_slope(Ptr[float], int, int, Ptr[float])
+
+# ── validation ──
+from C import flox_segment_validate_full(cobj, u8, u8) -> cobj
+from C import flox_dataset_validate(cobj) -> cobj
+
+# ── volume_profile ──
+from C import flox_volume_profile_create(float) -> cobj
+from C import flox_volume_profile_destroy(cobj)
+from C import flox_volume_profile_add_trade(cobj, float, float, u8)
+from C import flox_volume_profile_poc(cobj) -> float
+from C import flox_volume_profile_vah(cobj) -> float
+from C import flox_volume_profile_val(cobj) -> float
+from C import flox_volume_profile_total_volume(cobj) -> float
+from C import flox_volume_profile_total_delta(cobj) -> float
+from C import flox_volume_profile_num_levels(cobj) -> u32
+from C import flox_volume_profile_clear(cobj)
+

--- a/tools/codegen/golden/flox_capi.md
+++ b/tools/codegen/golden/flox_capi.md
@@ -1,0 +1,765 @@
+# FLOX C API Reference
+
+Generated from `include/flox/capi/flox_capi_spec.hpp`. Source of truth for FFI consumers (Codon, QuickJS, Rust, Go cgo, Python ctypes). The pybind11 (Python) and NAPI (Node) bindings wrap this surface but expose richer language-native APIs that live in `python/` and `node/` respectively — see those for the Python/TS-flavored interfaces.
+
+**Surface:** 290 functions, 22 handles, 25 structs, 7 callback typedefs, 2 enums, 37 groups.
+
+## Opaque handles
+
+All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the matching `_create` / `_destroy` pair.
+
+- `FloxStrategyHandle`
+- `FloxRegistryHandle`
+- `FloxBookHandle`
+- `FloxExecutorHandle`
+- `FloxPositionTrackerHandle`
+- `FloxPositionGroupHandle`
+- `FloxOrderTrackerHandle`
+- `FloxFootprintHandle`
+- `FloxVolumeProfileHandle`
+- `FloxMarketProfileHandle`
+- `FloxCompositeBookHandle`
+- `FloxIndicatorGraphHandle`
+- `FloxStreamingGraphHandle` (alias of `FloxIndicatorGraphHandle`)
+- `FloxL3BookHandle`
+- `FloxDataWriterHandle`
+- `FloxDataReaderHandle`
+- `FloxBacktestResultHandle`
+- `FloxDataRecorderHandle`
+- `FloxPartitionerHandle`
+- `FloxLiveEngineHandle`
+- `FloxRunnerHandle`
+- `FloxBacktestRunnerHandle`
+
+## Enums
+
+### `FloxSlippageModel`
+
+- `FLOX_SLIPPAGE_NONE` = `0`
+- `FLOX_SLIPPAGE_FIXED_TICKS` = `1`
+- `FLOX_SLIPPAGE_FIXED_BPS` = `2`
+- `FLOX_SLIPPAGE_VOLUME_IMPACT` = `3`
+
+### `FloxQueueModel`
+
+- `FLOX_QUEUE_NONE` = `0`
+- `FLOX_QUEUE_TOB` = `1`
+- `FLOX_QUEUE_FULL` = `2`
+
+## Callback typedefs
+
+- `typedef void (*FloxOnTradeCallback)(void *, const FloxSymbolContext *, const FloxTradeData *);`
+- `typedef void (*FloxOnBookCallback)(void *, const FloxSymbolContext *, const FloxBookData *);`
+- `typedef void (*FloxOnBarCallback)(void *, const FloxSymbolContext *, const FloxBarData *);`
+- `typedef void (*FloxOnStartCallback)(void *);`
+- `typedef void (*FloxOnStopCallback)(void *);`
+- `typedef const double * (*FloxGraphNodeFn)(void *, FloxIndicatorGraphHandle, uint32_t, size_t *);`
+- `typedef void (*FloxOnSignalCallback)(void *, const FloxSignal *);`
+
+## Structs
+
+### `FloxTradeData`
+
+| field | type |
+|---|---|
+| `symbol` | `uint32_t` |
+| `price_raw` | `int64_t` |
+| `quantity_raw` | `int64_t` |
+| `is_buy` | `uint8_t` |
+| `exchange_ts_ns` | `int64_t` |
+
+### `FloxBookLevel`
+
+| field | type |
+|---|---|
+| `price_raw` | `int64_t` |
+| `quantity_raw` | `int64_t` |
+
+### `FloxBookSnapshot`
+
+| field | type |
+|---|---|
+| `bid_price_raw` | `int64_t` |
+| `bid_qty_raw` | `int64_t` |
+| `ask_price_raw` | `int64_t` |
+| `ask_qty_raw` | `int64_t` |
+| `mid_raw` | `int64_t` |
+| `spread_raw` | `int64_t` |
+
+### `FloxBookData`
+
+| field | type |
+|---|---|
+| `symbol` | `uint32_t` |
+| `exchange_ts_ns` | `int64_t` |
+| `snapshot` | `FloxBookSnapshot` |
+
+### `FloxBarData`
+
+| field | type |
+|---|---|
+| `symbol` | `uint32_t` |
+| `bar_type` | `uint8_t` |
+| `close_reason` | `uint8_t` |
+| `_pad` | `uint8_t[2]` |
+| `bar_type_param` | `uint64_t` |
+| `open_raw` | `int64_t` |
+| `high_raw` | `int64_t` |
+| `low_raw` | `int64_t` |
+| `close_raw` | `int64_t` |
+| `volume_raw` | `int64_t` |
+| `buy_volume_raw` | `int64_t` |
+| `trade_count_raw` | `int64_t` |
+| `start_time_ns` | `int64_t` |
+| `end_time_ns` | `int64_t` |
+
+### `FloxSymbolContext`
+
+| field | type |
+|---|---|
+| `symbol_id` | `uint32_t` |
+| `position_raw` | `int64_t` |
+| `avg_entry_price_raw` | `int64_t` |
+| `last_trade_price_raw` | `int64_t` |
+| `last_update_ns` | `int64_t` |
+| `book` | `FloxBookSnapshot` |
+
+### `FloxStrategyCallbacks`
+
+| field | type |
+|---|---|
+| `on_trade` | `FloxOnTradeCallback` |
+| `on_book` | `FloxOnBookCallback` |
+| `on_bar` | `FloxOnBarCallback` |
+| `on_start` | `FloxOnStartCallback` |
+| `on_stop` | `FloxOnStopCallback` |
+| `user_data` | `void *` |
+
+### `FloxBar`
+
+| field | type |
+|---|---|
+| `start_time_ns` | `int64_t` |
+| `end_time_ns` | `int64_t` |
+| `open_raw` | `int64_t` |
+| `high_raw` | `int64_t` |
+| `low_raw` | `int64_t` |
+| `close_raw` | `int64_t` |
+| `volume_raw` | `int64_t` |
+| `buy_volume_raw` | `int64_t` |
+| `trade_count` | `uint32_t` |
+
+### `FloxFill`
+
+| field | type |
+|---|---|
+| `order_id` | `uint64_t` |
+| `symbol` | `uint32_t` |
+| `side` | `uint8_t` |
+| `price_raw` | `int64_t` |
+| `quantity_raw` | `int64_t` |
+| `timestamp_ns` | `int64_t` |
+
+### `FloxBacktestStats`
+
+| field | type |
+|---|---|
+| `totalTrades` | `uint64_t` |
+| `winningTrades` | `uint64_t` |
+| `losingTrades` | `uint64_t` |
+| `maxConsecutiveWins` | `uint64_t` |
+| `maxConsecutiveLosses` | `uint64_t` |
+| `initialCapital` | `double` |
+| `finalCapital` | `double` |
+| `totalPnl` | `double` |
+| `totalFees` | `double` |
+| `netPnl` | `double` |
+| `grossProfit` | `double` |
+| `grossLoss` | `double` |
+| `maxDrawdown` | `double` |
+| `maxDrawdownPct` | `double` |
+| `winRate` | `double` |
+| `profitFactor` | `double` |
+| `avgWin` | `double` |
+| `avgLoss` | `double` |
+| `avgWinLossRatio` | `double` |
+| `avgTradeDurationNs` | `double` |
+| `medianTradeDurationNs` | `double` |
+| `maxTradeDurationNs` | `double` |
+| `sharpeRatio` | `double` |
+| `sortinoRatio` | `double` |
+| `calmarRatio` | `double` |
+| `timeWeightedReturn` | `double` |
+| `returnPct` | `double` |
+| `startTimeNs` | `int64_t` |
+| `endTimeNs` | `int64_t` |
+
+### `FloxEquityPoint`
+
+| field | type |
+|---|---|
+| `timestamp_ns` | `int64_t` |
+| `equity` | `double` |
+| `drawdown_pct` | `double` |
+
+### `FloxMergeResult`
+
+| field | type |
+|---|---|
+| `success` | `uint8_t` |
+| `segments_merged` | `uint64_t` |
+| `events_written` | `uint64_t` |
+| `bytes_written` | `uint64_t` |
+
+### `FloxSplitResult`
+
+| field | type |
+|---|---|
+| `success` | `uint8_t` |
+| `segments_created` | `uint32_t` |
+| `events_written` | `uint64_t` |
+
+### `FloxExportResult`
+
+| field | type |
+|---|---|
+| `success` | `uint8_t` |
+| `events_exported` | `uint64_t` |
+| `bytes_written` | `uint64_t` |
+
+### `FloxSegmentValidation`
+
+| field | type |
+|---|---|
+| `valid` | `uint8_t` |
+| `header_valid` | `uint8_t` |
+| `reported_event_count` | `uint64_t` |
+| `actual_event_count` | `uint64_t` |
+| `has_index` | `uint8_t` |
+| `index_valid` | `uint8_t` |
+| `trades_found` | `uint64_t` |
+| `book_updates_found` | `uint64_t` |
+| `crc_errors` | `uint32_t` |
+| `timestamp_anomalies` | `uint32_t` |
+
+### `FloxDatasetValidation`
+
+| field | type |
+|---|---|
+| `valid` | `uint8_t` |
+| `total_segments` | `uint32_t` |
+| `valid_segments` | `uint32_t` |
+| `corrupted_segments` | `uint32_t` |
+| `total_events` | `uint64_t` |
+| `total_bytes` | `uint64_t` |
+| `first_timestamp` | `int64_t` |
+| `last_timestamp` | `int64_t` |
+
+### `FloxDatasetSummary`
+
+| field | type |
+|---|---|
+| `first_event_ns` | `int64_t` |
+| `last_event_ns` | `int64_t` |
+| `total_events` | `uint64_t` |
+| `segment_count` | `uint32_t` |
+| `total_bytes` | `uint64_t` |
+| `duration_seconds` | `double` |
+
+### `FloxReaderStats`
+
+| field | type |
+|---|---|
+| `files_read` | `uint64_t` |
+| `events_read` | `uint64_t` |
+| `trades_read` | `uint64_t` |
+| `book_updates_read` | `uint64_t` |
+| `bytes_read` | `uint64_t` |
+| `crc_errors` | `uint64_t` |
+
+### `FloxTradeRecord`
+
+| field | type |
+|---|---|
+| `exchange_ts_ns` | `int64_t` |
+| `recv_ts_ns` | `int64_t` |
+| `price_raw` | `int64_t` |
+| `qty_raw` | `int64_t` |
+| `trade_id` | `uint64_t` |
+| `symbol_id` | `uint32_t` |
+| `side` | `uint8_t` |
+
+### `FloxBBO`
+
+| field | type |
+|---|---|
+| `exchange_ts_ns` | `int64_t` |
+| `recv_ts_ns` | `int64_t` |
+| `seq` | `int64_t` |
+| `bid_price_raw` | `int64_t` |
+| `bid_qty_raw` | `int64_t` |
+| `ask_price_raw` | `int64_t` |
+| `ask_qty_raw` | `int64_t` |
+| `symbol_id` | `uint32_t` |
+| `event_type` | `uint8_t` |
+
+### `FloxBookUpdateHeader`
+
+| field | type |
+|---|---|
+| `exchange_ts_ns` | `int64_t` |
+| `recv_ts_ns` | `int64_t` |
+| `seq` | `int64_t` |
+| `level_offset` | `uint64_t` |
+| `symbol_id` | `uint32_t` |
+| `bid_count` | `uint16_t` |
+| `ask_count` | `uint16_t` |
+| `event_type` | `uint8_t` |
+
+### `FloxLevel`
+
+| field | type |
+|---|---|
+| `price_raw` | `int64_t` |
+| `qty_raw` | `int64_t` |
+| `side` | `uint8_t` |
+
+### `FloxWriterStats`
+
+| field | type |
+|---|---|
+| `bytes_written` | `uint64_t` |
+| `events_written` | `uint64_t` |
+| `segments_created` | `uint64_t` |
+| `trades_written` | `uint64_t` |
+
+### `FloxPartition`
+
+| field | type |
+|---|---|
+| `partition_id` | `uint32_t` |
+| `from_ns` | `int64_t` |
+| `to_ns` | `int64_t` |
+| `warmup_from_ns` | `int64_t` |
+| `estimated_events` | `uint64_t` |
+| `estimated_bytes` | `uint64_t` |
+
+### `FloxSignal`
+
+| field | type |
+|---|---|
+| `order_id` | `uint64_t` |
+| `symbol` | `uint32_t` |
+| `side` | `uint8_t` |
+| `order_type` | `uint8_t` |
+| `price` | `double` |
+| `quantity` | `double` |
+| `trigger_price` | `double` |
+| `trailing_offset` | `double` |
+| `trailing_bps` | `int32_t` |
+| `new_price` | `double` |
+| `new_quantity` | `double` |
+
+## Functions
+
+### additional_bar
+
+- `uint32_t flox_aggregate_range_bars(const int64_t * timestamps, const double * prices, const double * quantities, const uint8_t * is_buy, size_t len, double range_size, FloxBar * bars_out, uint32_t max_bars)`
+- `uint32_t flox_aggregate_renko_bars(const int64_t * timestamps, const double * prices, const double * quantities, const uint8_t * is_buy, size_t len, double brick_size, FloxBar * bars_out, uint32_t max_bars)`
+
+### additional_stats
+
+- `double flox_stat_permutation_test(const double * group1, size_t len1, const double * group2, size_t len2, uint32_t num_permutations)`
+- `void flox_stat_bootstrap_ci(const double * data, size_t len, double confidence, uint32_t num_samples, double * lower_out, double * median_out, double * upper_out)`
+
+### backtest_slippage
+
+- `void flox_executor_set_default_slippage(FloxExecutorHandle executor, int32_t model, int32_t ticks, double tick_size, double bps, double impact_coeff)`
+- `void flox_executor_set_symbol_slippage(FloxExecutorHandle executor, uint32_t symbol, int32_t model, int32_t ticks, double tick_size, double bps, double impact_coeff)`
+- `void flox_executor_set_queue_model(FloxExecutorHandle executor, int32_t model, uint32_t depth)`
+- `void flox_executor_on_trade_qty(FloxExecutorHandle executor, uint32_t symbol, double price, double quantity, uint8_t is_buy)`
+- `void flox_executor_on_best_levels(FloxExecutorHandle executor, uint32_t symbol, double bid_price, double bid_qty, double ask_price, double ask_qty)`
+- `void flox_executor_on_book_snapshot(FloxExecutorHandle executor, uint32_t symbol, const double * bid_prices, const double * bid_qtys, uint32_t n_bids, const double * ask_prices, const double * ask_qtys, uint32_t n_asks)`
+- `FloxBacktestResultHandle flox_backtest_result_create(double initial_capital, double fee_rate, uint8_t use_percentage_fee, double fixed_fee_per_trade, double risk_free_rate, double annualization_factor)`
+- `void flox_backtest_result_destroy(FloxBacktestResultHandle result)`
+- `void flox_backtest_result_record_fill(FloxBacktestResultHandle result, uint64_t order_id, uint32_t symbol, uint8_t side, double price, double quantity, int64_t timestamp_ns)`
+- `void flox_backtest_result_ingest_executor(FloxBacktestResultHandle result, FloxExecutorHandle executor)`
+- `void flox_backtest_result_stats(FloxBacktestResultHandle result, FloxBacktestStats * out)`
+- `uint32_t flox_backtest_result_equity_curve(FloxBacktestResultHandle result, FloxEquityPoint * points_out, uint32_t max_points)`
+- `uint8_t flox_backtest_result_write_equity_curve_csv(FloxBacktestResultHandle result, const char * path)`
+
+### backtestrunner_replay
+
+- `FloxBacktestRunnerHandle flox_backtest_runner_create(FloxRegistryHandle registry, double fee_rate, double initial_capital)`
+- `void flox_backtest_runner_destroy(FloxBacktestRunnerHandle runner)`
+- `void flox_backtest_runner_set_strategy(FloxBacktestRunnerHandle runner, FloxStrategyHandle strategy)`
+- `int flox_backtest_runner_run_csv(FloxBacktestRunnerHandle runner, const char * path, const char * symbol, FloxBacktestStats * stats_out)`
+- `int flox_backtest_runner_run_ohlcv(FloxBacktestRunnerHandle runner, const int64_t * timestamps_ns, const double * close_prices, uint32_t n, const char * symbol, FloxBacktestStats * stats_out)`
+- `int flox_backtest_runner_run_bars(FloxBacktestRunnerHandle runner, const int64_t * start_time_ns, const int64_t * end_time_ns, const double * open, const double * high, const double * low, const double * close, const double * volume, uint32_t n, const char * symbol, uint8_t bar_type, uint64_t bar_type_param, FloxBacktestStats * stats_out)`
+
+### bar_aggregation
+
+- `uint32_t flox_aggregate_time_bars(const int64_t * timestamps, const double * prices, const double * quantities, const uint8_t * is_buy, size_t len, double interval_seconds, FloxBar * bars_out, uint32_t max_bars)`
+- `uint32_t flox_aggregate_tick_bars(const int64_t * timestamps, const double * prices, const double * quantities, const uint8_t * is_buy, size_t len, uint32_t tick_count, FloxBar * bars_out, uint32_t max_bars)`
+- `uint32_t flox_aggregate_volume_bars(const int64_t * timestamps, const double * prices, const double * quantities, const uint8_t * is_buy, size_t len, double volume_threshold, FloxBar * bars_out, uint32_t max_bars)`
+
+### composite_book
+
+- `FloxCompositeBookHandle flox_composite_book_create(void)`
+- `void flox_composite_book_destroy(FloxCompositeBookHandle book)`
+- `uint8_t flox_composite_book_best_bid(FloxCompositeBookHandle book, uint32_t symbol, double * price_out, double * qty_out)`
+- `uint8_t flox_composite_book_best_ask(FloxCompositeBookHandle book, uint32_t symbol, double * price_out, double * qty_out)`
+- `uint8_t flox_composite_book_has_arb(FloxCompositeBookHandle book, uint32_t symbol)`
+- `void flox_composite_book_mark_stale(FloxCompositeBookHandle book, uint32_t exchange, uint32_t symbol)`
+- `void flox_composite_book_check_staleness(FloxCompositeBookHandle book, int64_t now_ns, int64_t threshold_ns)`
+
+### context_queries
+
+- `int64_t flox_position_raw(FloxStrategyHandle s, uint32_t symbol)`
+- `int64_t flox_last_trade_price_raw(FloxStrategyHandle s, uint32_t symbol)`
+- `int64_t flox_best_bid_raw(FloxStrategyHandle s, uint32_t symbol)`
+- `int64_t flox_best_ask_raw(FloxStrategyHandle s, uint32_t symbol)`
+- `int64_t flox_mid_price_raw(FloxStrategyHandle s, uint32_t symbol)`
+- `void flox_get_symbol_context(FloxStrategyHandle s, uint32_t symbol, FloxSymbolContext * out)`
+- `int32_t flox_get_order_status(FloxStrategyHandle s, uint64_t order_id)`
+
+### data_reader
+
+- `FloxDataReaderHandle flox_data_reader_create(const char * data_dir)`
+- `void flox_data_reader_destroy(FloxDataReaderHandle reader)`
+- `uint64_t flox_data_reader_count(FloxDataReaderHandle reader)`
+
+### data_writer
+
+- `FloxDataWriterHandle flox_data_writer_create(const char * output_dir, uint64_t max_segment_mb, uint8_t exchange_id)`
+- `void flox_data_writer_destroy(FloxDataWriterHandle writer)`
+- `uint8_t flox_data_writer_write_trade(FloxDataWriterHandle writer, int64_t exchange_ts_ns, int64_t recv_ts_ns, double price, double qty, uint64_t trade_id, uint32_t symbol_id, uint8_t side)`
+- `void flox_data_writer_flush(FloxDataWriterHandle writer)`
+- `void flox_data_writer_close(FloxDataWriterHandle writer)`
+
+### datareader
+
+- `FloxDataReaderHandle flox_data_reader_create_filtered(const char * data_dir, int64_t from_ns, int64_t to_ns, const uint32_t * symbols, uint32_t num_symbols)`
+- `FloxDatasetSummary flox_data_reader_summary(FloxDataReaderHandle reader)`
+- `FloxReaderStats flox_data_reader_stats(FloxDataReaderHandle reader)`
+- `uint64_t flox_data_reader_read_trades(FloxDataReaderHandle reader, FloxTradeRecord * trades_out, uint64_t max_trades)`
+- `uint64_t flox_data_reader_read_bbo(FloxDataReaderHandle reader, FloxBBO * bbos_out, uint64_t max_events)`
+- `uint64_t flox_data_reader_count_book_updates(FloxDataReaderHandle reader, uint64_t * total_levels_out)`
+- `uint64_t flox_data_reader_read_book_updates(FloxDataReaderHandle reader, FloxBookUpdateHeader * headers_out, uint64_t max_events, FloxLevel * levels_out, uint64_t max_levels)`
+- `uint64_t flox_data_reader_read_trades_from(FloxDataReaderHandle reader, int64_t start_ts_ns, FloxTradeRecord * trades_out, uint64_t max_trades)`
+- `uint64_t flox_data_reader_read_bbo_from(FloxDataReaderHandle reader, int64_t start_ts_ns, FloxBBO * bbos_out, uint64_t max_events)`
+- `uint64_t flox_data_reader_count_book_updates_from(FloxDataReaderHandle reader, int64_t start_ts_ns, uint64_t * total_levels_out)`
+- `uint64_t flox_data_reader_read_book_updates_from(FloxDataReaderHandle reader, int64_t start_ts_ns, FloxBookUpdateHeader * headers_out, uint64_t max_events, FloxLevel * levels_out, uint64_t max_levels)`
+
+### datarecorder
+
+- `FloxDataRecorderHandle flox_data_recorder_create(const char * output_dir, const char * exchange_name, uint64_t max_segment_mb)`
+- `void flox_data_recorder_destroy(FloxDataRecorderHandle recorder)`
+- `void flox_data_recorder_add_symbol(FloxDataRecorderHandle recorder, uint32_t symbol_id, const char * name, const char * base, const char * quote, int8_t price_precision, int8_t qty_precision)`
+- `void flox_data_recorder_start(FloxDataRecorderHandle recorder)`
+- `void flox_data_recorder_stop(FloxDataRecorderHandle recorder)`
+- `void flox_data_recorder_flush(FloxDataRecorderHandle recorder)`
+- `uint8_t flox_data_recorder_is_recording(FloxDataRecorderHandle recorder)`
+
+### datawriter
+
+- `FloxWriterStats flox_data_writer_stats(FloxDataWriterHandle writer)`
+
+### executor_fill
+
+- `uint32_t flox_executor_get_fills(FloxExecutorHandle executor, FloxFill * fills_out, uint32_t max_fills)`
+
+### fixed_point
+
+- `int64_t flox_price_from_double(double value)`
+- `double flox_price_to_double(int64_t raw)`
+- `int64_t flox_quantity_from_double(double value)`
+- `double flox_quantity_to_double(int64_t raw)`
+
+### floxliveengine_disruptor
+
+- `FloxLiveEngineHandle flox_live_engine_create(FloxRegistryHandle registry)`
+- `void flox_live_engine_destroy(FloxLiveEngineHandle engine)`
+- `void flox_live_engine_add_strategy(FloxLiveEngineHandle engine, FloxStrategyHandle strategy, FloxOnSignalCallback on_signal, void * user_data)`
+- `void flox_live_engine_start(FloxLiveEngineHandle engine)`
+- `void flox_live_engine_stop(FloxLiveEngineHandle engine)`
+- `void flox_live_engine_publish_trade(FloxLiveEngineHandle engine, uint32_t symbol, double price, double qty, uint8_t is_buy, int64_t exchange_ts_ns)`
+- `void flox_live_engine_publish_book_snapshot(FloxLiveEngineHandle engine, uint32_t symbol, const double * bid_prices, const double * bid_qtys, uint32_t n_bids, const double * ask_prices, const double * ask_qtys, uint32_t n_asks, int64_t exchange_ts_ns)`
+- `void flox_live_engine_publish_bar(FloxLiveEngineHandle engine, uint32_t symbol, uint8_t bar_type, uint64_t bar_type_param, double open, double high, double low, double close, double volume, double buy_volume, int64_t start_time_ns, int64_t end_time_ns, uint8_t close_reason)`
+
+### footprint_bar
+
+- `FloxFootprintHandle flox_footprint_create(double tick_size)`
+- `void flox_footprint_destroy(FloxFootprintHandle footprint)`
+- `void flox_footprint_add_trade(FloxFootprintHandle footprint, double price, double quantity, uint8_t is_buy)`
+- `double flox_footprint_total_delta(FloxFootprintHandle footprint)`
+- `double flox_footprint_total_volume(FloxFootprintHandle footprint)`
+- `uint32_t flox_footprint_num_levels(FloxFootprintHandle footprint)`
+- `void flox_footprint_clear(FloxFootprintHandle footprint)`
+
+### heikin_ashi
+
+- `uint32_t flox_aggregate_heikin_ashi_bars(const int64_t * timestamps, const double * prices, const double * quantities, const uint8_t * is_buy, size_t len, double interval_seconds, FloxBar * bars_out, uint32_t max_bars)`
+
+### indicator_functions
+
+- `void flox_indicator_ema(const double * input, size_t len, size_t period, double * output)`
+- `void flox_indicator_sma(const double * input, size_t len, size_t period, double * output)`
+- `void flox_indicator_rsi(const double * input, size_t len, size_t period, double * output)`
+- `void flox_indicator_atr(const double * high, const double * low, const double * close, size_t len, size_t period, double * output)`
+- `void flox_indicator_macd(const double * input, size_t len, size_t fast_period, size_t slow_period, size_t signal_period, double * macd_out, double * signal_out, double * hist_out)`
+- `void flox_indicator_bollinger(const double * input, size_t len, size_t period, double multiplier, double * upper, double * middle, double * lower)`
+- `void flox_indicator_rma(const double * input, size_t len, size_t period, double * output)`
+- `void flox_indicator_dema(const double * input, size_t len, size_t period, double * output)`
+- `void flox_indicator_tema(const double * input, size_t len, size_t period, double * output)`
+- `void flox_indicator_kama(const double * input, size_t len, size_t period, size_t fast, size_t slow, double * output)`
+- `void flox_indicator_slope(const double * input, size_t len, size_t length, double * output)`
+- `void flox_indicator_adx(const double * high, const double * low, const double * close, size_t len, size_t period, double * adx_out, double * plus_di_out, double * minus_di_out)`
+- `void flox_indicator_cci(const double * high, const double * low, const double * close, size_t len, size_t period, double * output)`
+- `void flox_indicator_stochastic(const double * high, const double * low, const double * close, size_t len, size_t k_period, size_t d_period, double * k_out, double * d_out)`
+- `void flox_indicator_chop(const double * high, const double * low, const double * close, size_t len, size_t period, double * output)`
+- `void flox_indicator_obv(const double * close, const double * volume, size_t len, double * output)`
+- `void flox_indicator_vwap(const double * close, const double * volume, size_t len, size_t window, double * output)`
+- `void flox_indicator_cvd(const double * open, const double * high, const double * low, const double * close, const double * volume, size_t len, double * output)`
+- `void flox_indicator_skewness(const double * input, size_t len, size_t period, double * output)`
+- `void flox_indicator_kurtosis(const double * input, size_t len, size_t period, double * output)`
+- `void flox_indicator_parkinson_vol(const double * high, const double * low, size_t len, size_t period, double * output)`
+- `void flox_indicator_rogers_satchell_vol(const double * open, const double * high, const double * low, const double * close, size_t len, size_t period, double * output)`
+- `void flox_indicator_rolling_zscore(const double * input, size_t len, size_t period, double * output)`
+- `void flox_indicator_shannon_entropy(const double * input, size_t len, size_t period, size_t bins, double * output)`
+- `void flox_indicator_correlation(const double * x, const double * y, size_t len, size_t period, double * output)`
+- `void flox_indicator_adf(const double * input, size_t len, size_t max_lag, const char * regression, double * test_stat_out, double * p_value_out, size_t * used_lag_out)`
+- `void flox_indicator_autocorrelation(const double * input, size_t len, size_t window, size_t lag, double * output)`
+
+### indicatorgraph
+
+- `FloxIndicatorGraphHandle flox_indicator_graph_create(void)`
+- `void flox_indicator_graph_destroy(FloxIndicatorGraphHandle g)`
+- `void flox_indicator_graph_set_bars(FloxIndicatorGraphHandle g, uint32_t symbol, const double * close, const double * high, const double * low, const double * volume, size_t len)`
+- `void flox_indicator_graph_add_node(FloxIndicatorGraphHandle g, const char * name, const char *const * deps, size_t num_deps, FloxGraphNodeFn fn, void * user_data)`
+- `const double * flox_indicator_graph_require(FloxIndicatorGraphHandle g, uint32_t symbol, const char * name, size_t * len_out)`
+- `const double * flox_indicator_graph_get(FloxIndicatorGraphHandle g, uint32_t symbol, const char * name, size_t * len_out)`
+- `const double * flox_indicator_graph_close(FloxIndicatorGraphHandle g, uint32_t symbol, size_t * len_out)`
+- `const double * flox_indicator_graph_high(FloxIndicatorGraphHandle g, uint32_t symbol, size_t * len_out)`
+- `const double * flox_indicator_graph_low(FloxIndicatorGraphHandle g, uint32_t symbol, size_t * len_out)`
+- `const double * flox_indicator_graph_volume(FloxIndicatorGraphHandle g, uint32_t symbol, size_t * len_out)`
+- `void flox_indicator_graph_invalidate(FloxIndicatorGraphHandle g, uint32_t symbol)`
+- `void flox_indicator_graph_invalidate_all(FloxIndicatorGraphHandle g)`
+- `void flox_indicator_graph_step(FloxIndicatorGraphHandle g, uint32_t symbol, double open, double high, double low, double close, double volume)`
+- `double flox_indicator_graph_current(FloxIndicatorGraphHandle g, uint32_t symbol, const char * name)`
+- `uint32_t flox_indicator_graph_bar_count(FloxIndicatorGraphHandle g, uint32_t symbol)`
+- `void flox_indicator_graph_reset(FloxIndicatorGraphHandle g, uint32_t symbol)`
+- `void flox_indicator_graph_reset_all(FloxIndicatorGraphHandle g)`
+- `FloxStreamingGraphHandle flox_streaming_graph_create(void)`
+- `void flox_streaming_graph_destroy(FloxStreamingGraphHandle sg)`
+- `void flox_streaming_graph_add_node(FloxStreamingGraphHandle sg, const char * name, const char *const * deps, size_t num_deps, FloxGraphNodeFn fn, void * user_data)`
+- `void flox_streaming_graph_step(FloxStreamingGraphHandle sg, uint32_t symbol, double open, double high, double low, double close, double volume)`
+- `double flox_streaming_graph_current(FloxStreamingGraphHandle sg, uint32_t symbol, const char * name)`
+- `uint32_t flox_streaming_graph_bar_count(FloxStreamingGraphHandle sg, uint32_t symbol)`
+- `void flox_streaming_graph_reset(FloxStreamingGraphHandle sg, uint32_t symbol)`
+- `void flox_streaming_graph_reset_all(FloxStreamingGraphHandle sg)`
+- `const double * flox_streaming_graph_close(FloxStreamingGraphHandle sg, uint32_t symbol, size_t * len_out)`
+- `const double * flox_streaming_graph_high(FloxStreamingGraphHandle sg, uint32_t symbol, size_t * len_out)`
+- `const double * flox_streaming_graph_low(FloxStreamingGraphHandle sg, uint32_t symbol, size_t * len_out)`
+- `const double * flox_streaming_graph_volume(FloxStreamingGraphHandle sg, uint32_t symbol, size_t * len_out)`
+
+### l3_order
+
+- `FloxL3BookHandle flox_l3_book_create(void)`
+- `void flox_l3_book_destroy(FloxL3BookHandle book)`
+- `int32_t flox_l3_book_add_order(FloxL3BookHandle book, uint64_t order_id, double price, double quantity, uint8_t side)`
+- `int32_t flox_l3_book_remove_order(FloxL3BookHandle book, uint64_t order_id)`
+- `int32_t flox_l3_book_modify_order(FloxL3BookHandle book, uint64_t order_id, double new_qty)`
+- `uint8_t flox_l3_book_best_bid(FloxL3BookHandle book, double * price_out)`
+- `uint8_t flox_l3_book_best_ask(FloxL3BookHandle book, double * price_out)`
+- `double flox_l3_book_bid_at_price(FloxL3BookHandle book, double price)`
+- `double flox_l3_book_ask_at_price(FloxL3BookHandle book, double price)`
+
+### market_profile
+
+- `FloxMarketProfileHandle flox_market_profile_create(double tick_size, uint32_t period_minutes, int64_t session_start_ns)`
+- `void flox_market_profile_destroy(FloxMarketProfileHandle profile)`
+- `void flox_market_profile_add_trade(FloxMarketProfileHandle profile, int64_t timestamp_ns, double price, double qty, uint8_t is_buy)`
+- `double flox_market_profile_poc(FloxMarketProfileHandle profile)`
+- `double flox_market_profile_vah(FloxMarketProfileHandle profile)`
+- `double flox_market_profile_val(FloxMarketProfileHandle profile)`
+- `double flox_market_profile_ib_high(FloxMarketProfileHandle profile)`
+- `double flox_market_profile_ib_low(FloxMarketProfileHandle profile)`
+- `uint8_t flox_market_profile_is_poor_high(FloxMarketProfileHandle profile)`
+- `uint8_t flox_market_profile_is_poor_low(FloxMarketProfileHandle profile)`
+- `uint32_t flox_market_profile_num_levels(FloxMarketProfileHandle profile)`
+- `void flox_market_profile_clear(FloxMarketProfileHandle profile)`
+
+### order_book
+
+- `FloxBookHandle flox_book_create(double tick_size)`
+- `void flox_book_destroy(FloxBookHandle book)`
+- `void flox_book_apply_snapshot(FloxBookHandle book, const double * bid_prices, const double * bid_qtys, size_t bid_len, const double * ask_prices, const double * ask_qtys, size_t ask_len)`
+- `void flox_book_apply_delta(FloxBookHandle book, const double * bid_prices, const double * bid_qtys, size_t bid_len, const double * ask_prices, const double * ask_qtys, size_t ask_len)`
+- `uint8_t flox_book_best_bid(FloxBookHandle book, double * price_out)`
+- `uint8_t flox_book_best_ask(FloxBookHandle book, double * price_out)`
+- `uint8_t flox_book_mid(FloxBookHandle book, double * price_out)`
+- `uint8_t flox_book_spread(FloxBookHandle book, double * spread_out)`
+- `double flox_book_bid_at_price(FloxBookHandle book, double price)`
+- `double flox_book_ask_at_price(FloxBookHandle book, double price)`
+- `uint8_t flox_book_is_crossed(FloxBookHandle book)`
+- `void flox_book_clear(FloxBookHandle book)`
+- `uint32_t flox_book_get_bids(FloxBookHandle book, double * prices_out, double * qtys_out, uint32_t max_levels)`
+- `uint32_t flox_book_get_asks(FloxBookHandle book, double * prices_out, double * qtys_out, uint32_t max_levels)`
+
+### order_tracker
+
+- `FloxOrderTrackerHandle flox_order_tracker_create(void)`
+- `void flox_order_tracker_destroy(FloxOrderTrackerHandle tracker)`
+- `uint8_t flox_order_tracker_on_submitted(FloxOrderTrackerHandle tracker, uint64_t order_id, uint32_t symbol, uint8_t side, double price, double qty)`
+- `uint8_t flox_order_tracker_on_filled(FloxOrderTrackerHandle tracker, uint64_t order_id, double fill_qty)`
+- `uint8_t flox_order_tracker_on_canceled(FloxOrderTrackerHandle tracker, uint64_t order_id)`
+- `uint8_t flox_order_tracker_is_active(FloxOrderTrackerHandle tracker, uint64_t order_id)`
+- `uint32_t flox_order_tracker_active_count(FloxOrderTrackerHandle tracker)`
+- `uint32_t flox_order_tracker_total_count(FloxOrderTrackerHandle tracker)`
+- `void flox_order_tracker_prune(FloxOrderTrackerHandle tracker)`
+
+### partitioner
+
+- `FloxPartitionerHandle flox_partitioner_create(const char * data_dir)`
+- `void flox_partitioner_destroy(FloxPartitionerHandle partitioner)`
+- `uint32_t flox_partitioner_by_time(FloxPartitionerHandle p, uint32_t num_partitions, int64_t warmup_ns, FloxPartition * partitions_out, uint32_t max_partitions)`
+- `uint32_t flox_partitioner_by_duration(FloxPartitionerHandle p, int64_t duration_ns, int64_t warmup_ns, FloxPartition * partitions_out, uint32_t max_partitions)`
+- `uint32_t flox_partitioner_by_calendar(FloxPartitionerHandle p, uint8_t unit, int64_t warmup_ns, FloxPartition * partitions_out, uint32_t max_partitions)`
+- `uint32_t flox_partitioner_by_symbol(FloxPartitionerHandle p, uint32_t num_partitions, FloxPartition * partitions_out, uint32_t max_partitions)`
+- `uint32_t flox_partitioner_per_symbol(FloxPartitionerHandle p, FloxPartition * partitions_out, uint32_t max_partitions)`
+- `uint32_t flox_partitioner_by_event_count(FloxPartitionerHandle p, uint32_t num_partitions, FloxPartition * partitions_out, uint32_t max_partitions)`
+
+### pointer_out
+
+- `void flox_data_reader_summary_p(FloxDataReaderHandle reader, void * out)`
+- `void flox_data_reader_stats_p(FloxDataReaderHandle reader, void * out)`
+- `void flox_data_writer_stats_p(FloxDataWriterHandle writer, void * out)`
+- `void flox_segment_merge_full_p(const char * input_paths, size_t num_paths, const char * output_dir, const char * output_name, uint8_t sort, void * out)`
+- `void flox_segment_merge_dir_p(const char * input_dir, const char * output_dir, void * out)`
+- `void flox_segment_split_p(const char * input_path, const char * output_dir, uint8_t mode, int64_t time_interval_ns, uint64_t events_per_file, void * out)`
+- `void flox_segment_export_p(const char * input_path, const char * output_path, uint8_t format, int64_t from_ns, int64_t to_ns, const uint32_t * symbols, uint32_t num_symbols, void * out)`
+- `void flox_segment_validate_full_p(const char * path, uint8_t verify_crc, uint8_t verify_timestamps, void * out)`
+- `void flox_dataset_validate_p(const char * data_dir, void * out)`
+
+### position
+
+- `FloxPositionTrackerHandle flox_position_tracker_create(uint8_t cost_basis)`
+- `void flox_position_tracker_destroy(FloxPositionTrackerHandle tracker)`
+- `void flox_position_tracker_on_fill(FloxPositionTrackerHandle tracker, uint32_t symbol, uint8_t side, double price, double quantity)`
+- `double flox_position_tracker_position(FloxPositionTrackerHandle tracker, uint32_t symbol)`
+- `double flox_position_tracker_avg_entry(FloxPositionTrackerHandle tracker, uint32_t symbol)`
+- `double flox_position_tracker_realized_pnl(FloxPositionTrackerHandle tracker, uint32_t symbol)`
+- `double flox_position_tracker_total_pnl(FloxPositionTrackerHandle tracker)`
+
+### position_group
+
+- `FloxPositionGroupHandle flox_position_group_create(void)`
+- `void flox_position_group_destroy(FloxPositionGroupHandle tracker)`
+- `uint64_t flox_position_group_open(FloxPositionGroupHandle tracker, uint64_t order_id, uint32_t symbol, uint8_t side, double price, double qty)`
+- `void flox_position_group_close(FloxPositionGroupHandle tracker, uint64_t position_id, double exit_price)`
+- `void flox_position_group_partial_close(FloxPositionGroupHandle tracker, uint64_t position_id, double qty, double exit_price)`
+- `double flox_position_group_net_position(FloxPositionGroupHandle tracker, uint32_t symbol)`
+- `double flox_position_group_realized_pnl(FloxPositionGroupHandle tracker, uint32_t symbol)`
+- `double flox_position_group_total_pnl(FloxPositionGroupHandle tracker)`
+- `uint32_t flox_position_group_open_count(FloxPositionGroupHandle tracker, uint32_t symbol)`
+- `void flox_position_group_prune(FloxPositionGroupHandle tracker)`
+
+### segment
+
+- `uint8_t flox_segment_validate(const char * path)`
+- `uint8_t flox_segment_merge(const char * input_dir, const char * output_path)`
+- `FloxMergeResult flox_segment_merge_full(const char * input_paths, size_t num_paths, const char * output_dir, const char * output_name, uint8_t sort)`
+- `FloxMergeResult flox_segment_merge_dir(const char * input_dir, const char * output_dir)`
+- `FloxSplitResult flox_segment_split(const char * input_path, const char * output_dir, uint8_t mode, int64_t time_interval_ns, uint64_t events_per_file)`
+- `FloxExportResult flox_segment_export(const char * input_path, const char * output_path, uint8_t format, int64_t from_ns, int64_t to_ns, const uint32_t * symbols, uint32_t num_symbols)`
+- `uint8_t flox_segment_recompress(const char * input_path, const char * output_path, uint8_t compression)`
+- `uint64_t flox_segment_extract_symbols(const char * input_path, const char * output_path, const uint32_t * symbols, uint32_t num_symbols)`
+- `uint64_t flox_segment_extract_time_range(const char * input_path, const char * output_path, int64_t from_ns, int64_t to_ns)`
+
+### signal_emission
+
+- `uint64_t flox_emit_market_buy(FloxStrategyHandle s, uint32_t symbol, int64_t qty_raw)`
+- `uint64_t flox_emit_market_sell(FloxStrategyHandle s, uint32_t symbol, int64_t qty_raw)`
+- `uint64_t flox_emit_limit_buy(FloxStrategyHandle s, uint32_t symbol, int64_t price_raw, int64_t qty_raw)`
+- `uint64_t flox_emit_limit_sell(FloxStrategyHandle s, uint32_t symbol, int64_t price_raw, int64_t qty_raw)`
+- `void flox_emit_cancel(FloxStrategyHandle s, uint64_t order_id)`
+- `void flox_emit_cancel_all(FloxStrategyHandle s, uint32_t symbol)`
+- `void flox_emit_modify(FloxStrategyHandle s, uint64_t order_id, int64_t new_price_raw, int64_t new_qty_raw)`
+- `uint64_t flox_emit_stop_market(FloxStrategyHandle s, uint32_t symbol, uint8_t side, int64_t trigger_raw, int64_t qty_raw)`
+- `uint64_t flox_emit_stop_limit(FloxStrategyHandle s, uint32_t symbol, uint8_t side, int64_t trigger_raw, int64_t limit_raw, int64_t qty_raw)`
+- `uint64_t flox_emit_take_profit_market(FloxStrategyHandle s, uint32_t symbol, uint8_t side, int64_t trigger_raw, int64_t qty_raw)`
+- `uint64_t flox_emit_trailing_stop(FloxStrategyHandle s, uint32_t symbol, uint8_t side, int64_t offset_raw, int64_t qty_raw)`
+- `uint64_t flox_emit_trailing_stop_percent(FloxStrategyHandle s, uint32_t symbol, uint8_t side, int32_t callback_bps, int64_t qty_raw)`
+- `uint64_t flox_emit_take_profit_limit(FloxStrategyHandle s, uint32_t symbol, uint8_t side, int64_t trigger_raw, int64_t limit_raw, int64_t qty_raw)`
+- `uint64_t flox_emit_limit_buy_tif(FloxStrategyHandle s, uint32_t symbol, int64_t price_raw, int64_t qty_raw, uint8_t time_in_force)`
+- `uint64_t flox_emit_limit_sell_tif(FloxStrategyHandle s, uint32_t symbol, int64_t price_raw, int64_t qty_raw, uint8_t time_in_force)`
+- `uint64_t flox_emit_close_position(FloxStrategyHandle s, uint32_t symbol)`
+
+### simulated_executor
+
+- `FloxExecutorHandle flox_executor_create(void)`
+- `void flox_executor_destroy(FloxExecutorHandle executor)`
+- `void flox_executor_submit_order(FloxExecutorHandle executor, uint64_t id, uint8_t side, double price, double quantity, uint8_t order_type, uint32_t symbol)`
+- `void flox_executor_cancel_order(FloxExecutorHandle executor, uint64_t order_id)`
+- `void flox_executor_cancel_all(FloxExecutorHandle executor, uint32_t symbol)`
+- `void flox_executor_on_bar(FloxExecutorHandle executor, uint32_t symbol, double close_price)`
+- `void flox_executor_on_trade(FloxExecutorHandle executor, uint32_t symbol, double price, uint8_t is_buy)`
+- `void flox_executor_advance_clock(FloxExecutorHandle executor, int64_t timestamp_ns)`
+- `uint32_t flox_executor_fill_count(FloxExecutorHandle executor)`
+
+### statistics
+
+- `double flox_stat_correlation(const double * x, const double * y, size_t len)`
+- `double flox_stat_profit_factor(const double * pnl, size_t len)`
+- `double flox_stat_win_rate(const double * pnl, size_t len)`
+
+### strategy_lifecycle
+
+- `FloxStrategyHandle flox_strategy_create(uint32_t id, const uint32_t * symbols, uint32_t num_symbols, FloxRegistryHandle registry, FloxStrategyCallbacks callbacks)`
+- `void flox_strategy_destroy(FloxStrategyHandle strategy)`
+
+### strategyrunner_synchronous
+
+- `FloxRunnerHandle flox_runner_create(FloxRegistryHandle registry, FloxOnSignalCallback on_signal, void * user_data)`
+- `void flox_runner_destroy(FloxRunnerHandle runner)`
+- `void flox_runner_add_strategy(FloxRunnerHandle runner, FloxStrategyHandle strategy)`
+- `void flox_runner_start(FloxRunnerHandle runner)`
+- `void flox_runner_stop(FloxRunnerHandle runner)`
+- `void flox_runner_on_trade(FloxRunnerHandle runner, uint32_t symbol, double price, double qty, uint8_t is_buy, int64_t exchange_ts_ns)`
+- `void flox_runner_on_book_snapshot(FloxRunnerHandle runner, uint32_t symbol, const double * bid_prices, const double * bid_qtys, uint32_t n_bids, const double * ask_prices, const double * ask_qtys, uint32_t n_asks, int64_t exchange_ts_ns)`
+- `void flox_runner_on_bar(FloxRunnerHandle runner, uint32_t symbol, uint8_t bar_type, uint64_t bar_type_param, double open, double high, double low, double close, double volume, double buy_volume, int64_t start_time_ns, int64_t end_time_ns, uint8_t close_reason)`
+
+### symbol_registry
+
+- `FloxRegistryHandle flox_registry_create(void)`
+- `void flox_registry_destroy(FloxRegistryHandle registry)`
+- `uint32_t flox_registry_add_symbol(FloxRegistryHandle registry, const char * exchange, const char * name, double tick_size)`
+- `uint8_t flox_registry_get_symbol_id(FloxRegistryHandle registry, const char * exchange, const char * name, uint32_t * id_out)`
+- `uint8_t flox_registry_get_symbol_name(FloxRegistryHandle registry, uint32_t symbol_id, char * exchange_out, size_t exchange_len, char * name_out, size_t name_len)`
+- `uint32_t flox_registry_symbol_count(FloxRegistryHandle registry)`
+
+### targets
+
+- `void flox_target_future_return(const double * close, size_t len, size_t horizon, double * output)`
+- `void flox_target_future_ctc_volatility(const double * close, size_t len, size_t horizon, double * output)`
+- `void flox_target_future_linear_slope(const double * close, size_t len, size_t horizon, double * output)`
+
+### validation
+
+- `FloxSegmentValidation flox_segment_validate_full(const char * path, uint8_t verify_crc, uint8_t verify_timestamps)`
+- `FloxDatasetValidation flox_dataset_validate(const char * data_dir)`
+
+### volume_profile
+
+- `FloxVolumeProfileHandle flox_volume_profile_create(double tick_size)`
+- `void flox_volume_profile_destroy(FloxVolumeProfileHandle profile)`
+- `void flox_volume_profile_add_trade(FloxVolumeProfileHandle profile, double price, double quantity, uint8_t is_buy)`
+- `double flox_volume_profile_poc(FloxVolumeProfileHandle profile)`
+- `double flox_volume_profile_vah(FloxVolumeProfileHandle profile)`
+- `double flox_volume_profile_val(FloxVolumeProfileHandle profile)`
+- `double flox_volume_profile_total_volume(FloxVolumeProfileHandle profile)`
+- `double flox_volume_profile_total_delta(FloxVolumeProfileHandle profile)`
+- `uint32_t flox_volume_profile_num_levels(FloxVolumeProfileHandle profile)`
+- `void flox_volume_profile_clear(FloxVolumeProfileHandle profile)`
+

--- a/tools/codegen/scripts/check.sh
+++ b/tools/codegen/scripts/check.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # CI-equivalent check for the codegen pipeline. Run locally before pushing.
-#   1. Regenerates the golden header from the spec.
-#   2. Diffs against the committed golden — fails on drift.
-#   3. Runs the signature check against the live flox_capi.h.
+#   1. Regenerates each golden artifact from the spec into a temp file.
+#   2. Diffs each against the committed golden — fails on drift.
+#   3. Runs the full-coverage signature check against the live flox_capi.h.
 #   4. Runs unit tests.
 #
 # Exits non-zero on any failure. Idempotent.
@@ -18,23 +18,30 @@ if [[ ! -x "$PY" ]]; then
   exit 2
 fi
 
-GOLDEN="$TOOL/golden/flox_capi.h"
 SPEC="$REPO/include/flox/capi/flox_capi_spec.hpp"
 LIVE="$REPO/include/flox/capi/flox_capi.h"
 
-PYTHONPATH="$TOOL" "$PY" -m flox_codegen.cli emit-capi --spec "$SPEC" --out "$GOLDEN.tmp"
+verify_one() {
+  local subcommand="$1" target="$2"
+  local tmp="${target}.tmp"
+  PYTHONPATH="$TOOL" "$PY" -m flox_codegen.cli "$subcommand" \
+    --spec "$SPEC" --out "$tmp"
+  if ! diff -u "$target" "$tmp" >/dev/null; then
+    echo "::error::$(basename "$target") drift — run 'tools/codegen/scripts/regenerate.sh'"
+    diff -u "$target" "$tmp" || true
+    rm -f "$tmp"
+    return 1
+  fi
+  rm -f "$tmp"
+}
 
-if ! diff -u "$GOLDEN" "$GOLDEN.tmp" >/dev/null; then
-  echo "::error::golden header drift — run 'tools/codegen/scripts/regenerate.sh'"
-  diff -u "$GOLDEN" "$GOLDEN.tmp" || true
-  rm -f "$GOLDEN.tmp"
-  exit 1
-fi
-rm -f "$GOLDEN.tmp"
+verify_one emit-capi  "$TOOL/golden/flox_capi.h"
+verify_one emit-codon "$TOOL/golden/flox_capi.codon"
+verify_one emit-llms  "$TOOL/golden/flox_capi.md"
 
 PYTHONPATH="$TOOL" "$PY" -m flox_codegen.cli check \
   --expected "$LIVE" \
-  --actual "$GOLDEN" \
+  --actual "$TOOL/golden/flox_capi.h" \
   --require-full-coverage
 
 PYTHONPATH="$TOOL" "$PY" -m pytest "$TOOL/tests/" -q

--- a/tools/codegen/scripts/regenerate.sh
+++ b/tools/codegen/scripts/regenerate.sh
@@ -12,8 +12,9 @@ if [[ ! -x "$PY" ]]; then
   bash "$TOOL/setup.sh"
 fi
 
-GOLDEN="$TOOL/golden/flox_capi.h"
 SPEC="$REPO/include/flox/capi/flox_capi_spec.hpp"
 
-PYTHONPATH="$TOOL" "$PY" -m flox_codegen.cli emit-capi --spec "$SPEC" --out "$GOLDEN"
-echo "regenerated $GOLDEN"
+PYTHONPATH="$TOOL" "$PY" -m flox_codegen.cli emit-capi  --spec "$SPEC" --out "$TOOL/golden/flox_capi.h"
+PYTHONPATH="$TOOL" "$PY" -m flox_codegen.cli emit-codon --spec "$SPEC" --out "$TOOL/golden/flox_capi.codon"
+PYTHONPATH="$TOOL" "$PY" -m flox_codegen.cli emit-llms  --spec "$SPEC" --out "$TOOL/golden/flox_capi.md"
+echo "regenerated golden/{flox_capi.h, flox_capi.codon, flox_capi.md}"

--- a/tools/codegen/tests/test_emit_codon.py
+++ b/tools/codegen/tests/test_emit_codon.py
@@ -1,0 +1,123 @@
+"""Tests for the Codon FFI emitter."""
+from __future__ import annotations
+
+from flox_codegen import emit_codon, ir
+
+
+def _module(*funcs: ir.Function, **kw) -> ir.Module:
+    return ir.Module(functions=list(funcs), **kw)
+
+
+def test_void_return_no_arrow():
+    m = _module(
+        ir.Function(name="flox_x", return_type="void", params=(),
+                    annotations={"group": "g"})
+    )
+    text = emit_codon.emit(m)
+    assert "from C import flox_x()" in text
+    assert "-> " not in text  # void return → no arrow
+
+
+def test_int_return_arrow():
+    m = _module(
+        ir.Function(name="flox_x", return_type="int32_t", params=(),
+                    annotations={"group": "g"})
+    )
+    text = emit_codon.emit(m)
+    assert "from C import flox_x() -> i32" in text
+
+
+def test_pointer_to_scalar():
+    m = _module(
+        ir.Function(
+            name="flox_x", return_type="void",
+            params=(
+                ir.Param("input", "const double *"),
+                ir.Param("len", "size_t"),
+                ir.Param("output", "double *"),
+            ),
+            annotations={"group": "g"},
+        )
+    )
+    text = emit_codon.emit(m)
+    assert "from C import flox_x(Ptr[float], int, Ptr[float])" in text
+
+
+def test_handle_and_string_collapse_to_cobj():
+    m = _module(
+        ir.Function(
+            name="flox_x", return_type="void",
+            params=(
+                ir.Param("h", "FloxStrategyHandle"),
+                ir.Param("name", "const char *"),
+            ),
+            annotations={"group": "g"},
+        )
+    )
+    text = emit_codon.emit(m)
+    assert "from C import flox_x(cobj, cobj)" in text
+
+
+def test_pointer_to_pointer():
+    """const char* const* maps to Ptr[cobj]."""
+    m = _module(
+        ir.Function(
+            name="flox_x", return_type="void",
+            params=(ir.Param("deps", "const char *const *"),),
+            annotations={"group": "g"},
+        )
+    )
+    text = emit_codon.emit(m)
+    assert "Ptr[cobj]" in text
+
+
+def test_grouping_alphabetical():
+    m = _module(
+        ir.Function(name="flox_b", return_type="void", params=(),
+                    annotations={"group": "zebra"}),
+        ir.Function(name="flox_a", return_type="void", params=(),
+                    annotations={"group": "alpha"}),
+    )
+    text = emit_codon.emit(m)
+    alpha_pos = text.find("alpha")
+    zebra_pos = text.find("zebra")
+    assert 0 < alpha_pos < zebra_pos
+
+
+def test_unsigned_widths():
+    m = _module(
+        ir.Function(
+            name="flox_x", return_type="uint64_t",
+            params=(
+                ir.Param("a", "uint8_t"),
+                ir.Param("b", "uint16_t"),
+                ir.Param("c", "uint32_t"),
+                ir.Param("d", "uint64_t"),
+            ),
+            annotations={"group": "g"},
+        )
+    )
+    text = emit_codon.emit(m)
+    assert "from C import flox_x(u8, u16, u32, u64) -> u64" in text
+
+
+def test_double_returns_codon_float():
+    m = _module(
+        ir.Function(name="flox_x", return_type="double", params=(),
+                    annotations={"group": "g"})
+    )
+    text = emit_codon.emit(m)
+    assert "-> float" in text
+
+
+def test_map_type_void_pointer():
+    assert emit_codon.map_type("void *") == "cobj"
+
+
+def test_map_type_const_pointer():
+    assert emit_codon.map_type("const double *") == "Ptr[float]"
+
+
+def test_map_type_unknown_passthrough():
+    # Unknown type keeps the literal — useful for noticing gaps.
+    assert emit_codon.map_type("__weird_type") == "__weird_type"

--- a/tools/codegen/tests/test_emit_llms.py
+++ b/tools/codegen/tests/test_emit_llms.py
@@ -1,0 +1,63 @@
+"""Tests for the llms.txt-style markdown emitter."""
+from __future__ import annotations
+
+from flox_codegen import emit_llms, ir
+
+
+def test_emit_minimal():
+    m = ir.Module(
+        handles=[ir.HandleTypedef(name="FloxXHandle")],
+        enums=[ir.Enum(name="FloxKind",
+                       values=(ir.EnumValue("FLOX_A", 0),
+                               ir.EnumValue("FLOX_B", 1)))],
+        functions=[
+            ir.Function(name="flox_a", return_type="void", params=(),
+                        annotations={"group": "g"})
+        ],
+    )
+    text = emit_llms.emit(m)
+    assert "# FLOX C API Reference" in text
+    assert "`FloxXHandle`" in text
+    assert "## Enums" in text
+    assert "`FLOX_A` = `0`" in text
+    assert "## Functions" in text
+
+
+def test_handle_alias_marked():
+    m = ir.Module(
+        handles=[
+            ir.HandleTypedef(name="FloxXHandle"),
+            ir.HandleTypedef(name="FloxYHandle", alias_of="FloxXHandle"),
+        ],
+    )
+    text = emit_llms.emit(m)
+    assert "alias of `FloxXHandle`" in text
+
+
+def test_struct_fields_table():
+    m = ir.Module(
+        structs=[
+            ir.Struct(
+                name="FloxRecord",
+                fields=(ir.StructField("x", "int32_t"),
+                        ir.StructField("y", "double")),
+            )
+        ]
+    )
+    text = emit_llms.emit(m)
+    assert "| `x` | `int32_t` |" in text
+    assert "| `y` | `double` |" in text
+
+
+def test_function_signature_format():
+    m = ir.Module(
+        functions=[
+            ir.Function(
+                name="flox_x", return_type="int",
+                params=(ir.Param("a", "double"), ir.Param("b", "size_t")),
+                annotations={"group": "g"},
+            )
+        ]
+    )
+    text = emit_llms.emit(m)
+    assert "`int flox_x(double a, size_t b)`" in text


### PR DESCRIPTION
## Summary

Stacked on top of #132. Adds two new IR-driven emitters:

| subcommand | golden artifact | purpose |
|---|---|---|
| `emit-codon` | `tools/codegen/golden/flox_capi.codon` | Codon \`from C import\` declarations — flat reference for the existing \`codon/flox/*.codon\` modules |
| `emit-llms` | \`tools/codegen/golden/flox_capi.md\` | Markdown C-API reference targeted at AI agents |

Both consume the same IR; new tests + CI gate cover both.

## Type mapping (codon)

| C type | Codon |
|---|---|
| `void` (return) | (no return) |
| `void*`, `Flox*Handle`, `FloxXCallbacks` | `cobj` |
| `const char*` | `cobj` (matches existing convention) |
| `const char* const*` | `Ptr[cobj]` |
| `uint{8,16,32,64}_t` | `u8`/`u16`/`u32`/`u64` |
| `int{8,16,32,64}_t` | `i8`/`i16`/`i32`/`i64` |
| `size_t` | `int` |
| `double`, `float` | `float`, `float32` |
| `T*` (scalar) | `Ptr[T]` |

11 unit tests cover edge cases (const stripping, pointer-to-pointer, primitive widths, void return, unknown-type passthrough).

## What's NOT in this PR

- **Pybind11 (.pyi) and NAPI (.d.ts) emitters.** Those stubs describe binding-side APIs that don't mirror the C surface 1:1, so `scripts/gen_pyi_stubs.py` and the hand-written `node/index.d.ts` remain the right tools.
- **Replacing live `flox_capi.h` with codegen output.** Inline doc comments (`// best bid, or 0 if absent`) aren't preserved by the emitter today; wholesale replacement would lose them.
- **ABI snapshot CI gate.** Separate follow-up.

## Test plan

- [x] All 41 unit tests pass.
- [x] \`tools/codegen/scripts/check.sh\` passes locally (golden parity for all 3 artifacts + signature equivalence + format-check).
- [ ] CI green.

Refs W1-T014