### PR TITLE
feat(capi): post-emission observer hooks (PnLTracker, StorageSink)

### DIFF
--- a/.api/c-api.snapshot
+++ b/.api/c-api.snapshot
@@ -180,7 +180,9 @@ flox_live_engine_publish_book_snapshot|void|FloxLiveEngineHandle|uint32_t|const 
 flox_live_engine_publish_trade|void|FloxLiveEngineHandle|uint32_t|double|double|uint8_t|int64_t
 flox_live_engine_set_kill_switch|void|FloxLiveEngineHandle|FloxKillSwitchHandle
 flox_live_engine_set_order_validator|void|FloxLiveEngineHandle|FloxOrderValidatorHandle
+flox_live_engine_set_pnl_tracker|void|FloxLiveEngineHandle|FloxPnLTrackerHandle
 flox_live_engine_set_risk_manager|void|FloxLiveEngineHandle|FloxRiskManagerHandle
+flox_live_engine_set_storage_sink|void|FloxLiveEngineHandle|FloxStorageSinkHandle
 flox_live_engine_start|void|FloxLiveEngineHandle
 flox_live_engine_stop|void|FloxLiveEngineHandle
 flox_market_profile_add_trade|void|FloxMarketProfileHandle|int64_t|double|double|uint8_t
@@ -215,6 +217,8 @@ flox_partitioner_by_time|uint32_t|FloxPartitionerHandle|uint32_t|int64_t|FloxPar
 flox_partitioner_create|FloxPartitionerHandle|const char *
 flox_partitioner_destroy|void|FloxPartitionerHandle
 flox_partitioner_per_symbol|uint32_t|FloxPartitionerHandle|FloxPartition *|uint32_t
+flox_pnl_tracker_create|FloxPnLTrackerHandle|FloxPnLTrackerCallbacks
+flox_pnl_tracker_destroy|void|FloxPnLTrackerHandle
 flox_position_group_close|void|FloxPositionGroupHandle|uint64_t|double
 flox_position_group_create|FloxPositionGroupHandle
 flox_position_group_destroy|void|FloxPositionGroupHandle
@@ -253,7 +257,9 @@ flox_runner_on_book_snapshot|void|FloxRunnerHandle|uint32_t|const double *|const
 flox_runner_on_trade|void|FloxRunnerHandle|uint32_t|double|double|uint8_t|int64_t
 flox_runner_set_kill_switch|void|FloxRunnerHandle|FloxKillSwitchHandle
 flox_runner_set_order_validator|void|FloxRunnerHandle|FloxOrderValidatorHandle
+flox_runner_set_pnl_tracker|void|FloxRunnerHandle|FloxPnLTrackerHandle
 flox_runner_set_risk_manager|void|FloxRunnerHandle|FloxRiskManagerHandle
+flox_runner_set_storage_sink|void|FloxRunnerHandle|FloxStorageSinkHandle
 flox_runner_start|void|FloxRunnerHandle
 flox_runner_stop|void|FloxRunnerHandle
 flox_segment_export|FloxExportResult|const char *|const char *|uint8_t|int64_t|int64_t|const uint32_t *|uint32_t
@@ -277,6 +283,8 @@ flox_stat_correlation|double|const double *|const double *|size_t
 flox_stat_permutation_test|double|const double *|size_t|const double *|size_t|uint32_t
 flox_stat_profit_factor|double|const double *|size_t
 flox_stat_win_rate|double|const double *|size_t
+flox_storage_sink_create|FloxStorageSinkHandle|FloxStorageSinkCallbacks
+flox_storage_sink_destroy|void|FloxStorageSinkHandle
 flox_strategy_create|FloxStrategyHandle|uint32_t|const uint32_t *|uint32_t|FloxRegistryHandle|FloxStrategyCallbacks
 flox_strategy_destroy|void|FloxStrategyHandle
 flox_streaming_graph_add_node|void|FloxStreamingGraphHandle|const char *|const char *const *|size_t|FloxGraphNodeFn|void *

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -1237,6 +1237,43 @@ extern "C"
   void flox_set_log_callback(FloxLogCallback callback, void* user_data);
 
   // ============================================================
+  // PnLTracker — post-emission observer (fires after on_signal,
+  // never blocks). Attach to a runner / engine to shadow-track
+  // exposure based on emitted signals. NULL detaches.
+  // ============================================================
+
+  typedef void (*FloxPnLTrackerOnSignalFn)(void* user_data, const FloxSignal* signal);
+
+  typedef struct
+  {
+    FloxPnLTrackerOnSignalFn on_signal;
+    void* user_data;
+  } FloxPnLTrackerCallbacks;
+
+  typedef void* FloxPnLTrackerHandle;
+
+  FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks callbacks);
+  void flox_pnl_tracker_destroy(FloxPnLTrackerHandle tracker);
+
+  // ============================================================
+  // StorageSink — same shape as PnLTracker; persist every emitted
+  // signal to the binding's storage. Fires after PnLTracker.
+  // ============================================================
+
+  typedef void (*FloxStorageSinkStoreFn)(void* user_data, const FloxSignal* signal);
+
+  typedef struct
+  {
+    FloxStorageSinkStoreFn store;
+    void* user_data;
+  } FloxStorageSinkCallbacks;
+
+  typedef void* FloxStorageSinkHandle;
+
+  FloxStorageSinkHandle flox_storage_sink_create(FloxStorageSinkCallbacks callbacks);
+  void flox_storage_sink_destroy(FloxStorageSinkHandle sink);
+
+  // ============================================================
   // FloxLiveEngine — Disruptor-based live trading engine.
   //
   // Uses real EventBus (SPSC ring buffer / Disruptor) internally.
