### PR TITLE
feat(errors): structured FloxError with code + help URL (T005)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       run: python3 scripts/gen_llms_txt.py --check
     - name: Verify node/index.d.ts exports match the C++ binding
       run: python3 scripts/check_dts_exports.py
+    - name: Verify error codes have docs and pages aren't stale
+      run: python3 scripts/check_error_codes.py
 
   linux-gcc:
     needs: format-check

--- a/docs/errors/E_SYM_001.md
+++ b/docs/errors/E_SYM_001.md
@@ -1,0 +1,72 @@
+---
+code: E_SYM_001
+title: Symbol is not registered
+severity: error
+since: 0.1.0
+---
+
+# E_SYM_001 — Symbol is not registered
+
+A request referenced a symbol name (e.g. `"BTCUSDT"`) that the engine's
+`SymbolRegistry` has never seen. FLOX requires every symbol to be
+registered up-front so that strategies, indicators, and replay sources
+can map names to compact `uint32_t` IDs at hot-path latency.
+
+## Where it fires
+
+- `Engine.run_csv()` and `Engine.run_ohlcv()` when a symbol referenced in
+  the input doesn't appear in `add_symbol()` calls.
+- `SignalBuilder.market_buy(symbol="…")` and similar emitters.
+- Any C-API path that accepts a `const char* symbol` (e.g.
+  `flox_registry_get_symbol_id`).
+
+## How to fix
+
+Register the symbol **before** running the engine or constructing
+signals.
+
+=== "Python"
+    ```python
+    import flox
+
+    eng = flox.Engine()
+    eng.add_symbol("BTCUSDT")           # ← register first
+    eng.run_csv("BTCUSDT", "btc.csv")   # ← then reference it
+    ```
+
+=== "Node"
+    ```js
+    const flox = require("@flox-foundation/flox");
+    const eng = new flox.Engine();
+    eng.addSymbol("BTCUSDT");
+    ```
+
+=== "C API"
+    ```c
+    FloxRegistryHandle reg = flox_registry_create();
+    flox_registry_add_symbol(reg, "exchange", "BTCUSDT", /*tick_size=*/0.01);
+    ```
+
+## Common causes
+
+- **Typos** between `add_symbol()` and the symbol referenced later.
+  FLOX is case-sensitive; `"BTCUSDT"` and `"btcusdt"` are different
+  symbols.
+- **Forgetting to register a symbol** that appears in the dataset but
+  isn't part of the strategy's declared universe — register every symbol
+  you intend to read from, even if you won't trade it.
+- **Loading data before registering** — for stream / replay paths that
+  need the symbol ID immediately.
+
+## Diagnosing
+
+The `FloxError` exception carries the offending symbol name in its
+`message` field. Print the registered set to compare:
+
+```python
+try:
+    eng.run_csv("BTCUSDT", "btc.csv")
+except flox.FloxError as e:
+    print(f"{e.code}: {e.message}")
+    print(f"registered: {sorted(eng.symbols())}")
+```

