### PR TITLE
feat(capi): ReplaySource hook for binding-supplied event streams

### DIFF
--- a/.api/c-api.snapshot
+++ b/.api/c-api.snapshot
@@ -19,6 +19,7 @@ flox_backtest_runner_destroy|void|FloxBacktestRunnerHandle
 flox_backtest_runner_run_bars|int|FloxBacktestRunnerHandle|const int64_t *|const int64_t *|const double *|const double *|const double *|const double *|const double *|uint32_t|const char *|uint8_t|uint64_t|FloxBacktestStats *
 flox_backtest_runner_run_csv|int|FloxBacktestRunnerHandle|const char *|const char *|FloxBacktestStats *
 flox_backtest_runner_run_ohlcv|int|FloxBacktestRunnerHandle|const int64_t *|const double *|uint32_t|const char *|FloxBacktestStats *
+flox_backtest_runner_run_replay_source|int|FloxBacktestRunnerHandle|FloxReplaySourceHandle|FloxBacktestStats *
 flox_backtest_runner_set_strategy|void|FloxBacktestRunnerHandle|FloxStrategyHandle
 flox_best_ask_raw|int64_t|FloxStrategyHandle|uint32_t
 flox_best_bid_raw|int64_t|FloxStrategyHandle|uint32_t
@@ -250,6 +251,9 @@ flox_registry_destroy|void|FloxRegistryHandle
 flox_registry_get_symbol_id|uint8_t|FloxRegistryHandle|const char *|const char *|uint32_t *
 flox_registry_get_symbol_name|uint8_t|FloxRegistryHandle|uint32_t|char *|size_t|char *|size_t
 flox_registry_symbol_count|uint32_t|FloxRegistryHandle
+flox_replay_source_create|FloxReplaySourceHandle|FloxReplaySourceCallbacks
+flox_replay_source_destroy|void|FloxReplaySourceHandle
+flox_replay_source_seek_to|uint8_t|FloxReplaySourceHandle|int64_t
 flox_risk_manager_create|FloxRiskManagerHandle|FloxRiskManagerCallbacks
 flox_risk_manager_destroy|void|FloxRiskManagerHandle
 flox_runner_add_strategy|void|FloxRunnerHandle|FloxStrategyHandle

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -1310,6 +1310,60 @@ extern "C"
   void flox_market_data_recorder_destroy(FloxMarketDataRecorderHandle recorder);
 
   // ============================================================
+  // ReplaySource — binding-side market data event source for backtests.
+  //
+  // Bindings provide a custom event reader. The engine pulls events by
+  // calling `next` repeatedly until it returns 0. For book events, the
+  // binding sets `bids` / `asks` to point at its own buffer; pointers
+  // must remain valid until the next `next` call.
+  // ============================================================
+
+  // Tagged event: 1=Trade, 2=BookSnapshot, 3=BookDelta. Matches
+  // flox::replay::EventType.
+  typedef struct
+  {
+    uint8_t type;
+    uint8_t _pad[3];
+    int64_t timestamp_ns;
+
+    // Trade payload — valid only when type == 1.
+    uint32_t trade_symbol;
+    uint8_t trade_is_buy;
+    uint8_t _pad2[3];
+    int64_t trade_price_raw;
+    int64_t trade_quantity_raw;
+
+    // Book payload — valid when type == 2 or 3.
+    uint32_t book_symbol;
+    uint32_t n_bids;
+    uint32_t n_asks;
+    uint32_t _pad3;
+    const FloxBookLevel* bids;
+    const FloxBookLevel* asks;
+  } FloxReplayEvent;
+
+  typedef uint8_t (*FloxReplaySourceNextFn)(void* user_data, FloxReplayEvent* event_out);
+  typedef uint8_t (*FloxReplaySourceSeekFn)(void* user_data, int64_t timestamp_ns);
+  typedef void (*FloxReplaySourceLifecycleFn)(void* user_data);
+
+  typedef struct
+  {
+    FloxReplaySourceLifecycleFn on_start;
+    FloxReplaySourceLifecycleFn on_stop;
+    FloxReplaySourceSeekFn seek_to;
+    FloxReplaySourceNextFn next;
+    void* user_data;
+  } FloxReplaySourceCallbacks;
+
+  typedef void* FloxReplaySourceHandle;
+
+  FloxReplaySourceHandle flox_replay_source_create(FloxReplaySourceCallbacks callbacks);
+  void flox_replay_source_destroy(FloxReplaySourceHandle source);
+
+  // Convenience: forward a seek to the binding's seek_to callback.
+  uint8_t flox_replay_source_seek_to(FloxReplaySourceHandle source, int64_t timestamp_ns);
+
+  // ============================================================
   // FloxLiveEngine — Disruptor-based live trading engine.
   //
   // Uses real EventBus (SPSC ring buffer / Disruptor) internally.
@@ -1539,6 +1593,13 @@ extern "C"
                                     uint8_t bar_type,
                                     uint64_t bar_type_param,
                                     FloxBacktestStats* stats_out);