@@ -1273,6 +1310,12 @@ extern "C"
                                         FloxKillSwitchHandle ks);
   void flox_live_engine_set_order_validator(FloxLiveEngineHandle engine,
                                             FloxOrderValidatorHandle ov);
+
+  // Post-emission observers. PnLTracker → StorageSink, after on_signal.
+  void flox_live_engine_set_pnl_tracker(FloxLiveEngineHandle engine,
+                                        FloxPnLTrackerHandle tracker);
+  void flox_live_engine_set_storage_sink(FloxLiveEngineHandle engine,
+                                         FloxStorageSinkHandle sink);
 
   // Attach a strategy to both TradeBus and BookUpdateBus.
   // on_signal is called from the consumer thread when the strategy emits an order.
@@ -1353,6 +1396,12 @@ extern "C"
                                    FloxKillSwitchHandle ks);
   void flox_runner_set_order_validator(FloxRunnerHandle runner,
                                        FloxOrderValidatorHandle ov);
+
+  // Post-emission observers. PnLTracker → StorageSink, after on_signal.
+  void flox_runner_set_pnl_tracker(FloxRunnerHandle runner,
+                                   FloxPnLTrackerHandle tracker);
+  void flox_runner_set_storage_sink(FloxRunnerHandle runner,
+                                    FloxStorageSinkHandle sink);
 
   void flox_runner_start(FloxRunnerHandle runner);
   void flox_runner_stop(FloxRunnerHandle runner);

--- a/include/flox/capi/flox_capi_spec.hpp
+++ b/include/flox/capi/flox_capi_spec.hpp
@@ -1538,6 +1538,67 @@ extern "C"
   void flox_set_log_callback(FloxLogCallback callback, void* user_data);
 
   // ============================================================
+  // PnLTracker — post-emission observer hook.
+  //
+  // Unlike the pre-trade gates (KillSwitch / OrderValidator /
+  // RiskManager) which can DROP a signal, PnLTracker fires **after**
+  // the user's on_signal callback runs. It's an observer; the return
+  // type is void and the signal has already been delivered to the
+  // binding. Use this for shadow-tracking exposure based on emitted
+  // signals — independent of any later fill confirmation from a
+  // broker.
+  //
+  // For real fill-driven P&L, attach the binding's tracker to its
+  // own broker callback path; the C API doesn't surface fill events
+  // beyond the SimulatedExecutor.
+  //
+  // Lifecycle / threading match RiskManager: NULL detaches; atomic
+  // pointer swap is safe with consumer threads active.
+  // ============================================================
+
+  typedef void (*FloxPnLTrackerOnSignalFn)(void* user_data, const FloxSignal* signal);
+
+  typedef struct
+  {
+    FloxPnLTrackerOnSignalFn on_signal;
+    void* user_data;
+  } FloxPnLTrackerCallbacks;
+
+  typedef void* FloxPnLTrackerHandle;
+
+  FLOX_EXPORT(group = "metrics")
+  FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks callbacks);
+  FLOX_EXPORT(group = "metrics")
+  void flox_pnl_tracker_destroy(FloxPnLTrackerHandle tracker);
+
+  // ============================================================
+  // StorageSink — persist every emitted signal.
+  //
+  // Same shape and timing as PnLTracker — fires after on_signal,
+  // never blocks. Use this to write each emitted signal to the
+  // binding's storage of choice (DB, append-only log, broker audit
+  // trail).
+  //
+  // The signal pointer is read-only and valid only for the duration
+  // of the callback; copy if retained.
+  // ============================================================
+
+  typedef void (*FloxStorageSinkStoreFn)(void* user_data, const FloxSignal* signal);
+
+  typedef struct
+  {
+    FloxStorageSinkStoreFn store;
+    void* user_data;
+  } FloxStorageSinkCallbacks;
+
+  typedef void* FloxStorageSinkHandle;
+
+  FLOX_EXPORT(group = "storage")
+  FloxStorageSinkHandle flox_storage_sink_create(FloxStorageSinkCallbacks callbacks);
+  FLOX_EXPORT(group = "storage")
+  void flox_storage_sink_destroy(FloxStorageSinkHandle sink);
+
+  // ============================================================
   // FloxLiveEngine — Disruptor-based live trading engine.
   //
   // Uses real EventBus (SPSC ring buffer / Disruptor) internally.
@@ -1588,6 +1649,15 @@ extern "C"
   FLOX_EXPORT(group = "risk")
   void flox_live_engine_set_order_validator(FloxLiveEngineHandle engine,
                                             FloxOrderValidatorHandle ov);
+
+  // Post-emission observers. Fire after on_signal, in the order
+  // PnLTracker → StorageSink. Detach with NULL.
+  FLOX_EXPORT(group = "metrics")
+  void flox_live_engine_set_pnl_tracker(FloxLiveEngineHandle engine,
+                                        FloxPnLTrackerHandle tracker);
+  FLOX_EXPORT(group = "storage")
+  void flox_live_engine_set_storage_sink(FloxLiveEngineHandle engine,
+                                         FloxStorageSinkHandle sink);
 
   FLOX_EXPORT(group = "floxliveengine_disruptor")
   void flox_live_engine_start(FloxLiveEngineHandle engine);
@@ -1672,6 +1742,15 @@ extern "C"
   FLOX_EXPORT(group = "risk")
   void flox_runner_set_order_validator(FloxRunnerHandle runner,
                                        FloxOrderValidatorHandle ov);
+
+  // Post-emission observers. Fire after on_signal in the order
+  // PnLTracker → StorageSink.
+  FLOX_EXPORT(group = "metrics")
+  void flox_runner_set_pnl_tracker(FloxRunnerHandle runner,
+                                   FloxPnLTrackerHandle tracker);
+  FLOX_EXPORT(group = "storage")
+  void flox_runner_set_storage_sink(FloxRunnerHandle runner,
+                                    FloxStorageSinkHandle sink);
 
   FLOX_EXPORT(group = "strategyrunner_synchronous")
   void flox_runner_start(FloxRunnerHandle runner);