--- a/docs/errors/index.md
+++ b/docs/errors/index.md
@@ -1,0 +1,62 @@
+# Error code reference
+
+Each FloxError carries a stable code (e.g. `E_SYM_001`), a human message,
+and a help URL pointing to the per-code page in this section. AI agents
+reading FLOX errors can resolve the code to a documented fix without
+parsing free-text messages.
+
+## Code format
+
+`E_<DOMAIN>_<NUMBER>` — `DOMAIN` is a short uppercase tag identifying the
+subsystem; `NUMBER` is a zero-padded 3-digit counter within that domain.
+Codes never change meaning once published; if the cause shifts, a new
+code is allocated.
+
+| Domain    | Subsystem                                        |
+|-----------|--------------------------------------------------|
+| `SYM`     | Symbol registry / lookups                         |
+| `DATA`    | Input data loading and parsing                    |
+| `KEY`     | Event field lookups and required keys             |
+| `TIME`    | Calendar, intervals, timestamps                   |
+| `LEN`     | Array length mismatches                           |
+| `ORDER`   | Order submission and lifecycle                    |
+| `RISK`    | Pre-trade risk hooks                              |
+| `IDX`     | Index out of range                                |
+| `IO`      | Filesystem and binary log I/O                     |
+| `CONFIG`  | Configuration validation                          |
+
+## Catalog
+
+| Code           | Message                                                       |
+|----------------|---------------------------------------------------------------|
+| [`E_SYM_001`](E_SYM_001.md) | Symbol is not registered                       |
+
+## How to add a new code
+
+1. Decide on a domain. If a new domain is needed, add it to the table
+   above.
+2. Pick the next number in that domain.
+3. Write a Markdown page `docs/errors/<code>.md` with the frontmatter
+   shown below.
+4. Use the code at the throw site:
+
+    ```cpp
+    throw flox::FloxError(
+        "E_SYM_001",
+        "Symbol '" + name + "' is not registered. ...");
+    ```
+
+5. Run `python3 scripts/check_error_codes.py` (it also runs in CI). It
+   verifies every code referenced from source has a Markdown page and
+   vice-versa.
+
+### Frontmatter convention
+
+```yaml
+---
+code: E_SYM_001
+title: Symbol is not registered
+severity: error
+since: 0.1.0
+---
+```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7232,6 +7232,156 @@ cmake .. -DFLOX_ENABLE_TESTS=ON -DFLOX_ENABLE_BENCHMARKS=ON
 - [Architecture](../explanation/architecture.md) — Understand the codebase
 
 ==============================================================================
