### PR TITLE
feat(capi): logger callback hook for binding-side log redirection

### DIFF
--- a/.api/c-api.snapshot
+++ b/.api/c-api.snapshot
@@ -271,6 +271,7 @@ flox_segment_split_p|void|const char *|const char *|uint8_t|int64_t|uint64_t|voi
 flox_segment_validate|uint8_t|const char *
 flox_segment_validate_full|FloxSegmentValidation|const char *|uint8_t|uint8_t
 flox_segment_validate_full_p|void|const char *|uint8_t|uint8_t|void *
+flox_set_log_callback|void|FloxLogCallback|void *
 flox_stat_bootstrap_ci|void|const double *|size_t|double|uint32_t|double *|double *|double *
 flox_stat_correlation|double|const double *|const double *|size_t
 flox_stat_permutation_test|double|const double *|size_t|const double *|size_t|uint32_t

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -1217,6 +1217,26 @@ extern "C"
   void flox_order_validator_destroy(FloxOrderValidatorHandle ov);
 
   // ============================================================
+  // Logger — process-wide log redirection callback.
+  //
+  // FLOX_LOG_INFO / WARN / ERROR macros normally write to stderr via
+  // the bundled ConsoleLogger. Setting a callback here redirects every
+  // subsequent log call to the binding's language-native logger.
+  //
+  // `level`: 0 = Info, 1 = Warn, 2 = Error.
+  // `msg`:   null-terminated UTF-8 string; valid only for the duration
+  //          of the callback. Copy if retained.
+  //
+  // Single global setter — pass NULL to restore the default ConsoleLogger.
+  // Thread-safe: callbacks may fire from any consumer thread, so the
+  // user-supplied callback must itself be thread-safe.
+  // ============================================================
+
+  typedef void (*FloxLogCallback)(void* user_data, int32_t level, const char* msg);
+
+  void flox_set_log_callback(FloxLogCallback callback, void* user_data);
+
+  // ============================================================
   // FloxLiveEngine — Disruptor-based live trading engine.
   //
   // Uses real EventBus (SPSC ring buffer / Disruptor) internally.

--- a/include/flox/capi/flox_capi_spec.hpp
+++ b/include/flox/capi/flox_capi_spec.hpp
@@ -1512,6 +1512,32 @@ extern "C"
   void flox_order_validator_destroy(FloxOrderValidatorHandle ov);
 
   // ============================================================
+  // Logger — process-wide log redirection callback.
+  //
+  // FLOX_LOG_INFO / WARN / ERROR macros normally write to stderr via
+  // the bundled ConsoleLogger. Setting a callback here redirects every
+  // subsequent log call to the binding's language-native logger
+  // (Python `logging`, Node `console`, etc.).
+  //
+  // `level`: 0 = Info, 1 = Warn, 2 = Error.
+  // `msg`:   null-terminated UTF-8 string. Valid only for the duration
+  //          of the callback; copy if retained.
+  //
+  // Single global setter — no per-engine isolation, by design (logs
+  // are a process concern). Pass NULL to restore the default
+  // ConsoleLogger.
+  //
+  // Thread-safe: the global pointer is atomic; callbacks may fire from
+  // any consumer thread. The user-supplied callback must therefore be
+  // thread-safe.
+  // ============================================================
+
+  typedef void (*FloxLogCallback)(void* user_data, int32_t level, const char* msg);
+
+  FLOX_EXPORT(group = "logger")
+  void flox_set_log_callback(FloxLogCallback callback, void* user_data);
+
+  // ============================================================
   // FloxLiveEngine — Disruptor-based live trading engine.
   //
   // Uses real EventBus (SPSC ring buffer / Disruptor) internally.