--- a/mcp/flox_mcp/data/c-api.snapshot
+++ b/mcp/flox_mcp/data/c-api.snapshot
@@ -180,7 +180,9 @@ flox_live_engine_publish_book_snapshot|void|FloxLiveEngineHandle|uint32_t|const 
 flox_live_engine_publish_trade|void|FloxLiveEngineHandle|uint32_t|double|double|uint8_t|int64_t
 flox_live_engine_set_kill_switch|void|FloxLiveEngineHandle|FloxKillSwitchHandle
 flox_live_engine_set_order_validator|void|FloxLiveEngineHandle|FloxOrderValidatorHandle
+flox_live_engine_set_pnl_tracker|void|FloxLiveEngineHandle|FloxPnLTrackerHandle
 flox_live_engine_set_risk_manager|void|FloxLiveEngineHandle|FloxRiskManagerHandle
+flox_live_engine_set_storage_sink|void|FloxLiveEngineHandle|FloxStorageSinkHandle
 flox_live_engine_start|void|FloxLiveEngineHandle
 flox_live_engine_stop|void|FloxLiveEngineHandle
 flox_market_profile_add_trade|void|FloxMarketProfileHandle|int64_t|double|double|uint8_t
@@ -215,6 +217,8 @@ flox_partitioner_by_time|uint32_t|FloxPartitionerHandle|uint32_t|int64_t|FloxPar
 flox_partitioner_create|FloxPartitionerHandle|const char *
 flox_partitioner_destroy|void|FloxPartitionerHandle
 flox_partitioner_per_symbol|uint32_t|FloxPartitionerHandle|FloxPartition *|uint32_t
+flox_pnl_tracker_create|FloxPnLTrackerHandle|FloxPnLTrackerCallbacks
+flox_pnl_tracker_destroy|void|FloxPnLTrackerHandle
 flox_position_group_close|void|FloxPositionGroupHandle|uint64_t|double
 flox_position_group_create|FloxPositionGroupHandle
 flox_position_group_destroy|void|FloxPositionGroupHandle
@@ -253,7 +257,9 @@ flox_runner_on_book_snapshot|void|FloxRunnerHandle|uint32_t|const double *|const
 flox_runner_on_trade|void|FloxRunnerHandle|uint32_t|double|double|uint8_t|int64_t
 flox_runner_set_kill_switch|void|FloxRunnerHandle|FloxKillSwitchHandle
 flox_runner_set_order_validator|void|FloxRunnerHandle|FloxOrderValidatorHandle
+flox_runner_set_pnl_tracker|void|FloxRunnerHandle|FloxPnLTrackerHandle
 flox_runner_set_risk_manager|void|FloxRunnerHandle|FloxRiskManagerHandle
+flox_runner_set_storage_sink|void|FloxRunnerHandle|FloxStorageSinkHandle
 flox_runner_start|void|FloxRunnerHandle
 flox_runner_stop|void|FloxRunnerHandle
 flox_segment_export|FloxExportResult|const char *|const char *|uint8_t|int64_t|int64_t|const uint32_t *|uint32_t
@@ -277,6 +283,8 @@ flox_stat_correlation|double|const double *|const double *|size_t
 flox_stat_permutation_test|double|const double *|size_t|const double *|size_t|uint32_t
 flox_stat_profit_factor|double|const double *|size_t
 flox_stat_win_rate|double|const double *|size_t
+flox_storage_sink_create|FloxStorageSinkHandle|FloxStorageSinkCallbacks
+flox_storage_sink_destroy|void|FloxStorageSinkHandle
 flox_strategy_create|FloxStrategyHandle|uint32_t|const uint32_t *|uint32_t|FloxRegistryHandle|FloxStrategyCallbacks
 flox_strategy_destroy|void|FloxStrategyHandle
 flox_streaming_graph_add_node|void|FloxStreamingGraphHandle|const char *|const char *const *|size_t|FloxGraphNodeFn|void *

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -2822,6 +2822,18 @@ struct FloxOrderValidatorImpl
   FloxOrderValidatorCallbacks cb;
 };
 
+// Post-emission observers. Fire after the user on_signal callback.
+// Never block; return type is void.
+struct FloxPnLTrackerImpl
+{
+  FloxPnLTrackerCallbacks cb;
+};
+
+struct FloxStorageSinkImpl
+{
+  FloxStorageSinkCallbacks cb;
+};
+
 class RunnerSignalHandler : public ISignalHandler
 {
  public:
@@ -2840,6 +2852,14 @@ class RunnerSignalHandler : public ISignalHandler
   void setOrderValidator(FloxOrderValidatorImpl* ov) noexcept
   {
     _validator.store(ov, std::memory_order_release);
+  }
+  void setPnLTracker(FloxPnLTrackerImpl* p) noexcept
+  {
+    _pnl.store(p, std::memory_order_release);
+  }
+  void setStorageSink(FloxStorageSinkImpl* s) noexcept
+  {
+    _sink.store(s, std::memory_order_release);
   }
 
   void onSignal(const Signal& sig) override
@@ -2927,6 +2947,21 @@ class RunnerSignalHandler : public ISignalHandler
     }
 
     _cb(_ud, &fs);
+
+    // Post-emission observers, fired in declared order: PnL → Storage.
+    // Return type is void; observers cannot drop the signal (it's already
+    // been delivered). The user callback runs first so the binding's
+    // hot-path latency isn't affected by observer cost.
+    if (auto* pnl = _pnl.load(std::memory_order_acquire);
+        pnl != nullptr && pnl->cb.on_signal != nullptr)
+    {
+      pnl->cb.on_signal(pnl->cb.user_data, &fs);
+    }
+    if (auto* sink = _sink.load(std::memory_order_acquire);
+        sink != nullptr && sink->cb.store != nullptr)
+    {
+      sink->cb.store(sink->cb.user_data, &fs);
+    }
   }
 
  private:
@@ -2935,6 +2970,8 @@ class RunnerSignalHandler : public ISignalHandler
   std::atomic<FloxRiskManagerImpl*> _risk{nullptr};
   std::atomic<FloxKillSwitchImpl*> _kill{nullptr};
   std::atomic<FloxOrderValidatorImpl*> _validator{nullptr};
+  std::atomic<FloxPnLTrackerImpl*> _pnl{nullptr};
+  std::atomic<FloxStorageSinkImpl*> _sink{nullptr};
 };
 
 struct FloxRunnerImpl
@@ -2961,6 +2998,8 @@ struct FloxRunnerImpl
   {
     handler.setOrderValidator(ov);
   }
+  void setPnLTracker(FloxPnLTrackerImpl* p) { handler.setPnLTracker(p); }
+  void setStorageSink(FloxStorageSinkImpl* s) { handler.setStorageSink(s); }
 
   void start()
   {
@@ -3077,6 +3116,8 @@ struct FloxLiveEngineImpl
   std::atomic<FloxRiskManagerImpl*> riskManager{nullptr};
   std::atomic<FloxKillSwitchImpl*> killSwitch{nullptr};
   std::atomic<FloxOrderValidatorImpl*> orderValidator{nullptr};
+  std::atomic<FloxPnLTrackerImpl*> pnlTracker{nullptr};
+  std::atomic<FloxStorageSinkImpl*> storageSink{nullptr};
 
   explicit FloxLiveEngineImpl(SymbolRegistry* reg)
       : registry(reg),
@@ -3092,6 +3133,8 @@ struct FloxLiveEngineImpl
     h->setRiskManager(riskManager.load(std::memory_order_acquire));
     h->setKillSwitch(killSwitch.load(std::memory_order_acquire));
     h->setOrderValidator(orderValidator.load(std::memory_order_acquire));
+    h->setPnLTracker(pnlTracker.load(std::memory_order_acquire));
+    h->setStorageSink(storageSink.load(std::memory_order_acquire));
     s->setSignalHandler(h.get());
     handlers.push_back(std::move(h));
     tradeBus->subscribe(s);
@@ -3124,6 +3167,22 @@ struct FloxLiveEngineImpl
     for (auto& h : handlers)
     {
       h->setOrderValidator(ov);
+    }
+  }
+  void setPnLTracker(FloxPnLTrackerImpl* p)
+  {
+    pnlTracker.store(p, std::memory_order_release);
+    for (auto& h : handlers)
+    {
+      h->setPnLTracker(p);
+    }
+  }
+  void setStorageSink(FloxStorageSinkImpl* s)
+  {
+    storageSink.store(s, std::memory_order_release);
+    for (auto& h : handlers)
+    {
+      h->setStorageSink(s);
     }
   }
 
@@ -3508,6 +3567,26 @@ void flox_order_validator_destroy(FloxOrderValidatorHandle ov)
   delete static_cast<FloxOrderValidatorImpl*>(ov);
 }
 
+FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks callbacks)
+{
+  return static_cast<FloxPnLTrackerHandle>(new FloxPnLTrackerImpl{callbacks});
+}
+
+void flox_pnl_tracker_destroy(FloxPnLTrackerHandle tracker)
+{
+  delete static_cast<FloxPnLTrackerImpl*>(tracker);
+}
+
+FloxStorageSinkHandle flox_storage_sink_create(FloxStorageSinkCallbacks callbacks)
+{
+  return static_cast<FloxStorageSinkHandle>(new FloxStorageSinkImpl{callbacks});
+}
+
+void flox_storage_sink_destroy(FloxStorageSinkHandle sink)
+{
+  delete static_cast<FloxStorageSinkImpl*>(sink);
+}
+
 // ============================================================
 // Logger callback adapter
 // ============================================================
@@ -3593,6 +3672,18 @@ void flox_runner_set_order_validator(FloxRunnerHandle runner, FloxOrderValidator
       static_cast<capi_impl::FloxOrderValidatorImpl*>(ov));
 }
 