+
+  // Run a backtest pulling events from a binding-supplied replay source.
+  // Fires source.on_start before reading and source.on_stop after the
+  // runner has drained the stream. Returns 1 on success, 0 on error.
+  int flox_backtest_runner_run_replay_source(FloxBacktestRunnerHandle runner,
+                                             FloxReplaySourceHandle source,
+                                             FloxBacktestStats* stats_out);
 
 #ifdef __cplusplus
 }

--- a/include/flox/capi/flox_capi_spec.hpp
+++ b/include/flox/capi/flox_capi_spec.hpp
@@ -1643,6 +1643,75 @@ extern "C"
   void flox_market_data_recorder_destroy(FloxMarketDataRecorderHandle recorder);
 
   // ============================================================
+  // ReplaySource — binding-side market data event source.
+  //
+  // Bindings provide a custom event reader (e.g. exchange-specific
+  // archive format, S3-streamed segments) that BacktestRunner pulls
+  // events from. The engine drives playback by repeatedly calling
+  // `next` until it returns 0.
+  //
+  // Event shape: `next` populates a FloxReplayEvent describing one
+  // event (Trade, BookSnapshot, or BookDelta). For book events, the
+  // binding sets `bids` / `asks` to point at its own buffer; the
+  // pointers must remain valid until the next `next` call. The engine
+  // copies the levels it needs before invoking the callback again.
+  // ============================================================
+
+  // 1=Trade, 2=BookSnapshot, 3=BookDelta. Matches flox::replay::EventType.
+  typedef struct
+  {
+    uint8_t type;
+    uint8_t _pad[3];
+    int64_t timestamp_ns;
+
+    // Trade payload — valid only when type == 1.
+    uint32_t trade_symbol;
+    uint8_t trade_is_buy;
+    uint8_t _pad2[3];
+    int64_t trade_price_raw;
+    int64_t trade_quantity_raw;
+
+    // Book payload — valid when type == 2 or 3.
+    uint32_t book_symbol;
+    uint32_t n_bids;
+    uint32_t n_asks;
+    uint32_t _pad3;
+    // Pointers owned by the binding; must remain valid for the duration
+    // of the engine's processing of this event (until the next `next`
+    // call returns).
+    const FloxBookLevel* bids;
+    const FloxBookLevel* asks;
+  } FloxReplayEvent;
+
+  // Yield the next event. Return 1 if an event was produced (event_out
+  // populated), 0 if the source is exhausted.
+  typedef uint8_t (*FloxReplaySourceNextFn)(void* user_data, FloxReplayEvent* event_out);
+  // Seek to a timestamp. Return 1 if the seek succeeded, 0 otherwise.
+  typedef uint8_t (*FloxReplaySourceSeekFn)(void* user_data, int64_t timestamp_ns);
+  typedef void (*FloxReplaySourceLifecycleFn)(void* user_data);
+
+  typedef struct
+  {
+    FloxReplaySourceLifecycleFn on_start;
+    FloxReplaySourceLifecycleFn on_stop;
+    FloxReplaySourceSeekFn seek_to;
+    FloxReplaySourceNextFn next;
+    void* user_data;
+  } FloxReplaySourceCallbacks;
+
+  typedef void* FloxReplaySourceHandle;
+
+  FLOX_EXPORT(group = "replay")
+  FloxReplaySourceHandle flox_replay_source_create(FloxReplaySourceCallbacks callbacks);
+  FLOX_EXPORT(group = "replay")
+  void flox_replay_source_destroy(FloxReplaySourceHandle source);
+
+  // Seek the underlying source to a timestamp. Returns 1 on success.
+  // Convenience wrapper that forwards to the binding's seek_to callback.
+  FLOX_EXPORT(group = "replay")
+  uint8_t flox_replay_source_seek_to(FloxReplaySourceHandle source, int64_t timestamp_ns);
+
+  // ============================================================
   // FloxLiveEngine — Disruptor-based live trading engine.
   //
   // Uses real EventBus (SPSC ring buffer / Disruptor) internally.
@@ -1909,6 +1978,14 @@ extern "C"
                                     uint8_t bar_type,
                                     uint64_t bar_type_param,
                                     FloxBacktestStats* stats_out);
+
+  // Run a backtest pulling events from a binding-supplied replay source.
+  // Fires source.on_start before reading, source.on_stop after the runner
+  // has drained the stream. Returns 1 on success, 0 on error.
+  FLOX_EXPORT(group = "backtestrunner_replay")
+  int flox_backtest_runner_run_replay_source(FloxBacktestRunnerHandle runner,
+                                             FloxReplaySourceHandle source,
+                                             FloxBacktestStats* stats_out);
 
 #ifdef __cplusplus
 }