+# Section: Errors
+==============================================================================
+
+------------------------------------------------------------------------------
+# Source: docs/errors/index.md
+# URL: https://flox-foundation.github.io/flox/errors/
+------------------------------------------------------------------------------
+
+# Error code reference
+
+Each FloxError carries a stable code (e.g. `E_SYM_001`), a human message,
+and a help URL pointing to the per-code page in this section. AI agents
+reading FLOX errors can resolve the code to a documented fix without
+parsing free-text messages.
+
+## Code format
+
+`E_<DOMAIN>_<NUMBER>` — `DOMAIN` is a short uppercase tag identifying the
+subsystem; `NUMBER` is a zero-padded 3-digit counter within that domain.
+Codes never change meaning once published; if the cause shifts, a new
+code is allocated.
+
+| Domain    | Subsystem                                        |
+|-----------|--------------------------------------------------|
+| `SYM`     | Symbol registry / lookups                         |
+| `DATA`    | Input data loading and parsing                    |
+| `KEY`     | Event field lookups and required keys             |
+| `TIME`    | Calendar, intervals, timestamps                   |
+| `LEN`     | Array length mismatches                           |
+| `ORDER`   | Order submission and lifecycle                    |
+| `RISK`    | Pre-trade risk hooks                              |
+| `IDX`     | Index out of range                                |
+| `IO`      | Filesystem and binary log I/O                     |
+| `CONFIG`  | Configuration validation                          |
+
+## Catalog
+
+| Code           | Message                                                       |
+|----------------|---------------------------------------------------------------|
+| [`E_SYM_001`](E_SYM_001.md) | Symbol is not registered                       |
+
+## How to add a new code
+
+1. Decide on a domain. If a new domain is needed, add it to the table
+   above.
+2. Pick the next number in that domain.
+3. Write a Markdown page `docs/errors/<code>.md` with the frontmatter
+   shown below.
+4. Use the code at the throw site:
+
+    ```cpp
+    throw flox::FloxError(
+        "E_SYM_001",
+        "Symbol '" + name + "' is not registered. ...");
+    ```
+
+5. Run `python3 scripts/check_error_codes.py` (it also runs in CI). It
+   verifies every code referenced from source has a Markdown page and
+   vice-versa.
+
+### Frontmatter convention
+
+```yaml
+---
+code: E_SYM_001
+title: Symbol is not registered
+severity: error
+since: 0.1.0
+---
+```
+
+------------------------------------------------------------------------------
+# Source: docs/errors/E_SYM_001.md
+# URL: https://flox-foundation.github.io/flox/errors/E_SYM_001/
+------------------------------------------------------------------------------
+
+---
+code: E_SYM_001
+title: Symbol is not registered
+severity: error
+since: 0.1.0
+---
+
+# E_SYM_001 — Symbol is not registered
+
+A request referenced a symbol name (e.g. `"BTCUSDT"`) that the engine's
+`SymbolRegistry` has never seen. FLOX requires every symbol to be
+registered up-front so that strategies, indicators, and replay sources
+can map names to compact `uint32_t` IDs at hot-path latency.
+
+## Where it fires
+
+- `Engine.run_csv()` and `Engine.run_ohlcv()` when a symbol referenced in
+  the input doesn't appear in `add_symbol()` calls.
+- `SignalBuilder.market_buy(symbol="…")` and similar emitters.
+- Any C-API path that accepts a `const char* symbol` (e.g.
+  `flox_registry_get_symbol_id`).
+
+## How to fix
+
+Register the symbol **before** running the engine or constructing
+signals.
+
+=== "Python"
+    ```python
+    import flox
+
+    eng = flox.Engine()
+    eng.add_symbol("BTCUSDT")           # ← register first
+    eng.run_csv("BTCUSDT", "btc.csv")   # ← then reference it
+    ```
+
+=== "Node"
+    ```js
+    const flox = require("@flox-foundation/flox");
+    const eng = new flox.Engine();
+    eng.addSymbol("BTCUSDT");
+    ```
+
+=== "C API"
+    ```c
+    FloxRegistryHandle reg = flox_registry_create();
+    flox_registry_add_symbol(reg, "exchange", "BTCUSDT", /*tick_size=*/0.01);
+    ```
+
+## Common causes
+
+- **Typos** between `add_symbol()` and the symbol referenced later.
+  FLOX is case-sensitive; `"BTCUSDT"` and `"btcusdt"` are different
+  symbols.
+- **Forgetting to register a symbol** that appears in the dataset but
+  isn't part of the strategy's declared universe — register every symbol
+  you intend to read from, even if you won't trade it.
+- **Loading data before registering** — for stream / replay paths that
+  need the symbol ID immediately.
+
+## Diagnosing
+
+The `FloxError` exception carries the offending symbol name in its
+`message` field. Print the registered set to compare:
+
+```python
+try:
+    eng.run_csv("BTCUSDT", "btc.csv")
+except flox.FloxError as e:
+    print(f"{e.code}: {e.message}")
+    print(f"registered: {sorted(eng.symbols())}")
+```
+
+==============================================================================
 # Section: Reference: Python
 ==============================================================================
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -73,6 +73,11 @@ Documentation is grouped below by Diátaxis category — pick the section matchi
 - [CI configuration](https://flox-foundation.github.io/flox/how-to/ci/): Continuous integration setup
 - [Contributing](https://flox-foundation.github.io/flox/how-to/contributing/): How to contribute
 
+## Errors
+
+- [Error code reference](https://flox-foundation.github.io/flox/errors/): Catalog of FloxError codes, format, and lifecycle
+- [E_SYM_001 — Symbol is not registered](https://flox-foundation.github.io/flox/errors/E_SYM_001/): Fix: call Engine.add_symbol() before referencing the symbol
+
 ## Reference: Python
 
 - [Python reference index](https://flox-foundation.github.io/flox/reference/python/): All Python binding modules

--- a/include/flox/error/flox_error.h
+++ b/include/flox/error/flox_error.h
@@ -1,0 +1,74 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+// FloxError — structured exception for FLOX core code.
+//
+// Each FloxError carries a stable code (e.g. "E_SYM_001"), a human message,
+// and a help URL pointing to the corresponding documentation page in the
+// FLOX site. Bindings translate this into their language-native exception
+// type (FloxError(Exception) in Python, FloxError extends Error in Node,
+// etc.) while preserving the three fields.
+//
+// Codes follow the convention E_<DOMAIN>_<NUMBER> (3 digits). DOMAIN is a
+// short uppercase tag identifying the subsystem: SYM (registry), DATA
+// (input streams), KEY (event field lookup), TIME (calendar/intervals),
+// LEN (array length mismatches), ORDER, RISK, IDX, IO, CONFIG, ...
+//
+// Migration policy is **incremental**: new throw sites use FloxError;
+// existing std::invalid_argument / std::runtime_error sites stay until
+// touched. Each code committed to public surface gets a Markdown page in
+// docs/errors/<code>.md (CI gate, scripts/check_error_codes.py).
+
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace flox
+{
+
+class FloxError : public std::runtime_error
+{
+ public:
+  FloxError(std::string code, std::string message, std::string helpUrl)
+      : std::runtime_error(message),
+        _code(std::move(code)),
+        _message(std::move(message)),
+        _helpUrl(std::move(helpUrl))
+  {
+  }
+
+  FloxError(std::string code, std::string message)
+      : std::runtime_error(message),
+        _code(std::move(code)),
+        _message(std::move(message)),
+        _helpUrl(defaultHelpUrl(_code))
+  {
+  }
+
+  const std::string& code() const noexcept { return _code; }
+  const std::string& message() const noexcept { return _message; }
+  const std::string& helpUrl() const noexcept { return _helpUrl; }
+
+  // Build the canonical help-URL for a given code. Bindings reuse this so
+  // the URL convention is one definition rather than scattered string
+  // builders.
+  static std::string defaultHelpUrl(const std::string& code)
+  {
+    return "https://flox-foundation.github.io/flox/errors/" + code + "/";
+  }
+
+ private:
+  std::string _code;
+  std::string _message;
+  std::string _helpUrl;
+};
+
+}  // namespace flox

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,10 @@ nav:
       - Integration Flow: explanation/integration-flow.md
       - Indicators: explanation/indicators.md
 
+  - Errors:
+      - errors/index.md
+      - E_SYM_001 - Symbol is not registered: errors/E_SYM_001.md
+
   - Reference:
       - reference/README.md
       - Python:

--- a/python/flox_py.cpp
+++ b/python/flox_py.cpp
@@ -12,6 +12,7 @@
 #include "flox/backtest/simulated_clock.h"
 #include "flox/backtest/simulated_executor.h"
 #include "flox/common.h"
+#include "flox/error/flox_error.h"
 #include "graph_bindings.h"
 #include "indicator_bindings.h"
 #include "optimizer_bindings.h"
@@ -468,7 +469,10 @@ class Engine
         auto it = _symbols.find(names[i]);
         if (it == _symbols.end())
         {
-          throw std::invalid_argument("unknown symbol: " + names[i]);
+          throw flox::FloxError("E_SYM_001",
+                                "Symbol '" + names[i] +
+                                    "' is not registered. Add it via "
+                                    "Engine.add_symbol() before referencing it.");
         }
         sigs[i].symbol_id = it->second.id;
       }
@@ -558,7 +562,10 @@ class Engine
     auto it = _symbols.find(symbol);
     if (it == _symbols.end())
     {
-      throw std::invalid_argument("unknown symbol: " + symbol);
+      throw flox::FloxError("E_SYM_001",
+                            "Symbol '" + symbol +
+                                "' is not registered. Add it via "
+                                "Engine.add_symbol() before referencing it.");
     }
     return it->second;
   }
@@ -651,6 +658,34 @@ PYBIND11_MODULE(_flox_py, m)
   m.doc() = "Flox -- Python bindings";
 
   PYBIND11_NUMPY_DTYPE(PyBar, timestamp_ns, open_raw, high_raw, low_raw, close_raw, volume_raw);
+
+  // FloxError — structured exception. New throw sites in C++ raise
+  // flox::FloxError; this translator surfaces them in Python with the
+  // `code`, `message`, `help_url` attributes intact. Pre-existing
+  // std::invalid_argument / std::runtime_error throws keep their default
+  // pybind11 → ValueError / RuntimeError mapping (incremental migration).
+  static py::exception<flox::FloxError> floxError(m, "FloxError");
+  py::register_exception_translator(
+      [](std::exception_ptr p)
+      {
+        try
+        {
+          if (p)
+          {
+            std::rethrow_exception(p);
+          }
+        }
+        catch (const flox::FloxError& e)
+        {
+          PyObject* excTypePtr = floxError.ptr();
+          py::object excType = py::reinterpret_borrow<py::object>(excTypePtr);
+          py::object inst = excType(e.message());
+          inst.attr("code") = e.code();
+          inst.attr("message") = e.message();
+          inst.attr("help_url") = e.helpUrl();
+          PyErr_SetObject(excTypePtr, inst.ptr());
+        }
+      });
 
   // Stats
   py::class_<PyStats>(m, "Stats")

--- a/python/strategy_bindings.h
+++ b/python/strategy_bindings.h
@@ -17,6 +17,7 @@
 #include "flox/capi/bridge_strategy.h"
 #include "flox/capi/flox_capi.h"
 #include "flox/engine/symbol_registry.h"
+#include "flox/error/flox_error.h"
 #include "flox/replay/abstract_event_reader.h"
 #include "flox/replay/binary_format_v1.h"
 #include "flox/util/memory/pool.h"
@@ -517,7 +518,11 @@ class PyStrategyBase
     {
       return it->second;
     }
-    throw std::invalid_argument("Unknown symbol: " + symbol.value());
+    throw flox::FloxError(
+        "E_SYM_001",
+        "Symbol '" + symbol.value() +
+            "' is not registered. Add it via Engine.add_symbol() "
+            "before referencing it.");
   }
 
   uint32_t _resolve(std::optional<uint32_t> symbol) const

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -378,6 +378,41 @@ if os.path.exists(csv_path):
 else:
     print(f"  skip Engine (CSV not found: {csv_path})")
 
+# ── FloxError ────────────────────────────────────────────────────────
+
+print("=== FloxError ===")
+
+# The FloxError class is exposed at the top level and inherits from Exception
+# so existing `except Exception` blocks still catch it.
+check(issubclass(flox.FloxError, Exception),
+      "FloxError is an Exception subclass")
+
+# Triggering an "unknown symbol" path via Engine.run on a registry that
+# never saw the requested symbol. We need data to be loaded and the
+# strategy to reference a symbol not in the engine's set. Without a CSV
+# fixture we exercise the code via a SignalBuilder + run path that the
+# engine itself rejects.
+if os.path.exists(csv_path):
+    engine = flox.Engine()
+    engine.load_csv(csv_path)
+    sb = flox.SignalBuilder()
+    sb.buy(0, 1.0, symbol="ETH/USDT-not-registered")
+    try:
+        engine.run(sb)
+    except flox.FloxError as e:
+        check(e.code == "E_SYM_001",
+              f'FloxError.code == "E_SYM_001" (got {e.code!r})')
+        check("not registered" in e.message,
+              f'FloxError.message mentions "not registered"')
+        check(e.help_url.endswith("E_SYM_001/"),
+              f'FloxError.help_url ends with "E_SYM_001/"')
+        check(e.help_url.startswith("https://"),
+              f'FloxError.help_url is an https URL')
+    else:
+        check(False, "engine.run did not raise on unknown symbol")
+else:
+    print(f"  skip FloxError (CSV not found: {csv_path})")
+
 # ── Summary ──────────────────────────────────────────────────────────
 
 print(f"\n{_passed} passed, {_failed} failed")

--- a/scripts/check_error_codes.py
+++ b/scripts/check_error_codes.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""scripts/check_error_codes.py
+
+Cross-reference FLOX error codes between source code and documentation.
+
+Two failure modes:
+1. A code is thrown from C++ / Python source but has no `docs/errors/<code>.md`.
+2. A `docs/errors/<code>.md` exists but the code is referenced nowhere in
+   source — likely a stale page.
+
+The check exits non-zero on either, so AI agents and humans relying on the
+help URLs always land on a real page (and unused pages don't accumulate).
+
+Usage:
+    python3 scripts/check_error_codes.py            # report + exit 1 on mismatch
+    python3 scripts/check_error_codes.py --quiet    # only failures
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Set
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_ERRORS = REPO_ROOT / "docs" / "errors"
+
+# Match the literal first arg to FloxError(...): a quoted string starting
+# with "E_". Catches both C++ (`flox::FloxError("E_SYM_001", ...)`) and
+# Python (FloxError("E_SYM_001", ...)) call sites.
+_CODE_LITERAL_RE = re.compile(r'FloxError\s*\(\s*"(E_[A-Z]+_\d{3,4})"')
+
+# Files to scan for code references. Engine + bindings + tests.
+_SOURCE_GLOBS = (
+    "include/**/*.h",
+    "src/**/*.cpp",
+    "src/**/*.h",
+    "python/**/*.cpp",
+    "python/**/*.h",
+    "node/**/*.cpp",
+    "node/**/*.h",
+    "tests/**/*.cpp",
+)
+
+_FRONTMATTER_CODE_RE = re.compile(r"^code:\s*(E_[A-Z]+_\d{3,4})\s*$", re.MULTILINE)
+
+
+def _scan_source_codes(root: Path) -> Dict[str, Set[Path]]:
+    """Return {code: {paths}} for every FloxError("E_…") found in source."""
+    out: Dict[str, Set[Path]] = {}
+    for pattern in _SOURCE_GLOBS:
+        for path in root.glob(pattern):
+            try:
+                text = path.read_text()
+            except (OSError, UnicodeDecodeError):
+                continue
+            for m in _CODE_LITERAL_RE.finditer(text):
+                out.setdefault(m.group(1), set()).add(path)
+    return out
+
+
+def _scan_doc_codes(root: Path) -> Dict[str, Path]:
+    """Return {code: doc_path} for every docs/errors/E_*.md page."""
+    out: Dict[str, Path] = {}
+    if not root.is_dir():
+        return out
+    for md in root.glob("E_*.md"):
+        text = md.read_text()
+        m = _FRONTMATTER_CODE_RE.search(text)
+        if m is not None:
+            out[m.group(1)] = md
+        else:
+            # Fallback: filename without extension. Lets a page be parsed
+            # even if frontmatter is missing — but the missing frontmatter
+            # itself is reported as a separate error class.
+            stem = md.stem
+            if stem.startswith("E_"):
+                out[stem] = md
+    return out
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--quiet", action="store_true",
+                   help="suppress success log; only print failures")
+    args = p.parse_args(argv)
+
+    src_codes = _scan_source_codes(REPO_ROOT)
+    doc_codes = _scan_doc_codes(DOCS_ERRORS)
+
+    missing_pages = sorted(set(src_codes) - set(doc_codes))
+    stale_pages = sorted(set(doc_codes) - set(src_codes))
+
+    rc = 0
+    if missing_pages:
+        rc = 1
+        print("::error::Error codes used in source but missing docs page:",
+              file=sys.stderr)
+        for code in missing_pages:
+            paths = sorted(str(p.relative_to(REPO_ROOT)) for p in src_codes[code])
+            print(f"  {code} (used in: {', '.join(paths)})", file=sys.stderr)
+            print(f"    Fix: create docs/errors/{code}.md", file=sys.stderr)
+
+    if stale_pages:
+        rc = 1
+        print("::error::docs/errors pages without any source references:",
+              file=sys.stderr)
+        for code in stale_pages:
+            print(f"  {code} ({doc_codes[code].relative_to(REPO_ROOT)})",
+                  file=sys.stderr)
+            print(f"    Fix: remove the page or restore the source reference",
+                  file=sys.stderr)
+
+    if rc == 0 and not args.quiet:
+        print(f"OK: {len(src_codes)} error codes — all have docs and are referenced.")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gen_llms_txt.py
+++ b/scripts/gen_llms_txt.py
@@ -111,6 +111,10 @@ SECTIONS: list[tuple[str, list[Entry]]] = [
         ("docs/how-to/ci.md", "CI configuration", "Continuous integration setup"),
         ("docs/how-to/contributing.md", "Contributing", "How to contribute"),
     ]),
+    ("Errors", [
+        ("docs/errors/index.md", "Error code reference", "Catalog of FloxError codes, format, and lifecycle"),
+        ("docs/errors/E_SYM_001.md", "E_SYM_001 — Symbol is not registered", "Fix: call Engine.add_symbol() before referencing the symbol"),
+    ]),
     ("Reference: Python", [
         ("docs/reference/python/index.md", "Python reference index", "All Python binding modules"),
         ("docs/reference/python/engine.md", "Engine and Backtest", "Engine + backtest entry points"),


### PR DESCRIPTION
## Summary

Introduces \`flox::FloxError\` — a structured exception carrying a stable code (e.g. \`E_SYM_001\`), a human message, and a help URL pointing to \`https://flox-foundation.github.io/flox/errors/<code>/\`. AI agents reading FLOX errors can resolve the code → URL → documented fix without parsing free-text messages.

This is the first PR of W2-T005 (structured errors). Migration is **incremental**: new throw sites use FloxError; pre-existing \`std::invalid_argument\` / \`std::runtime_error\` keep their default pybind11 mapping. The most-trafficked path — \"unknown symbol\" lookups — is migrated to \`E_SYM_001\` (3 sites in \`python/\`).

## What ships

- \`include/flox/error/flox_error.h\` — C++ class with \`code()\`, \`message()\`, \`helpUrl()\`. Inherits from \`std::runtime_error\` so existing C++ \`catch (const std::exception&)\` blocks keep working.
- \`python/flox_py.cpp\` translator — registers \`flox_py.FloxError(Exception)\` with \`.code\`, \`.message\`, \`.help_url\` attributes.
- \`docs/errors/index.md\` — code-format spec, domain table, frontmatter convention, contributor recipe.
- \`docs/errors/E_SYM_001.md\` — first migrated code with cross-language fix recipes.
- \`scripts/check_error_codes.py\` — CI gate that fails on (a) codes in source without a doc page, or (b) doc pages without source references.
- \`mkdocs.yml\` — Errors section in nav.
- \`scripts/gen_llms_txt.py\` — Errors entries in llms.txt / llms-full.txt.
- \`python/tests/test_bindings.py\` — 4 new assertions verifying FloxError surfaces correctly to Python.

## Migration policy

- **New throw sites:** \`throw flox::FloxError(\"E_DOMAIN_NNN\", \"message\")\`.
- **Existing sites:** stay until touched. Document each migrated code as a \`.md\` page.
- **Cross-binding (Node, Codon, QuickJS):** deferred to follow-up PRs. Each binding has its own exception model.

## Test plan

- [x] Build: \`cmake --build build --target _flox_py\` ✅
- [x] Python tests: \`python3 python/tests/test_bindings.py\` → 98 passed ✅
- [x] Error-code CI script: \`python3 scripts/check_error_codes.py\` → 1 code, all docs present ✅
- [x] Format check: \`bash scripts/check-format.sh\` ✅
- [x] Codegen check: \`bash tools/codegen/scripts/check.sh\` ✅
- [ ] CI green.

## Follow-ups

Tracked in T005. Top-20 most-trafficked errors → individual codes + pages, in subsequent PRs:

- E_DATA_001 (no data loaded)
- E_KEY_001 (missing event field)
- E_TIME_001 (unknown interval unit)
- E_LEN_001 (mismatched array lengths)
- E_ORDER_001 (invalid order parameters)
- ...

Plus Node / Codon / QuickJS FloxError exposure.

Refs W2-T005