+void flox_runner_set_pnl_tracker(FloxRunnerHandle runner, FloxPnLTrackerHandle tracker)
+{
+  toRunner(runner)->setPnLTracker(
+      static_cast<capi_impl::FloxPnLTrackerImpl*>(tracker));
+}
+
+void flox_runner_set_storage_sink(FloxRunnerHandle runner, FloxStorageSinkHandle sink)
+{
+  toRunner(runner)->setStorageSink(
+      static_cast<capi_impl::FloxStorageSinkImpl*>(sink));
+}
+
 void flox_runner_start(FloxRunnerHandle runner)
 {
   toRunner(runner)->start();
@@ -3674,6 +3765,20 @@ void flox_live_engine_set_order_validator(FloxLiveEngineHandle engine,
 {
   toLiveEngine(engine)->setOrderValidator(
       static_cast<capi_impl::FloxOrderValidatorImpl*>(ov));
+}
+
+void flox_live_engine_set_pnl_tracker(FloxLiveEngineHandle engine,
+                                      FloxPnLTrackerHandle tracker)
+{
+  toLiveEngine(engine)->setPnLTracker(
+      static_cast<capi_impl::FloxPnLTrackerImpl*>(tracker));
+}
+
+void flox_live_engine_set_storage_sink(FloxLiveEngineHandle engine,
+                                       FloxStorageSinkHandle sink)
+{
+  toLiveEngine(engine)->setStorageSink(
+      static_cast<capi_impl::FloxStorageSinkImpl*>(sink));
 }
 
 void flox_live_engine_start(FloxLiveEngineHandle engine)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,8 @@ if(FLOX_ENABLE_CAPI)
   target_link_libraries(test_capi_risk_manager PRIVATE flox_capi)
   add_flox_test(test_capi_kill_switch)
   target_link_libraries(test_capi_kill_switch PRIVATE flox_capi)
+  add_flox_test(test_capi_observers)
+  target_link_libraries(test_capi_observers PRIVATE flox_capi)
   # test_capi_logger needs to share a single ILogger global with flox_capi.
   # If we use add_flox_test, the test exe links the static `flox` library
   # alongside flox_capi.dylib (which itself statically embeds `flox`) —

--- a/tests/test_capi_observers.cpp
+++ b/tests/test_capi_observers.cpp
@@ -1,0 +1,294 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+// Tests for the post-emission observer hooks (T018 PnLTracker, T019
+// StorageSink). Both fire after the user on_signal callback, never block.
+
+#include "flox/capi/flox_capi.h"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <vector>
+
+namespace
+{
+
+struct State
+{
+  std::atomic<int> on_signal_calls{0};
+  std::atomic<int> pnl_calls{0};
+  std::atomic<int> storage_calls{0};
+
+  // Order of callback invocations: 'u' = user on_signal, 'p' = pnl,
+  // 's' = storage. Used to verify post-emission ordering.
+  std::vector<char> order;
+};
+
+void on_signal_cb(void* ud, const FloxSignal*)
+{
+  auto* s = static_cast<State*>(ud);
+  s->on_signal_calls.fetch_add(1, std::memory_order_relaxed);
+  s->order.push_back('u');
+}
+
+void pnl_cb(void* ud, const FloxSignal*)
+{
+  auto* s = static_cast<State*>(ud);
+  s->pnl_calls.fetch_add(1, std::memory_order_relaxed);
+  s->order.push_back('p');
+}
+
+void storage_cb(void* ud, const FloxSignal*)
+{
+  auto* s = static_cast<State*>(ud);
+  s->storage_calls.fetch_add(1, std::memory_order_relaxed);
+  s->order.push_back('s');
+}
+
+struct RunnerCtx
+{
+  FloxRegistryHandle registry{nullptr};
+  FloxStrategyHandle strategy{nullptr};
+  FloxRunnerHandle runner{nullptr};
+  uint32_t symbol_id{0};
+
+  ~RunnerCtx()
+  {
+    if (runner)
+    {
+      flox_runner_destroy(runner);
+    }
+    if (strategy)
+    {
+      flox_strategy_destroy(strategy);
+    }
+    if (registry)
+    {
+      flox_registry_destroy(registry);
+    }
+  }
+};
+
+void make_runner(RunnerCtx& s, State& state)
+{
+  s.registry = flox_registry_create();
+  ASSERT_NE(s.registry, nullptr);
+  s.symbol_id = flox_registry_add_symbol(s.registry, "test", "BTC", 0.01);
+
+  FloxStrategyCallbacks cb{};
+  uint32_t syms[] = {s.symbol_id};
+  s.strategy = flox_strategy_create(/*id=*/1, syms, 1, s.registry, cb);
+  ASSERT_NE(s.strategy, nullptr);
+
+  s.runner = flox_runner_create(s.registry, on_signal_cb, &state);
+  ASSERT_NE(s.runner, nullptr);
+  flox_runner_add_strategy(s.runner, s.strategy);
+  flox_runner_start(s.runner);
+}
+
+}  // namespace
+
+TEST(CapiObservers, PnLTrackerFiresAfterOnSignal)
+{
+  State state;
+  RunnerCtx s;
+  make_runner(s, state);
+
+  FloxPnLTrackerCallbacks cb{};
+  cb.on_signal = pnl_cb;
+  cb.user_data = &state;
+  FloxPnLTrackerHandle tracker = flox_pnl_tracker_create(cb);
+  ASSERT_NE(tracker, nullptr);
+  flox_runner_set_pnl_tracker(s.runner, tracker);
+
+  flox_emit_market_buy(s.strategy, s.symbol_id, flox_quantity_from_double(1.0));
+
+  EXPECT_EQ(state.on_signal_calls.load(), 1);
+  EXPECT_EQ(state.pnl_calls.load(), 1);
+  ASSERT_EQ(state.order.size(), 2u);
+  EXPECT_EQ(state.order[0], 'u') << "user on_signal must fire before pnl";
+  EXPECT_EQ(state.order[1], 'p');
+
+  flox_runner_stop(s.runner);
+  flox_pnl_tracker_destroy(tracker);
+}
+
+TEST(CapiObservers, StorageSinkFiresAfterOnSignal)
+{
+  State state;
+  RunnerCtx s;
+  make_runner(s, state);
+
+  FloxStorageSinkCallbacks cb{};
+  cb.store = storage_cb;
+  cb.user_data = &state;
+  FloxStorageSinkHandle sink = flox_storage_sink_create(cb);
+  flox_runner_set_storage_sink(s.runner, sink);
+
+  flox_emit_market_buy(s.strategy, s.symbol_id, flox_quantity_from_double(1.0));
+
+  EXPECT_EQ(state.on_signal_calls.load(), 1);
+  EXPECT_EQ(state.storage_calls.load(), 1);
+  ASSERT_EQ(state.order.size(), 2u);
+  EXPECT_EQ(state.order[0], 'u');
+  EXPECT_EQ(state.order[1], 's');
+
+  flox_runner_stop(s.runner);
+  flox_storage_sink_destroy(sink);
+}
+
+TEST(CapiObservers, PnLBeforeStorage)
+{
+  // When both observers attached, the order should be:
+  //   on_signal → PnL → Storage.
+  State state;
+  RunnerCtx s;
+  make_runner(s, state);
+
+  FloxPnLTrackerCallbacks pcb{};
+  pcb.on_signal = pnl_cb;
+  pcb.user_data = &state;
+  FloxStorageSinkCallbacks scb{};
+  scb.store = storage_cb;
+  scb.user_data = &state;
+
+  auto* tracker = flox_pnl_tracker_create(pcb);
+  auto* sink = flox_storage_sink_create(scb);
+  flox_runner_set_pnl_tracker(s.runner, tracker);
+  flox_runner_set_storage_sink(s.runner, sink);
+
+  flox_emit_market_buy(s.strategy, s.symbol_id, flox_quantity_from_double(1.0));
+
+  ASSERT_EQ(state.order.size(), 3u);
+  EXPECT_EQ(state.order[0], 'u');
+  EXPECT_EQ(state.order[1], 'p');
+  EXPECT_EQ(state.order[2], 's');
+
+  flox_runner_stop(s.runner);
+  flox_storage_sink_destroy(sink);
+  flox_pnl_tracker_destroy(tracker);
+}
+
+TEST(CapiObservers, ObserversNeverBlock)
+{
+  // Even if an observer "would deny" by some custom logic, the user
+  // on_signal callback already fired. Verify that returning from the
+  // observer with no effect doesn't surface anywhere.
+  State state;
+  RunnerCtx s;
+  make_runner(s, state);
+
+  FloxPnLTrackerCallbacks pcb{};
+  pcb.on_signal = pnl_cb;
+  pcb.user_data = &state;
+  auto* tracker = flox_pnl_tracker_create(pcb);
+  flox_runner_set_pnl_tracker(s.runner, tracker);
+
+  // 3 emissions; each fires user + pnl, regardless of "what happens" in
+  // the observer.
+  for (int i = 0; i < 3; ++i)
+  {
+    flox_emit_market_buy(s.strategy, s.symbol_id, flox_quantity_from_double(1.0));
+  }
+  EXPECT_EQ(state.on_signal_calls.load(), 3);
+  EXPECT_EQ(state.pnl_calls.load(), 3);
+
+  flox_runner_stop(s.runner);
+  flox_pnl_tracker_destroy(tracker);
+}
+
+TEST(CapiObservers, NullDetaches)
+{
+  State state;
+  RunnerCtx s;
+  make_runner(s, state);
+
+  FloxPnLTrackerCallbacks pcb{};
+  pcb.on_signal = pnl_cb;
+  pcb.user_data = &state;
+  auto* tracker = flox_pnl_tracker_create(pcb);
+  flox_runner_set_pnl_tracker(s.runner, tracker);
+
+  flox_emit_market_buy(s.strategy, s.symbol_id, flox_quantity_from_double(1.0));
+  EXPECT_EQ(state.pnl_calls.load(), 1);
+
+  flox_runner_set_pnl_tracker(s.runner, nullptr);
+  flox_emit_market_buy(s.strategy, s.symbol_id, flox_quantity_from_double(1.0));
+  EXPECT_EQ(state.pnl_calls.load(), 1) << "pnl detached; should not fire";
+  EXPECT_EQ(state.on_signal_calls.load(), 2) << "user on_signal still works";
+
+  flox_runner_stop(s.runner);
+  flox_pnl_tracker_destroy(tracker);
+}
+
+TEST(CapiObservers, NullCallbackFunctionIsNoOp)
+{
+  State state;
+  RunnerCtx s;
+  make_runner(s, state);
+
+  FloxPnLTrackerCallbacks cb{};
+  cb.on_signal = nullptr;  // missing fn, but bundle present
+  cb.user_data = &state;
+  auto* tracker = flox_pnl_tracker_create(cb);
+  flox_runner_set_pnl_tracker(s.runner, tracker);
+
+  flox_emit_market_buy(s.strategy, s.symbol_id, flox_quantity_from_double(1.0));
+
+  EXPECT_EQ(state.on_signal_calls.load(), 1);
+  EXPECT_EQ(state.pnl_calls.load(), 0);
+
+  flox_runner_stop(s.runner);
+  flox_pnl_tracker_destroy(tracker);
+}
+
+TEST(CapiObservers, RiskDenialSkipsObservers)
+{
+  // If a pre-trade gate denies, the user on_signal does NOT fire — and
+  // observers also must not fire (they're "after on_signal", not "after
+  // emission attempt").
+  State state;
+  std::atomic<uint8_t> deny{0};
+
+  auto allow_cb = [](void* ud, const FloxSignal*) -> uint8_t
+  {
+    return static_cast<std::atomic<uint8_t>*>(ud)->load(std::memory_order_acquire);
+  };
+
+  RunnerCtx s;
+  make_runner(s, state);
+
+  FloxRiskManagerCallbacks rcb{};
+  rcb.allow = allow_cb;
+  rcb.user_data = &deny;
+  auto* rm = flox_risk_manager_create(rcb);
+  flox_runner_set_risk_manager(s.runner, rm);
+
+  FloxPnLTrackerCallbacks pcb{};
+  pcb.on_signal = pnl_cb;
+  pcb.user_data = &state;
+  auto* tracker = flox_pnl_tracker_create(pcb);
+  flox_runner_set_pnl_tracker(s.runner, tracker);
+
+  // deny=0 → drop
+  deny.store(0);
+  flox_emit_market_buy(s.strategy, s.symbol_id, flox_quantity_from_double(1.0));
+  EXPECT_EQ(state.on_signal_calls.load(), 0);
+  EXPECT_EQ(state.pnl_calls.load(), 0) << "observers must not fire when risk denies";
+
+  // deny=1 → allow
+  deny.store(1);
+  flox_emit_market_buy(s.strategy, s.symbol_id, flox_quantity_from_double(1.0));
+  EXPECT_EQ(state.on_signal_calls.load(), 1);
+  EXPECT_EQ(state.pnl_calls.load(), 1);
+
+  flox_runner_stop(s.runner);
+  flox_pnl_tracker_destroy(tracker);
+  flox_risk_manager_destroy(rm);
+}

--- a/tools/codegen/golden/flox_capi.codon
+++ b/tools/codegen/golden/flox_capi.codon
@@ -216,6 +216,12 @@ from C import flox_market_profile_is_poor_low(cobj) -> u8
 from C import flox_market_profile_num_levels(cobj) -> u32
 from C import flox_market_profile_clear(cobj)
 
+# ── metrics ──
+from C import flox_pnl_tracker_create(cobj) -> cobj
+from C import flox_pnl_tracker_destroy(cobj)
+from C import flox_live_engine_set_pnl_tracker(cobj, cobj)
+from C import flox_runner_set_pnl_tracker(cobj, cobj)
+
 # ── order_book ──
 from C import flox_book_create(float) -> cobj
 from C import flox_book_destroy(cobj)
@@ -343,6 +349,12 @@ from C import flox_executor_fill_count(cobj) -> u32
 from C import flox_stat_correlation(Ptr[float], Ptr[float], int) -> float
 from C import flox_stat_profit_factor(Ptr[float], int) -> float
 from C import flox_stat_win_rate(Ptr[float], int) -> float
+
+# ── storage ──
+from C import flox_storage_sink_create(cobj) -> cobj
+from C import flox_storage_sink_destroy(cobj)
+from C import flox_live_engine_set_storage_sink(cobj, cobj)
+from C import flox_runner_set_storage_sink(cobj, cobj)
 
 # ── strategy_lifecycle ──
 from C import flox_strategy_create(u32, Ptr[u32], u32, cobj, cobj) -> cobj

--- a/tools/codegen/golden/flox_capi.h
+++ b/tools/codegen/golden/flox_capi.h
@@ -47,6 +47,8 @@ extern "C"
   typedef void* FloxRiskManagerHandle;
   typedef void* FloxKillSwitchHandle;
   typedef void* FloxOrderValidatorHandle;
+  typedef void* FloxPnLTrackerHandle;
+  typedef void* FloxStorageSinkHandle;
   typedef void* FloxLiveEngineHandle;
   typedef void* FloxRunnerHandle;
   typedef void* FloxBacktestRunnerHandle;
@@ -355,6 +357,8 @@ extern "C"
   typedef uint8_t (*FloxKillSwitchCheckFn)(void*, const FloxSignal*);
   typedef uint8_t (*FloxOrderValidatorValidateFn)(void*, const FloxSignal*);
   typedef void (*FloxLogCallback)(void*, int32_t, const char*);
+  typedef void (*FloxPnLTrackerOnSignalFn)(void*, const FloxSignal*);
+  typedef void (*FloxStorageSinkStoreFn)(void*, const FloxSignal*);
 
   // ============================================================
   // Callback bundles
@@ -387,6 +391,18 @@ extern "C"
     FloxOrderValidatorValidateFn validate;
     void* user_data;
   } FloxOrderValidatorCallbacks;
+
+  typedef struct
+  {
+    FloxPnLTrackerOnSignalFn on_signal;
+    void* user_data;
+  } FloxPnLTrackerCallbacks;
+
+  typedef struct
+  {
+    FloxStorageSinkStoreFn store;
+    void* user_data;
+  } FloxStorageSinkCallbacks;
 
   // ============================================================
   // Fixed-point conversion helpers
@@ -787,6 +803,15 @@ extern "C"
   void flox_market_profile_clear(FloxMarketProfileHandle profile);
 
   // ============================================================
+  // Metrics
+  // ============================================================
+
+  FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks callbacks);
+  void flox_pnl_tracker_destroy(FloxPnLTrackerHandle tracker);
+  void flox_live_engine_set_pnl_tracker(FloxLiveEngineHandle engine, FloxPnLTrackerHandle tracker);
+  void flox_runner_set_pnl_tracker(FloxRunnerHandle runner, FloxPnLTrackerHandle tracker);
+
+  // ============================================================
   // Order Book
   // ============================================================
 