--- a/mcp/flox_mcp/data/c-api.snapshot
+++ b/mcp/flox_mcp/data/c-api.snapshot
@@ -19,6 +19,7 @@ flox_backtest_runner_destroy|void|FloxBacktestRunnerHandle
 flox_backtest_runner_run_bars|int|FloxBacktestRunnerHandle|const int64_t *|const int64_t *|const double *|const double *|const double *|const double *|const double *|uint32_t|const char *|uint8_t|uint64_t|FloxBacktestStats *
 flox_backtest_runner_run_csv|int|FloxBacktestRunnerHandle|const char *|const char *|FloxBacktestStats *
 flox_backtest_runner_run_ohlcv|int|FloxBacktestRunnerHandle|const int64_t *|const double *|uint32_t|const char *|FloxBacktestStats *
+flox_backtest_runner_run_replay_source|int|FloxBacktestRunnerHandle|FloxReplaySourceHandle|FloxBacktestStats *
 flox_backtest_runner_set_strategy|void|FloxBacktestRunnerHandle|FloxStrategyHandle
 flox_best_ask_raw|int64_t|FloxStrategyHandle|uint32_t
 flox_best_bid_raw|int64_t|FloxStrategyHandle|uint32_t
@@ -250,6 +251,9 @@ flox_registry_destroy|void|FloxRegistryHandle
 flox_registry_get_symbol_id|uint8_t|FloxRegistryHandle|const char *|const char *|uint32_t *
 flox_registry_get_symbol_name|uint8_t|FloxRegistryHandle|uint32_t|char *|size_t|char *|size_t
 flox_registry_symbol_count|uint32_t|FloxRegistryHandle
+flox_replay_source_create|FloxReplaySourceHandle|FloxReplaySourceCallbacks
+flox_replay_source_destroy|void|FloxReplaySourceHandle
+flox_replay_source_seek_to|uint8_t|FloxReplaySourceHandle|int64_t
 flox_risk_manager_create|FloxRiskManagerHandle|FloxRiskManagerCallbacks
 flox_risk_manager_destroy|void|FloxRiskManagerHandle
 flox_runner_add_strategy|void|FloxRunnerHandle|FloxStrategyHandle

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -2839,6 +2839,108 @@ struct FloxMarketDataRecorderImpl
   FloxMarketDataRecorderCallbacks cb;
 };
 
+struct FloxReplaySourceImpl
+{
+  FloxReplaySourceCallbacks cb;
+};
+
+// Adapter that exposes a binding's FloxReplaySourceCallbacks as a
+// flox::replay::IMultiSegmentReader so BacktestRunner can drive it via
+// the existing forEach contract.
+class CapiReplaySourceReader : public flox::replay::IMultiSegmentReader
+{
+ public:
+  explicit CapiReplaySourceReader(FloxReplaySourceImpl* source) : _source(source) {}
+
+  uint64_t forEach(EventCallback callback) override
+  {
+    if (_source == nullptr || _source->cb.next == nullptr)
+    {
+      return 0;
+    }
+    uint64_t count = 0;
+    FloxReplayEvent ev{};
+    while (_source->cb.next(_source->cb.user_data, &ev) != 0)
+    {
+      flox::replay::ReplayEvent re;
+      re.timestamp_ns = ev.timestamp_ns;
+      switch (ev.type)
+      {
+        case 1:  // Trade
+        {
+          re.type = flox::replay::EventType::Trade;
+          re.trade.exchange_ts_ns = ev.timestamp_ns;
+          re.trade.recv_ts_ns = ev.timestamp_ns;
+          re.trade.price_raw = ev.trade_price_raw;
+          re.trade.qty_raw = ev.trade_quantity_raw;
+          re.trade.symbol_id = ev.trade_symbol;
+          re.trade.side = ev.trade_is_buy ? 0u : 1u;
+          break;
+        }
+        case 2:  // BookSnapshot
+        case 3:  // BookDelta
+        {
+          re.type = (ev.type == 2) ? flox::replay::EventType::BookSnapshot
+                                   : flox::replay::EventType::BookDelta;
+          re.book_header.exchange_ts_ns = ev.timestamp_ns;
+          re.book_header.recv_ts_ns = ev.timestamp_ns;
+          re.book_header.symbol_id = ev.book_symbol;
+          re.book_header.bid_count = static_cast<uint16_t>(ev.n_bids);
+          re.book_header.ask_count = static_cast<uint16_t>(ev.n_asks);
+          re.book_header.type = static_cast<uint8_t>(re.type);
+          re.bids.clear();
+          re.asks.clear();
+          re.bids.reserve(ev.n_bids);
+          re.asks.reserve(ev.n_asks);
+          for (uint32_t i = 0; i < ev.n_bids; ++i)
+          {
+            flox::replay::BookLevel lvl{};
+            lvl.price_raw = ev.bids[i].price_raw;
+            lvl.qty_raw = ev.bids[i].quantity_raw;
+            re.bids.push_back(lvl);
+          }
+          for (uint32_t i = 0; i < ev.n_asks; ++i)
+          {
+            flox::replay::BookLevel lvl{};
+            lvl.price_raw = ev.asks[i].price_raw;
+            lvl.qty_raw = ev.asks[i].quantity_raw;
+            re.asks.push_back(lvl);
+          }
+          break;
+        }
+        default:
+          // Unknown event type — skip without aborting playback.
+          continue;
+      }
+      ++count;
+      if (!callback(re))
+      {
+        break;
+      }
+    }
+    return count;
+  }
+
+  uint64_t forEachFrom(int64_t start_ts_ns, EventCallback callback) override
+  {
+    if (_source != nullptr && _source->cb.seek_to != nullptr)
+    {
+      _source->cb.seek_to(_source->cb.user_data, start_ts_ns);
+    }
+    return forEach(std::move(callback));
+  }
+
+  const std::vector<flox::replay::SegmentInfo>& segments() const override
+  {
+    return _empty_segments;
+  }
+  uint64_t totalEvents() const override { return 0; }
+
+ private:
+  FloxReplaySourceImpl* _source;
+  std::vector<flox::replay::SegmentInfo> _empty_segments;
+};
+
 class RunnerSignalHandler : public ISignalHandler
 {
  public:
@@ -3693,6 +3795,29 @@ struct FloxBacktestRunnerImpl
     }
     return 1;
   }