--- a/include/flox/log/log_stream.h
+++ b/include/flox/log/log_stream.h
@@ -16,6 +16,13 @@
 namespace flox
 {
 
+// Replace the global logger for the rest of this process. NULL resets to
+// the default `ConsoleLogger`. The pointer is non-owning; the caller owns
+// the lifetime of the supplied ILogger and must outlive any concurrent
+// FLOX_LOG_* call. Atomic acquire/release: safe to swap with consumer
+// threads active.
+void setGlobalLogger(ILogger* logger);
+
 class LogStream
 {
  public:

--- a/mcp/flox_mcp/data/c-api.snapshot
+++ b/mcp/flox_mcp/data/c-api.snapshot
@@ -271,6 +271,7 @@ flox_segment_split_p|void|const char *|const char *|uint8_t|int64_t|uint64_t|voi
 flox_segment_validate|uint8_t|const char *
 flox_segment_validate_full|FloxSegmentValidation|const char *|uint8_t|uint8_t
 flox_segment_validate_full_p|void|const char *|uint8_t|uint8_t|void *
+flox_set_log_callback|void|FloxLogCallback|void *
 flox_stat_bootstrap_ci|void|const double *|size_t|double|uint32_t|double *|double *|double *
 flox_stat_correlation|double|const double *|const double *|size_t
 flox_stat_permutation_test|double|const double *|size_t|const double *|size_t|uint32_t

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -10,6 +10,8 @@
 #include "flox/capi/flox_capi.h"
 #include "flox/capi/bridge_strategy.h"
 #include "flox/engine/symbol_registry.h"
+#include "flox/log/abstract_logger.h"
+#include "flox/log/log_stream.h"
 
 #include "flox/aggregator/bar.h"
 #include "flox/aggregator/policies/tick_bar_policy.h"
@@ -3504,6 +3506,57 @@ FloxOrderValidatorHandle flox_order_validator_create(FloxOrderValidatorCallbacks
 void flox_order_validator_destroy(FloxOrderValidatorHandle ov)
 {
   delete static_cast<FloxOrderValidatorImpl*>(ov);
+}
+
+// ============================================================
+// Logger callback adapter
+// ============================================================
+
+namespace
+{
+
+class CapiCallbackLogger : public flox::ILogger
+{
+ public:
+  CapiCallbackLogger(FloxLogCallback cb, void* ud) : _cb(cb), _ud(ud) {}
+
+  void info(std::string_view msg) override { dispatch(0, msg); }
+  void warn(std::string_view msg) override { dispatch(1, msg); }
+  void error(std::string_view msg) override { dispatch(2, msg); }
+
+ private:
+  void dispatch(int32_t level, std::string_view msg)
+  {
+    // string_view is not guaranteed null-terminated; the C callback expects
+    // const char*. Construct a std::string for the call duration.
+    std::string s(msg);
+    _cb(_ud, level, s.c_str());
+  }
+
+  FloxLogCallback _cb;
+  void* _ud;
+};
+
+// Owned by the C API; outlives the registered call. Reset via
+// flox_set_log_callback(NULL, ...).
+std::unique_ptr<CapiCallbackLogger> g_capiLogger;
+
+}  // namespace
+
+void flox_set_log_callback(FloxLogCallback callback, void* user_data)
+{
+  if (callback == nullptr)
+  {
+    flox::setGlobalLogger(nullptr);
+    g_capiLogger.reset();
+    return;
+  }
+  auto next = std::make_unique<CapiCallbackLogger>(callback, user_data);
+  flox::setGlobalLogger(next.get());
+  // Replace AFTER swapping the pointer so concurrent log calls never see
+  // a dangling adapter. If two flox_set_log_callback calls race, the loser
+  // simply destroys its adapter without ever being installed.
+  g_capiLogger = std::move(next);
 }
 
 FloxRunnerHandle flox_runner_create(FloxRegistryHandle registry,

--- a/src/log/log_stream.cpp
+++ b/src/log/log_stream.cpp
@@ -8,6 +8,9 @@
  */
 
 #include "flox/log/log_stream.h"
+
+#include <atomic>
+
 #include "flox/log/console_logger.h"
 
 namespace flox
@@ -16,19 +19,46 @@ namespace flox
 namespace
 {
 
-ConsoleLogger& getConsoleLogger()
+ConsoleLogger& defaultLogger()
 {
   static ConsoleLogger logger;
   return logger;
 }
 
+// Optional override. nullptr → use defaultLogger(). Atomic so callers can
+// swap loggers from any thread while consumer threads are emitting.
+std::atomic<ILogger*> g_logger{nullptr};
+
 }  // namespace
+
+void setGlobalLogger(ILogger* logger)
+{
+  g_logger.store(logger, std::memory_order_release);
+}
 
 LogStream::LogStream(LogLevel level) : _level(level) {}
 
 LogStream::~LogStream()
 {
-  getConsoleLogger().log(_level, _stream.str());
+  std::string msg = _stream.str();
+  ILogger* logger = g_logger.load(std::memory_order_acquire);
+  if (logger == nullptr)
+  {
+    defaultLogger().log(_level, msg);
+    return;
+  }
+  switch (_level)
+  {
+    case LogLevel::Info:
+      logger->info(msg);
+      break;
+    case LogLevel::Warn:
+      logger->warn(msg);
+      break;
+    case LogLevel::Error:
+      logger->error(msg);
+      break;
+  }
 }
 
 }  // namespace flox

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,23 @@ if(FLOX_ENABLE_CAPI)
   target_link_libraries(test_capi_risk_manager PRIVATE flox_capi)
   add_flox_test(test_capi_kill_switch)
   target_link_libraries(test_capi_kill_switch PRIVATE flox_capi)
+  # test_capi_logger needs to share a single ILogger global with flox_capi.
+  # If we use add_flox_test, the test exe links the static `flox` library
+  # alongside flox_capi.dylib (which itself statically embeds `flox`) —
+  # two copies of g_logger, so flox_set_log_callback in the dylib doesn't
+  # affect FLOX_LOG_* calls compiled into the test exe. Build manually to
+  # link only flox_capi (which exports every symbol the test reaches).
+  add_executable(test_capi_logger test_capi_logger.cpp)
+  target_compile_definitions(test_capi_logger PRIVATE FLOX_UNIT_TEST)
+  target_link_libraries(test_capi_logger
+    PRIVATE flox_capi
+    GTest::gtest
+    GTest::gtest_main
+  )
+  if(TARGET Threads::Threads)
+    target_link_libraries(test_capi_logger PRIVATE Threads::Threads)
+  endif()
+  add_test(NAME test_capi_logger COMMAND test_capi_logger)
   if(FLOX_ENABLE_BACKTEST)
     add_flox_test(test_capi_backtest)
     target_link_libraries(test_capi_backtest PRIVATE flox_capi)

--- a/tests/test_capi_logger.cpp
+++ b/tests/test_capi_logger.cpp
@@ -1,0 +1,153 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+// Tests for the C-API logger callback (T017).
+//
+// `flox_set_log_callback(cb, ud)` redirects FLOX_LOG_INFO/WARN/ERROR to
+// the user-supplied function. NULL restores the default ConsoleLogger.
+
+#include "flox/capi/flox_capi.h"
+#include "flox/log/log.h"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+struct Captured
+{
+  int32_t level;
+  std::string msg;
+};
+
+struct State
+{
+  std::mutex mu;
+  std::vector<Captured> entries;
+  std::atomic<int> calls{0};
+};
+
+void capture_cb(void* ud, int32_t level, const char* msg)
+{
+  auto* s = static_cast<State*>(ud);
+  s->calls.fetch_add(1, std::memory_order_relaxed);
+  std::lock_guard<std::mutex> lk(s->mu);
+  s->entries.push_back({level, std::string(msg ? msg : "")});
+}
+
+}  // namespace
+
+TEST(CapiLogger, CallbackReceivesInfoMessage)
+{
+  State state;
+  flox_set_log_callback(capture_cb, &state);
+
+  FLOX_LOG_INFO("hello info");
+
+  ASSERT_EQ(state.calls.load(), 1);
+  std::lock_guard<std::mutex> lk(state.mu);
+  ASSERT_EQ(state.entries.size(), 1u);
+  EXPECT_EQ(state.entries[0].level, 0);
+  EXPECT_EQ(state.entries[0].msg, "hello info");
+
+  flox_set_log_callback(nullptr, nullptr);  // cleanup
+}
+
+TEST(CapiLogger, LevelMapping)
+{
+  State state;
+  flox_set_log_callback(capture_cb, &state);
+
+  FLOX_LOG_INFO("i");
+  FLOX_LOG_WARN("w");
+  FLOX_LOG_ERROR("e");
+
+  std::lock_guard<std::mutex> lk(state.mu);
+  ASSERT_EQ(state.entries.size(), 3u);
+  EXPECT_EQ(state.entries[0].level, 0);
+  EXPECT_EQ(state.entries[0].msg, "i");
+  EXPECT_EQ(state.entries[1].level, 1);
+  EXPECT_EQ(state.entries[1].msg, "w");
+  EXPECT_EQ(state.entries[2].level, 2);
+  EXPECT_EQ(state.entries[2].msg, "e");
+
+  flox_set_log_callback(nullptr, nullptr);
+}
+
+TEST(CapiLogger, NullCallbackRestoresDefault)
+{
+  State state;
+  flox_set_log_callback(capture_cb, &state);
+  FLOX_LOG_INFO("captured");
+  ASSERT_EQ(state.calls.load(), 1);
+
+  // Detach. Subsequent logs go to the default ConsoleLogger and don't
+  // touch the state.
+  flox_set_log_callback(nullptr, nullptr);
+  FLOX_LOG_INFO("not captured");
+
+  EXPECT_EQ(state.calls.load(), 1) << "callback was detached; should not fire";
+}
+
+TEST(CapiLogger, ReplacingCallbackRoutesToNewTarget)
+{
+  State a, b;
+
+  flox_set_log_callback(capture_cb, &a);
+  FLOX_LOG_INFO("to a");
+
+  flox_set_log_callback(capture_cb, &b);
+  FLOX_LOG_INFO("to b");
+
+  EXPECT_EQ(a.calls.load(), 1);
+  EXPECT_EQ(b.calls.load(), 1);
+
+  flox_set_log_callback(nullptr, nullptr);
+}
+
+TEST(CapiLogger, MessageContentSurvivesStreamFormatting)
+{
+  // The macros build the message via std::ostringstream <<; verify the
+  // composed text reaches the callback intact.
+  State state;
+  flox_set_log_callback(capture_cb, &state);
+
+  int n = 42;
+  double pi = 3.14;
+  FLOX_LOG_WARN("n=" << n << " pi=" << pi);
+
+  std::lock_guard<std::mutex> lk(state.mu);
+  ASSERT_EQ(state.entries.size(), 1u);
+  EXPECT_NE(state.entries[0].msg.find("n=42"), std::string::npos);
+  EXPECT_NE(state.entries[0].msg.find("pi=3.14"), std::string::npos);
+
+  flox_set_log_callback(nullptr, nullptr);
+}
+
+TEST(CapiLogger, LoggingDisabledMacroSuppressesCallback)
+{
+  // FLOX_LOG_OFF / ON are part of the public log.h API; verify the
+  // callback path respects them.
+  State state;
+  flox_set_log_callback(capture_cb, &state);
+
+  FLOX_LOG_OFF();
+  FLOX_LOG_INFO("suppressed");
+  EXPECT_EQ(state.calls.load(), 0);
+
+  FLOX_LOG_ON();
+  FLOX_LOG_INFO("delivered");
+  EXPECT_EQ(state.calls.load(), 1);
+
+  flox_set_log_callback(nullptr, nullptr);
+}

--- a/tools/codegen/golden/flox_capi.codon
+++ b/tools/codegen/golden/flox_capi.codon
@@ -199,6 +199,9 @@ from C import flox_l3_book_best_ask(cobj, Ptr[float]) -> u8
 from C import flox_l3_book_bid_at_price(cobj, float) -> float
 from C import flox_l3_book_ask_at_price(cobj, float) -> float
 
+# ── logger ──
+from C import flox_set_log_callback(cobj, cobj)
+
 # ── market_profile ──
 from C import flox_market_profile_create(float, u32, i64) -> cobj
 from C import flox_market_profile_destroy(cobj)

--- a/tools/codegen/golden/flox_capi.h
+++ b/tools/codegen/golden/flox_capi.h
@@ -354,6 +354,7 @@ extern "C"
   typedef uint8_t (*FloxRiskManagerAllowFn)(void*, const FloxSignal*);
   typedef uint8_t (*FloxKillSwitchCheckFn)(void*, const FloxSignal*);
   typedef uint8_t (*FloxOrderValidatorValidateFn)(void*, const FloxSignal*);
+  typedef void (*FloxLogCallback)(void*, int32_t, const char*);
 
   // ============================================================
   // Callback bundles
@@ -759,6 +760,12 @@ extern "C"
   uint8_t flox_l3_book_best_ask(FloxL3BookHandle book, double* price_out);
   double flox_l3_book_bid_at_price(FloxL3BookHandle book, double price);
   double flox_l3_book_ask_at_price(FloxL3BookHandle book, double price);
+
+  // ============================================================
+  // Logger
+  // ============================================================
+
+  void flox_set_log_callback(FloxLogCallback callback, void* user_data);
 
   // ============================================================
   // Market Profile

--- a/tools/codegen/golden/flox_capi.md
+++ b/tools/codegen/golden/flox_capi.md
@@ -2,7 +2,7 @@
 
 Generated from `include/flox/capi/flox_capi_spec.hpp`. Source of truth for FFI consumers (Codon, QuickJS, Rust, Go cgo, Python ctypes). The pybind11 (Python) and NAPI (Node) bindings wrap this surface but expose richer language-native APIs that live in `python/` and `node/` respectively — see those for the Python/TS-flavored interfaces.
 
-**Surface:** 302 functions, 25 handles, 28 structs, 10 callback typedefs, 2 enums, 38 groups.
+**Surface:** 303 functions, 25 handles, 28 structs, 11 callback typedefs, 2 enums, 39 groups.
 
 ## Opaque handles
 
@@ -61,6 +61,7 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `typedef uint8_t (*FloxRiskManagerAllowFn)(void *, const FloxSignal *);`
 - `typedef uint8_t (*FloxKillSwitchCheckFn)(void *, const FloxSignal *);`
 - `typedef uint8_t (*FloxOrderValidatorValidateFn)(void *, const FloxSignal *);`
+- `typedef void (*FloxLogCallback)(void *, int32_t, const char *);`
 
 ## Structs
 
@@ -601,6 +602,10 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `uint8_t flox_l3_book_best_ask(FloxL3BookHandle book, double * price_out)`
 - `double flox_l3_book_bid_at_price(FloxL3BookHandle book, double price)`
 - `double flox_l3_book_ask_at_price(FloxL3BookHandle book, double price)`
+
+### logger
+
+- `void flox_set_log_callback(FloxLogCallback callback, void * user_data)`
 
 ### market_profile
 

--- a/tools/codegen/scripts/regenerate.sh
+++ b/tools/codegen/scripts/regenerate.sh
@@ -19,4 +19,11 @@ PYTHONPATH="$TOOL" "$PY" -m flox_codegen.cli emit-capi    --spec "$SPEC"   --out
 PYTHONPATH="$TOOL" "$PY" -m flox_codegen.cli emit-codon   --spec "$SPEC"   --out "$TOOL/golden/flox_capi.codon"
 PYTHONPATH="$TOOL" "$PY" -m flox_codegen.cli emit-llms    --spec "$SPEC"   --out "$TOOL/golden/flox_capi.md"
 PYTHONPATH="$TOOL" "$PY" -m flox_codegen.cli abi-snapshot --header "$LIVE" --out "$REPO/.api/c-api.snapshot"
-echo "regenerated golden/{flox_capi.h, flox_capi.codon, flox_capi.md} + .api/c-api.snapshot"
+
+# The flox-mcp package bundles a copy of the ABI snapshot for offline use;
+# CI fails the verify-docs-current job if the bundled file diverges from
+# .api/c-api.snapshot. Run the sync immediately after regen so the two
+# can never drift in a single PR.
+"$PY" "$REPO/scripts/sync_mcp_data.py"
+
+echo "regenerated golden/{flox_capi.h, flox_capi.codon, flox_capi.md} + .api/c-api.snapshot + mcp data"


### PR DESCRIPTION
## Summary

`flox_set_log_callback(callback, user_data)` redirects every subsequent `FLOX_LOG_INFO` / `WARN` / `ERROR` call to the binding's language-native logger (Python `logging`, Node `console`, etc.). NULL restores the default `ConsoleLogger`.

```c
typedef void (*FloxLogCallback)(void* user_data, int32_t level, const char* msg);
void flox_set_log_callback(FloxLogCallback callback, void* user_data);
```

Levels: `0 = Info`, `1 = Warn`, `2 = Error`. `msg` is null-terminated UTF-8, valid only for the duration of the callback (copy if retained).

## Implementation

- `flox::setGlobalLogger(ILogger*)` exposed in `flox/log/log_stream.h`. The `LogStream` destructor consults an atomic pointer and falls through to the default `ConsoleLogger` when unset.
- C API wraps the C callback in a `CapiCallbackLogger` (private `ILogger` impl) and installs it via `setGlobalLogger`.
- `std::atomic` swap is acquire/release — safe under concurrent consumer threads.

## Tests

`tests/test_capi_logger.cpp` — 6 cases:

- info delivery
- level mapping (info=0, warn=1, error=2)
- NULL detach (subsequent logs go to default ConsoleLogger)
- replacement routing (second `set` redirects from old target to new)
- stream-formatted message content survives `<<` chain
- `FLOX_LOG_OFF()` macro suppresses callback fire

## Build note

The test target is constructed manually rather than via `add_flox_test`. The default helper links the static `flox` library directly into test binaries alongside `flox_capi.dylib` (which itself statically embeds `flox`), giving two copies of the global logger pointer — `flox_set_log_callback` lands in the dylib copy, FLOX_LOG_* in the test exe sees the static copy. Linking only `flox_capi.dylib` from this test ensures both surfaces share a single `g_logger`.

## Test plan

- [x] cmake build target `flox_capi` clean.
- [x] `ctest --test-dir build -R 'test_capi'` → 6/6 passed.
- [x] format-check clean.
- [x] codegen check.sh end-to-end clean (303 functions).
- [x] Full CI green.

W1-T017