@@ -992,6 +1017,15 @@ extern "C"
   double flox_stat_correlation(const double* x, const double* y, size_t len);
   double flox_stat_profit_factor(const double* pnl, size_t len);
   double flox_stat_win_rate(const double* pnl, size_t len);
+
+  // ============================================================
+  // Storage
+  // ============================================================
+
+  FloxStorageSinkHandle flox_storage_sink_create(FloxStorageSinkCallbacks callbacks);
+  void flox_storage_sink_destroy(FloxStorageSinkHandle sink);
+  void flox_live_engine_set_storage_sink(FloxLiveEngineHandle engine, FloxStorageSinkHandle sink);
+  void flox_runner_set_storage_sink(FloxRunnerHandle runner, FloxStorageSinkHandle sink);
 
   // ============================================================
   // Strategy Lifecycle

--- a/tools/codegen/golden/flox_capi.md
+++ b/tools/codegen/golden/flox_capi.md
@@ -2,7 +2,7 @@
 
 Generated from `include/flox/capi/flox_capi_spec.hpp`. Source of truth for FFI consumers (Codon, QuickJS, Rust, Go cgo, Python ctypes). The pybind11 (Python) and NAPI (Node) bindings wrap this surface but expose richer language-native APIs that live in `python/` and `node/` respectively — see those for the Python/TS-flavored interfaces.
 