+
+  int runReplaySource(FloxReplaySourceImpl* source, FloxBacktestStats* out)
+  {
+    if (source == nullptr)
+    {
+      return 0;
+    }
+    if (source->cb.on_start != nullptr)
+    {
+      source->cb.on_start(source->cb.user_data);
+    }
+    CapiReplaySourceReader reader(source);
+    BacktestResult result = runner->run(reader);
+    if (source->cb.on_stop != nullptr)
+    {
+      source->cb.on_stop(source->cb.user_data);
+    }
+    if (out)
+    {
+      fillStats(result.computeStats(), out);
+    }
+    return 1;
+  }
 };
 
 static FloxBacktestRunnerImpl* toBacktestRunner(FloxBacktestRunnerHandle h)
@@ -3771,6 +3896,27 @@ FloxMarketDataRecorderHandle flox_market_data_recorder_create(
 void flox_market_data_recorder_destroy(FloxMarketDataRecorderHandle recorder)
 {
   delete static_cast<FloxMarketDataRecorderImpl*>(recorder);
+}
+
+FloxReplaySourceHandle flox_replay_source_create(FloxReplaySourceCallbacks callbacks)
+{
+  return static_cast<FloxReplaySourceHandle>(
+      new FloxReplaySourceImpl{callbacks});
+}
+
+void flox_replay_source_destroy(FloxReplaySourceHandle source)
+{
+  delete static_cast<FloxReplaySourceImpl*>(source);
+}
+
+uint8_t flox_replay_source_seek_to(FloxReplaySourceHandle source, int64_t timestamp_ns)
+{
+  auto* s = static_cast<FloxReplaySourceImpl*>(source);
+  if (s == nullptr || s->cb.seek_to == nullptr)
+  {
+    return 0;
+  }
+  return s->cb.seek_to(s->cb.user_data, timestamp_ns);
 }
 
 // ============================================================
@@ -4086,4 +4232,12 @@ int flox_backtest_runner_run_bars(FloxBacktestRunnerHandle h,
   return toBacktestRunner(h)->runFullBars(start_time_ns, end_time_ns,
                                           open, high, low, close, volume,
                                           n, symbol, bar_type, bar_type_param, out);
+}
+
+int flox_backtest_runner_run_replay_source(FloxBacktestRunnerHandle h,
+                                           FloxReplaySourceHandle source,
+                                           FloxBacktestStats* out)
+{
+  return toBacktestRunner(h)->runReplaySource(
+      static_cast<capi_impl::FloxReplaySourceImpl*>(source), out);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,8 @@ if(FLOX_ENABLE_CAPI)
   target_link_libraries(test_capi_observers PRIVATE flox_capi)
   add_flox_test(test_capi_market_data_recorder)
   target_link_libraries(test_capi_market_data_recorder PRIVATE flox_capi)
+  add_flox_test(test_capi_replay_source)
+  target_link_libraries(test_capi_replay_source PRIVATE flox_capi)
   # test_capi_logger needs to share a single ILogger global with flox_capi.
   # If we use add_flox_test, the test exe links the static `flox` library
   # alongside flox_capi.dylib (which itself statically embeds `flox`) —

--- a/tests/test_capi_replay_source.cpp
+++ b/tests/test_capi_replay_source.cpp
@@ -1,0 +1,231 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+// Tests for the ReplaySource hook (T021). A binding-supplied replay
+// source is pulled by the BacktestRunner via the IMultiSegmentReader
+// adapter; this verifies trade events flow into the runner and that
+// lifecycle / seek_to callbacks fire as expected.
+
+#include "flox/capi/flox_capi.h"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <vector>
+
+namespace
+{
+
+struct TradeFixture
+{
+  uint32_t symbol;
+  int64_t timestamp_ns;
+  int64_t price_raw;
+  int64_t qty_raw;
+  uint8_t is_buy;
+};
+
+struct BookFixture
+{
+  uint32_t symbol;
+  int64_t timestamp_ns;
+  uint8_t is_snapshot;  // 1 → BookSnapshot (event_type 2), 0 → BookDelta (3)
+  std::vector<FloxBookLevel> bids;
+  std::vector<FloxBookLevel> asks;
+};
+
+struct State
+{
+  std::vector<TradeFixture> trades;
+  std::vector<BookFixture> books;
+  size_t cursor{0};
+
+  std::atomic<int> on_start_calls{0};
+  std::atomic<int> on_stop_calls{0};
+  std::atomic<int> seek_calls{0};
+  int64_t last_seek_ts{0};
+};
+
+uint8_t source_next(void* ud, FloxReplayEvent* ev)
+{
+  auto* s = static_cast<State*>(ud);
+  size_t idx = s->cursor++;
+  size_t n_trades = s->trades.size();
+  if (idx < n_trades)
+  {
+    const auto& t = s->trades[idx];
+    ev->type = 1;
+    ev->timestamp_ns = t.timestamp_ns;
+    ev->trade_symbol = t.symbol;
+    ev->trade_is_buy = t.is_buy;
+    ev->trade_price_raw = t.price_raw;
+    ev->trade_quantity_raw = t.qty_raw;
+    return 1;
+  }
+  size_t book_idx = idx - n_trades;
+  if (book_idx < s->books.size())
+  {
+    const auto& b = s->books[book_idx];
+    ev->type = b.is_snapshot ? 2u : 3u;
+    ev->timestamp_ns = b.timestamp_ns;
+    ev->book_symbol = b.symbol;
+    ev->n_bids = static_cast<uint32_t>(b.bids.size());
+    ev->n_asks = static_cast<uint32_t>(b.asks.size());
+    ev->bids = b.bids.empty() ? nullptr : b.bids.data();
+    ev->asks = b.asks.empty() ? nullptr : b.asks.data();
+    return 1;
+  }
+  return 0;
+}
+
+uint8_t source_seek(void* ud, int64_t ts)
+{
+  auto* s = static_cast<State*>(ud);
+  s->seek_calls.fetch_add(1, std::memory_order_relaxed);
+  s->last_seek_ts = ts;
+  return 1;
+}
+
+void source_on_start(void* ud)
+{
+  static_cast<State*>(ud)->on_start_calls.fetch_add(1, std::memory_order_relaxed);
+}
+
+void source_on_stop(void* ud)
+{
+  static_cast<State*>(ud)->on_stop_calls.fetch_add(1, std::memory_order_relaxed);
+}
+
+FloxReplaySourceCallbacks make_cb(State& state)
+{
+  FloxReplaySourceCallbacks cb{};
+  cb.on_start = source_on_start;
+  cb.on_stop = source_on_stop;
+  cb.seek_to = source_seek;
+  cb.next = source_next;
+  cb.user_data = &state;
+  return cb;
+}
+
+}  // namespace
+
+TEST(CapiReplaySource, RunsTradesThroughBacktestRunner)
+{
+  State state;
+  state.trades = {
+      {1, 1'000'000'000LL, 10000000000LL /*100.0 raw*/, 100000000LL /*1.0 raw*/, 1},
+      {1, 2'000'000'000LL, 10100000000LL /*101.0 raw*/, 100000000LL, 0},
+      {1, 3'000'000'000LL, 10200000000LL /*102.0 raw*/, 100000000LL, 1},
+  };
+
+  auto* registry = flox_registry_create();
+  ASSERT_NE(registry, nullptr);
+  uint32_t symbol_id = flox_registry_add_symbol(registry, "test", "BTC", 0.01);
+  // Rewrite trade fixtures to use the actual id assigned by the registry.
+  for (auto& t : state.trades)
+  {
+    t.symbol = symbol_id;
+  }
+
+  auto* btr = flox_backtest_runner_create(registry, /*fee_rate=*/0.001,
+                                          /*initial_capital=*/10000.0);
+  ASSERT_NE(btr, nullptr);
+
+  // Strategy with no callbacks — the runner just needs *some* strategy.
+  FloxStrategyCallbacks scb{};
+  uint32_t syms[] = {symbol_id};
+  auto* strat = flox_strategy_create(/*id=*/1, syms, 1, registry, scb);
+  ASSERT_NE(strat, nullptr);
+  flox_backtest_runner_set_strategy(btr, strat);
+
+  auto* source = flox_replay_source_create(make_cb(state));
+  ASSERT_NE(source, nullptr);
+
+  FloxBacktestStats stats{};
+  int rc = flox_backtest_runner_run_replay_source(btr, source, &stats);
+  EXPECT_EQ(rc, 1);
+
+  EXPECT_EQ(state.on_start_calls.load(), 1);
+  EXPECT_EQ(state.on_stop_calls.load(), 1);
+
+  flox_replay_source_destroy(source);
+  flox_strategy_destroy(strat);
+  flox_backtest_runner_destroy(btr);
+  flox_registry_destroy(registry);
+}
+
+TEST(CapiReplaySource, NextReturnsZeroEndsPlayback)
+{
+  // A source that immediately returns 0 leaves the runner with an empty
+  // event stream; lifecycle still fires balanced.
+  State state;
+  state.trades.clear();
+  state.books.clear();
+
+  auto* registry = flox_registry_create();
+  uint32_t symbol_id = flox_registry_add_symbol(registry, "test", "BTC", 0.01);
+  auto* btr = flox_backtest_runner_create(registry, 0.0, 1000.0);
+
+  FloxStrategyCallbacks scb{};
+  uint32_t syms[] = {symbol_id};
+  auto* strat = flox_strategy_create(1, syms, 1, registry, scb);
+  flox_backtest_runner_set_strategy(btr, strat);
+
+  auto* source = flox_replay_source_create(make_cb(state));
+  FloxBacktestStats stats{};
+  int rc = flox_backtest_runner_run_replay_source(btr, source, &stats);
+  EXPECT_EQ(rc, 1);
+  EXPECT_EQ(state.on_start_calls.load(), 1);
+  EXPECT_EQ(state.on_stop_calls.load(), 1);
+
+  flox_replay_source_destroy(source);
+  flox_strategy_destroy(strat);
+  flox_backtest_runner_destroy(btr);
+  flox_registry_destroy(registry);
+}
+
+TEST(CapiReplaySource, SeekToForwardsToCallback)
+{
+  State state;
+  auto* source = flox_replay_source_create(make_cb(state));
+  ASSERT_NE(source, nullptr);
+
+  uint8_t rc = flox_replay_source_seek_to(source, 12345LL);
+  EXPECT_EQ(rc, 1);
+  EXPECT_EQ(state.seek_calls.load(), 1);
+  EXPECT_EQ(state.last_seek_ts, 12345LL);
+
+  flox_replay_source_destroy(source);
+}
+
+TEST(CapiReplaySource, SeekToWithNullCallbackReturnsZero)
+{
+  FloxReplaySourceCallbacks cb{};
+  // No callbacks at all — handle exists but seek_to is null.
+  auto* source = flox_replay_source_create(cb);
+  ASSERT_NE(source, nullptr);
+
+  uint8_t rc = flox_replay_source_seek_to(source, 99LL);
+  EXPECT_EQ(rc, 0) << "missing seek_to callback should report failure";
+
+  flox_replay_source_destroy(source);
+}
+
+TEST(CapiReplaySource, NullSourceFailsRunWithoutCrash)
+{
+  auto* registry = flox_registry_create();
+  flox_registry_add_symbol(registry, "test", "BTC", 0.01);
+  auto* btr = flox_backtest_runner_create(registry, 0.0, 1000.0);
+
+  FloxBacktestStats stats{};
+  int rc = flox_backtest_runner_run_replay_source(btr, nullptr, &stats);
+  EXPECT_EQ(rc, 0);
+
+  flox_backtest_runner_destroy(btr);
+  flox_registry_destroy(registry);
+}

--- a/tools/codegen/golden/flox_capi.codon
+++ b/tools/codegen/golden/flox_capi.codon
@@ -36,6 +36,7 @@ from C import flox_backtest_runner_set_strategy(cobj, cobj)
 from C import flox_backtest_runner_run_csv(cobj, cobj, cobj, cobj) -> int
 from C import flox_backtest_runner_run_ohlcv(cobj, Ptr[i64], Ptr[float], u32, cobj, cobj) -> int
 from C import flox_backtest_runner_run_bars(cobj, Ptr[i64], Ptr[i64], Ptr[float], Ptr[float], Ptr[float], Ptr[float], Ptr[float], u32, cobj, u8, u64, cobj) -> int
+from C import flox_backtest_runner_run_replay_source(cobj, cobj, cobj) -> int
 
 # ── bar_aggregation ──
 from C import flox_aggregate_time_bars(Ptr[i64], Ptr[float], Ptr[float], Ptr[u8], int, float, cobj, u32) -> u32
@@ -296,6 +297,11 @@ from C import flox_market_data_recorder_create(cobj) -> cobj
 from C import flox_market_data_recorder_destroy(cobj)
 from C import flox_live_engine_set_market_data_recorder(cobj, cobj)
 from C import flox_runner_set_market_data_recorder(cobj, cobj)
+
+# ── replay ──
+from C import flox_replay_source_create(cobj) -> cobj
+from C import flox_replay_source_destroy(cobj)
+from C import flox_replay_source_seek_to(cobj, i64) -> u8
 
 # ── risk ──
 from C import flox_risk_manager_create(cobj) -> cobj

--- a/tools/codegen/golden/flox_capi.h
+++ b/tools/codegen/golden/flox_capi.h
@@ -50,6 +50,7 @@ extern "C"
   typedef void* FloxPnLTrackerHandle;
   typedef void* FloxStorageSinkHandle;
   typedef void* FloxMarketDataRecorderHandle;
+  typedef void* FloxReplaySourceHandle;
   typedef void* FloxLiveEngineHandle;
   typedef void* FloxRunnerHandle;
   typedef void* FloxBacktestRunnerHandle;
@@ -343,6 +344,24 @@ extern "C"
     double new_quantity;
   } FloxSignal;
 
+  typedef struct
+  {
+    uint8_t type;
+    uint8_t _pad[3];
+    int64_t timestamp_ns;
+    uint32_t trade_symbol;
+    uint8_t trade_is_buy;
+    uint8_t _pad2[3];
+    int64_t trade_price_raw;
+    int64_t trade_quantity_raw;
+    uint32_t book_symbol;
+    uint32_t n_bids;
+    uint32_t n_asks;
+    uint32_t _pad3;
+    const FloxBookLevel* bids;
+    const FloxBookLevel* asks;
+  } FloxReplayEvent;
+
   // ============================================================
   // Callback function pointer types
   // ============================================================
@@ -363,6 +382,9 @@ extern "C"
   typedef void (*FloxRecorderOnTradeFn)(void*, const FloxTradeData*);
   typedef void (*FloxRecorderOnBookUpdateFn)(void*, uint32_t, uint8_t, const FloxBookLevel*, uint32_t, const FloxBookLevel*, uint32_t, int64_t);
   typedef void (*FloxRecorderLifecycleFn)(void*);
+  typedef uint8_t (*FloxReplaySourceNextFn)(void*, FloxReplayEvent*);
+  typedef uint8_t (*FloxReplaySourceSeekFn)(void*, int64_t);
+  typedef void (*FloxReplaySourceLifecycleFn)(void*);
 
   // ============================================================
   // Callback bundles
@@ -416,6 +438,15 @@ extern "C"
     FloxRecorderLifecycleFn on_stop;
     void* user_data;
   } FloxMarketDataRecorderCallbacks;
+
+  typedef struct
+  {
+    FloxReplaySourceLifecycleFn on_start;
+    FloxReplaySourceLifecycleFn on_stop;
+    FloxReplaySourceSeekFn seek_to;
+    FloxReplaySourceNextFn next;
+    void* user_data;
+  } FloxReplaySourceCallbacks;
 
   // ============================================================
   // Fixed-point conversion helpers
@@ -502,6 +533,9 @@ extern "C"
                                     const double* volume, uint32_t n, const char* symbol,
                                     uint8_t bar_type, uint64_t bar_type_param,
                                     FloxBacktestStats* stats_out);
+  int flox_backtest_runner_run_replay_source(FloxBacktestRunnerHandle runner,
+                                             FloxReplaySourceHandle source,
+                                             FloxBacktestStats* stats_out);
 
   // ============================================================
   // Bar Aggregation
@@ -946,6 +980,14 @@ extern "C"
                                                  FloxMarketDataRecorderHandle recorder);
   void flox_runner_set_market_data_recorder(FloxRunnerHandle runner,
                                             FloxMarketDataRecorderHandle recorder);
+
+  // ============================================================
+  // Replay
+  // ============================================================
+
+  FloxReplaySourceHandle flox_replay_source_create(FloxReplaySourceCallbacks callbacks);
+  void flox_replay_source_destroy(FloxReplaySourceHandle source);
+  uint8_t flox_replay_source_seek_to(FloxReplaySourceHandle source, int64_t timestamp_ns);
 
   // ============================================================
   // Risk

--- a/tools/codegen/golden/flox_capi.md
+++ b/tools/codegen/golden/flox_capi.md
@@ -2,7 +2,7 @@
 
 Generated from `include/flox/capi/flox_capi_spec.hpp`. Source of truth for FFI consumers (Codon, QuickJS, Rust, Go cgo, Python ctypes). The pybind11 (Python) and NAPI (Node) bindings wrap this surface but expose richer language-native APIs that live in `python/` and `node/` respectively — see those for the Python/TS-flavored interfaces.
 
-**Surface:** 315 functions, 28 handles, 31 structs, 16 callback typedefs, 2 enums, 42 groups.
+**Surface:** 319 functions, 29 handles, 33 structs, 19 callback typedefs, 2 enums, 43 groups.
 
 ## Opaque handles
 
@@ -33,6 +33,7 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `FloxPnLTrackerHandle`
 - `FloxStorageSinkHandle`
 - `FloxMarketDataRecorderHandle`
+- `FloxReplaySourceHandle`
 - `FloxLiveEngineHandle`
 - `FloxRunnerHandle`
 - `FloxBacktestRunnerHandle`
@@ -70,6 +71,9 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `typedef void (*FloxRecorderOnTradeFn)(void *, const FloxTradeData *);`
 - `typedef void (*FloxRecorderOnBookUpdateFn)(void *, uint32_t, uint8_t, const FloxBookLevel *, uint32_t, const FloxBookLevel *, uint32_t, int64_t);`
 - `typedef void (*FloxRecorderLifecycleFn)(void *);`
+- `typedef uint8_t (*FloxReplaySourceNextFn)(void *, FloxReplayEvent *);`
+- `typedef uint8_t (*FloxReplaySourceSeekFn)(void *, int64_t);`
+- `typedef void (*FloxReplaySourceLifecycleFn)(void *);`
 
 ## Structs
 
@@ -420,6 +424,35 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 | `on_stop` | `FloxRecorderLifecycleFn` |
 | `user_data` | `void *` |
 
+### `FloxReplayEvent`
+
+| field | type |
+|---|---|
+| `type` | `uint8_t` |
+| `_pad` | `uint8_t[3]` |
+| `timestamp_ns` | `int64_t` |
+| `trade_symbol` | `uint32_t` |
+| `trade_is_buy` | `uint8_t` |
+| `_pad2` | `uint8_t[3]` |
+| `trade_price_raw` | `int64_t` |
+| `trade_quantity_raw` | `int64_t` |
+| `book_symbol` | `uint32_t` |
+| `n_bids` | `uint32_t` |
+| `n_asks` | `uint32_t` |
+| `_pad3` | `uint32_t` |
+| `bids` | `const FloxBookLevel *` |
+| `asks` | `const FloxBookLevel *` |
+
+### `FloxReplaySourceCallbacks`
+
+| field | type |
+|---|---|
+| `on_start` | `FloxReplaySourceLifecycleFn` |
+| `on_stop` | `FloxReplaySourceLifecycleFn` |
+| `seek_to` | `FloxReplaySourceSeekFn` |
+| `next` | `FloxReplaySourceNextFn` |
+| `user_data` | `void *` |
+
 ## Functions
 
 ### additional_bar
@@ -456,6 +489,7 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `int flox_backtest_runner_run_csv(FloxBacktestRunnerHandle runner, const char * path, const char * symbol, FloxBacktestStats * stats_out)`
 - `int flox_backtest_runner_run_ohlcv(FloxBacktestRunnerHandle runner, const int64_t * timestamps_ns, const double * close_prices, uint32_t n, const char * symbol, FloxBacktestStats * stats_out)`
 - `int flox_backtest_runner_run_bars(FloxBacktestRunnerHandle runner, const int64_t * start_time_ns, const int64_t * end_time_ns, const double * open, const double * high, const double * low, const double * close, const double * volume, uint32_t n, const char * symbol, uint8_t bar_type, uint64_t bar_type_param, FloxBacktestStats * stats_out)`
+- `int flox_backtest_runner_run_replay_source(FloxBacktestRunnerHandle runner, FloxReplaySourceHandle source, FloxBacktestStats * stats_out)`
 
 ### bar_aggregation
 
@@ -742,6 +776,12 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `void flox_market_data_recorder_destroy(FloxMarketDataRecorderHandle recorder)`
 - `void flox_live_engine_set_market_data_recorder(FloxLiveEngineHandle engine, FloxMarketDataRecorderHandle recorder)`
 - `void flox_runner_set_market_data_recorder(FloxRunnerHandle runner, FloxMarketDataRecorderHandle recorder)`
+
+### replay
+
+- `FloxReplaySourceHandle flox_replay_source_create(FloxReplaySourceCallbacks callbacks)`
+- `void flox_replay_source_destroy(FloxReplaySourceHandle source)`
+- `uint8_t flox_replay_source_seek_to(FloxReplaySourceHandle source, int64_t timestamp_ns)`
 
 ### risk
 


### PR DESCRIPTION
## Summary
- Adds a callback-bundle hook (`on_start`, `on_stop`, `seek_to`, `next`, `user_data`) so bindings can implement `flox::replay::IMultiSegmentReader` in the host language.
- Tagged `FloxReplayEvent` carries one event at a time (`Trade` / `BookSnapshot` / `BookDelta`); for book events the binding sets `bids` / `asks` pointers that remain valid until the next `next` call.
- `CapiReplaySourceReader` adapts the callbacks onto the existing `IMultiSegmentReader::forEach` contract, so `BacktestRunner` runs binding-side streams without any core engine changes.

## API surface (4 new functions, 315 → 319)
- `flox_replay_source_create` / `_destroy`
- `flox_replay_source_seek_to` (convenience forwarder)
- `flox_backtest_runner_run_replay_source(runner, source, stats_out)`
- new types: `FloxReplaySourceCallbacks`, `FloxReplaySourceHandle`, `FloxReplayEvent`, `FloxReplaySourceNextFn`, `FloxReplaySourceSeekFn`, `FloxReplaySourceLifecycleFn`

## Scope
Live engine integration is intentionally deferred — bindings can already drive the live engine via `flox_live_engine_publish_trade` / `publish_book_snapshot` from any source loop, so an engine-side pull hook would add wrapper without functional value. Documented on the tracker.

## Test plan
- [x] 5 new GTest cases (`tests/test_capi_replay_source.cpp`) covering trade playback through `BacktestRunner`, empty stream, `seek_to` forwarding, NULL `seek_to`, and NULL source rejection
- [x] Local: full test suite (54/54 passing)
- [x] Codegen check: `tools/codegen/scripts/check.sh` clean (signatures + ABI snapshot in sync)
- [x] CI: 20 checks expected green

W1-T021

🤖 Generated with [Claude Code](https://claude.com/claude-code)