-**Surface:** 303 functions, 25 handles, 28 structs, 11 callback typedefs, 2 enums, 39 groups.
+**Surface:** 311 functions, 27 handles, 30 structs, 13 callback typedefs, 2 enums, 41 groups.
 
 ## Opaque handles
 
@@ -30,6 +30,8 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `FloxRiskManagerHandle`
 - `FloxKillSwitchHandle`
 - `FloxOrderValidatorHandle`
+- `FloxPnLTrackerHandle`
+- `FloxStorageSinkHandle`
 - `FloxLiveEngineHandle`
 - `FloxRunnerHandle`
 - `FloxBacktestRunnerHandle`
@@ -62,6 +64,8 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `typedef uint8_t (*FloxKillSwitchCheckFn)(void *, const FloxSignal *);`
 - `typedef uint8_t (*FloxOrderValidatorValidateFn)(void *, const FloxSignal *);`
 - `typedef void (*FloxLogCallback)(void *, int32_t, const char *);`
+- `typedef void (*FloxPnLTrackerOnSignalFn)(void *, const FloxSignal *);`
+- `typedef void (*FloxStorageSinkStoreFn)(void *, const FloxSignal *);`
 
 ## Structs
 
@@ -388,6 +392,20 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 | `validate` | `FloxOrderValidatorValidateFn` |
 | `user_data` | `void *` |
 
+### `FloxPnLTrackerCallbacks`
+
+| field | type |
+|---|---|
+| `on_signal` | `FloxPnLTrackerOnSignalFn` |
+| `user_data` | `void *` |
+
+### `FloxStorageSinkCallbacks`
+
+| field | type |
+|---|---|
+| `store` | `FloxStorageSinkStoreFn` |
+| `user_data` | `void *` |
+
 ## Functions
 
 ### additional_bar
@@ -622,6 +640,13 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `uint32_t flox_market_profile_num_levels(FloxMarketProfileHandle profile)`
 - `void flox_market_profile_clear(FloxMarketProfileHandle profile)`
 
+### metrics
+
+- `FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks callbacks)`
+- `void flox_pnl_tracker_destroy(FloxPnLTrackerHandle tracker)`
+- `void flox_live_engine_set_pnl_tracker(FloxLiveEngineHandle engine, FloxPnLTrackerHandle tracker)`
+- `void flox_runner_set_pnl_tracker(FloxRunnerHandle runner, FloxPnLTrackerHandle tracker)`
+
 ### order_book
 
 - `FloxBookHandle flox_book_create(double tick_size)`
@@ -760,6 +785,13 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `double flox_stat_correlation(const double * x, const double * y, size_t len)`
 - `double flox_stat_profit_factor(const double * pnl, size_t len)`
 - `double flox_stat_win_rate(const double * pnl, size_t len)`
+
+### storage
+
+- `FloxStorageSinkHandle flox_storage_sink_create(FloxStorageSinkCallbacks callbacks)`
+- `void flox_storage_sink_destroy(FloxStorageSinkHandle sink)`
+- `void flox_live_engine_set_storage_sink(FloxLiveEngineHandle engine, FloxStorageSinkHandle sink)`
+- `void flox_runner_set_storage_sink(FloxRunnerHandle runner, FloxStorageSinkHandle sink)`
 
 ### strategy_lifecycle
 


### PR DESCRIPTION
## Summary

Two new callback bundles that fire **after** the user `on_signal` callback runs. They observe — never block — every emitted signal that makes it past the pre-trade gates.

Use cases:
- **PnLTracker**: shadow-track expected exposure based on emitted signals, independent of broker fill confirmations.
- **StorageSink**: persist every emitted signal to the binding's storage (DB, append-only log, broker audit trail).

## Surface (8 new fns)

```c
typedef void (*FloxPnLTrackerOnSignalFn)(void* user_data, const FloxSignal*);
typedef struct { FloxPnLTrackerOnSignalFn on_signal; void* user_data; } FloxPnLTrackerCallbacks;
typedef void* FloxPnLTrackerHandle;
FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks);
void                 flox_pnl_tracker_destroy(FloxPnLTrackerHandle);

typedef void (*FloxStorageSinkStoreFn)(void* user_data, const FloxSignal*);
typedef struct { FloxStorageSinkStoreFn store; void* user_data; } FloxStorageSinkCallbacks;
typedef void* FloxStorageSinkHandle;
FloxStorageSinkHandle flox_storage_sink_create(FloxStorageSinkCallbacks);
void                  flox_storage_sink_destroy(FloxStorageSinkHandle);

void flox_runner_set_pnl_tracker(FloxRunnerHandle, FloxPnLTrackerHandle);
void flox_runner_set_storage_sink(FloxRunnerHandle, FloxStorageSinkHandle);
void flox_live_engine_set_pnl_tracker(FloxLiveEngineHandle, FloxPnLTrackerHandle);
void flox_live_engine_set_storage_sink(FloxLiveEngineHandle, FloxStorageSinkHandle);
```

## Evaluation order on every emitted signal

```
KillSwitch.check
  → OrderValidator.validate
    → RiskManager.allow
      → user on_signal
        → PnLTracker.on_signal
          → StorageSink.store
```

If any pre-trade gate denies, none of user / PnL / Storage fires. PnL and Storage are independent — either can be detached without affecting the other.

## Tests

`tests/test_capi_observers.cpp` — 7 cases: ordering (user → pnl → storage), independence, NULL detach, NULL function as no-op, risk-denial skips observers.

## Codegen

303 → 311 functions in the ABI snapshot. `tools/codegen/scripts/regenerate.sh` now also syncs `mcp/flox_mcp/data/` automatically (fixed in this branch's predecessor #144).

## Test plan

- [x] cmake build target `flox_capi` clean.
- [x] `ctest --test-dir build -R 'test_capi'` → 7/7 passed (registry, infra, risk_manager, kill_switch, observers, logger, backtest).
- [x] format-check clean.
- [x] codegen check.sh end-to-end clean.
- [x] Full CI green.

W1-T018 W1-T019