### PR TITLE
feat(capi): Executor + ExecutionListener hooks

### DIFF
--- a/.api/c-api.snapshot
+++ b/.api/c-api.snapshot
@@ -10,16 +10,18 @@ flox_aggregate_volume_bars|uint32_t|const int64_t *|const double *|const double 
 flox_backtest_result_create|FloxBacktestResultHandle|double|double|uint8_t|double|double|double
 flox_backtest_result_destroy|void|FloxBacktestResultHandle
 flox_backtest_result_equity_curve|uint32_t|FloxBacktestResultHandle|FloxEquityPoint *|uint32_t
-flox_backtest_result_ingest_executor|void|FloxBacktestResultHandle|FloxExecutorHandle
+flox_backtest_result_ingest_executor|void|FloxBacktestResultHandle|FloxSimulatedExecutorHandle
 flox_backtest_result_record_fill|void|FloxBacktestResultHandle|uint64_t|uint32_t|uint8_t|double|double|int64_t
 flox_backtest_result_stats|void|FloxBacktestResultHandle|FloxBacktestStats *
 flox_backtest_result_write_equity_curve_csv|uint8_t|FloxBacktestResultHandle|const char *
+flox_backtest_runner_add_execution_listener|void|FloxBacktestRunnerHandle|FloxExecutionListenerHandle
 flox_backtest_runner_create|FloxBacktestRunnerHandle|FloxRegistryHandle|double|double
 flox_backtest_runner_destroy|void|FloxBacktestRunnerHandle
 flox_backtest_runner_run_bars|int|FloxBacktestRunnerHandle|const int64_t *|const int64_t *|const double *|const double *|const double *|const double *|const double *|uint32_t|const char *|uint8_t|uint64_t|FloxBacktestStats *
 flox_backtest_runner_run_csv|int|FloxBacktestRunnerHandle|const char *|const char *|FloxBacktestStats *
 flox_backtest_runner_run_ohlcv|int|FloxBacktestRunnerHandle|const int64_t *|const double *|uint32_t|const char *|FloxBacktestStats *
 flox_backtest_runner_run_replay_source|int|FloxBacktestRunnerHandle|FloxReplaySourceHandle|FloxBacktestStats *
+flox_backtest_runner_set_executor|void|FloxBacktestRunnerHandle|FloxExecutorHandle
 flox_backtest_runner_set_strategy|void|FloxBacktestRunnerHandle|FloxStrategyHandle
 flox_best_ask_raw|int64_t|FloxStrategyHandle|uint32_t
 flox_best_bid_raw|int64_t|FloxStrategyHandle|uint32_t
@@ -92,22 +94,11 @@ flox_emit_take_profit_limit|uint64_t|FloxStrategyHandle|uint32_t|uint8_t|int64_t
 flox_emit_take_profit_market|uint64_t|FloxStrategyHandle|uint32_t|uint8_t|int64_t|int64_t
 flox_emit_trailing_stop|uint64_t|FloxStrategyHandle|uint32_t|uint8_t|int64_t|int64_t
 flox_emit_trailing_stop_percent|uint64_t|FloxStrategyHandle|uint32_t|uint8_t|int32_t|int64_t
-flox_executor_advance_clock|void|FloxExecutorHandle|int64_t
-flox_executor_cancel_all|void|FloxExecutorHandle|uint32_t
-flox_executor_cancel_order|void|FloxExecutorHandle|uint64_t
-flox_executor_create|FloxExecutorHandle
+flox_execution_listener_create|FloxExecutionListenerHandle|FloxExecutionListenerCallbacks
+flox_execution_listener_destroy|void|FloxExecutionListenerHandle
+flox_executor_create|FloxExecutorHandle|FloxExecutorCallbacks
 flox_executor_destroy|void|FloxExecutorHandle
-flox_executor_fill_count|uint32_t|FloxExecutorHandle
-flox_executor_get_fills|uint32_t|FloxExecutorHandle|FloxFill *|uint32_t
-flox_executor_on_bar|void|FloxExecutorHandle|uint32_t|double
-flox_executor_on_best_levels|void|FloxExecutorHandle|uint32_t|double|double|double|double
-flox_executor_on_book_snapshot|void|FloxExecutorHandle|uint32_t|const double *|const double *|uint32_t|const double *|const double *|uint32_t
-flox_executor_on_trade|void|FloxExecutorHandle|uint32_t|double|uint8_t
-flox_executor_on_trade_qty|void|FloxExecutorHandle|uint32_t|double|double|uint8_t
-flox_executor_set_default_slippage|void|FloxExecutorHandle|int32_t|int32_t|double|double|double
-flox_executor_set_queue_model|void|FloxExecutorHandle|int32_t|uint32_t
-flox_executor_set_symbol_slippage|void|FloxExecutorHandle|uint32_t|int32_t|int32_t|double|double|double
-flox_executor_submit_order|void|FloxExecutorHandle|uint64_t|uint8_t|double|double|uint8_t|uint32_t
+flox_executor_get_capabilities|void|FloxExecutorHandle|FloxExchangeCapabilities *
 flox_footprint_add_trade|void|FloxFootprintHandle|double|double|uint8_t
 flox_footprint_clear|void|FloxFootprintHandle
 flox_footprint_create|FloxFootprintHandle|double
@@ -179,6 +170,7 @@ flox_live_engine_destroy|void|FloxLiveEngineHandle
 flox_live_engine_publish_bar|void|FloxLiveEngineHandle|uint32_t|uint8_t|uint64_t|double|double|double|double|double|double|int64_t|int64_t|uint8_t
 flox_live_engine_publish_book_snapshot|void|FloxLiveEngineHandle|uint32_t|const double *|const double *|uint32_t|const double *|const double *|uint32_t|int64_t
 flox_live_engine_publish_trade|void|FloxLiveEngineHandle|uint32_t|double|double|uint8_t|int64_t
+flox_live_engine_set_executor|void|FloxLiveEngineHandle|FloxExecutorHandle
 flox_live_engine_set_kill_switch|void|FloxLiveEngineHandle|FloxKillSwitchHandle
 flox_live_engine_set_market_data_recorder|void|FloxLiveEngineHandle|FloxMarketDataRecorderHandle
 flox_live_engine_set_order_validator|void|FloxLiveEngineHandle|FloxOrderValidatorHandle
@@ -262,6 +254,7 @@ flox_runner_destroy|void|FloxRunnerHandle
 flox_runner_on_bar|void|FloxRunnerHandle|uint32_t|uint8_t|uint64_t|double|double|double|double|double|double|int64_t|int64_t|uint8_t
 flox_runner_on_book_snapshot|void|FloxRunnerHandle|uint32_t|const double *|const double *|uint32_t|const double *|const double *|uint32_t|int64_t
 flox_runner_on_trade|void|FloxRunnerHandle|uint32_t|double|double|uint8_t|int64_t
+flox_runner_set_executor|void|FloxRunnerHandle|FloxExecutorHandle
 flox_runner_set_kill_switch|void|FloxRunnerHandle|FloxKillSwitchHandle
 flox_runner_set_market_data_recorder|void|FloxRunnerHandle|FloxMarketDataRecorderHandle
 flox_runner_set_order_validator|void|FloxRunnerHandle|FloxOrderValidatorHandle
@@ -286,6 +279,22 @@ flox_segment_validate|uint8_t|const char *
 flox_segment_validate_full|FloxSegmentValidation|const char *|uint8_t|uint8_t
 flox_segment_validate_full_p|void|const char *|uint8_t|uint8_t|void *
 flox_set_log_callback|void|FloxLogCallback|void *
+flox_simulated_executor_advance_clock|void|FloxSimulatedExecutorHandle|int64_t
+flox_simulated_executor_cancel_all|void|FloxSimulatedExecutorHandle|uint32_t
+flox_simulated_executor_cancel_order|void|FloxSimulatedExecutorHandle|uint64_t
+flox_simulated_executor_create|FloxSimulatedExecutorHandle
+flox_simulated_executor_destroy|void|FloxSimulatedExecutorHandle
+flox_simulated_executor_fill_count|uint32_t|FloxSimulatedExecutorHandle
+flox_simulated_executor_get_fills|uint32_t|FloxSimulatedExecutorHandle|FloxFill *|uint32_t
+flox_simulated_executor_on_bar|void|FloxSimulatedExecutorHandle|uint32_t|double
+flox_simulated_executor_on_best_levels|void|FloxSimulatedExecutorHandle|uint32_t|double|double|double|double
+flox_simulated_executor_on_book_snapshot|void|FloxSimulatedExecutorHandle|uint32_t|const double *|const double *|uint32_t|const double *|const double *|uint32_t
+flox_simulated_executor_on_trade|void|FloxSimulatedExecutorHandle|uint32_t|double|uint8_t
+flox_simulated_executor_on_trade_qty|void|FloxSimulatedExecutorHandle|uint32_t|double|double|uint8_t
+flox_simulated_executor_set_default_slippage|void|FloxSimulatedExecutorHandle|int32_t|int32_t|double|double|double
+flox_simulated_executor_set_queue_model|void|FloxSimulatedExecutorHandle|int32_t|uint32_t
+flox_simulated_executor_set_symbol_slippage|void|FloxSimulatedExecutorHandle|uint32_t|int32_t|int32_t|double|double|double
+flox_simulated_executor_submit_order|void|FloxSimulatedExecutorHandle|uint64_t|uint8_t|double|double|uint8_t|uint32_t
 flox_stat_bootstrap_ci|void|const double *|size_t|double|uint32_t|double *|double *|double *
 flox_stat_correlation|double|const double *|const double *|size_t
 flox_stat_permutation_test|double|const double *|size_t|const double *|size_t|uint32_t

--- a/codon/flox/backtest.codon
+++ b/codon/flox/backtest.codon
@@ -5,20 +5,20 @@
 #
 # Handles are heap-allocated by the C API. Call .close() when done to free them.
 
-from C import flox_executor_create() -> cobj
-from C import flox_executor_destroy(cobj)
-from C import flox_executor_submit_order(cobj, u64, u8, float, float, u8, u32)
-from C import flox_executor_cancel_order(cobj, u64)
-from C import flox_executor_cancel_all(cobj, u32)
-from C import flox_executor_on_bar(cobj, u32, float)
-from C import flox_executor_on_trade(cobj, u32, float, u8)
-from C import flox_executor_on_trade_qty(cobj, u32, float, float, u8)
-from C import flox_executor_on_best_levels(cobj, u32, float, float, float, float)
-from C import flox_executor_advance_clock(cobj, i64)
-from C import flox_executor_fill_count(cobj) -> u32
-from C import flox_executor_set_default_slippage(cobj, i32, i32, float, float, float)
-from C import flox_executor_set_symbol_slippage(cobj, u32, i32, i32, float, float, float)
-from C import flox_executor_set_queue_model(cobj, i32, u32)
+from C import flox_simulated_executor_create() -> cobj
+from C import flox_simulated_executor_destroy(cobj)
+from C import flox_simulated_executor_submit_order(cobj, u64, u8, float, float, u8, u32)
+from C import flox_simulated_executor_cancel_order(cobj, u64)
+from C import flox_simulated_executor_cancel_all(cobj, u32)
+from C import flox_simulated_executor_on_bar(cobj, u32, float)
+from C import flox_simulated_executor_on_trade(cobj, u32, float, u8)
+from C import flox_simulated_executor_on_trade_qty(cobj, u32, float, float, u8)
+from C import flox_simulated_executor_on_best_levels(cobj, u32, float, float, float, float)
+from C import flox_simulated_executor_advance_clock(cobj, i64)
+from C import flox_simulated_executor_fill_count(cobj) -> u32
+from C import flox_simulated_executor_set_default_slippage(cobj, i32, i32, float, float, float)
+from C import flox_simulated_executor_set_symbol_slippage(cobj, u32, i32, i32, float, float, float)
+from C import flox_simulated_executor_set_queue_model(cobj, i32, u32)
 
 from C import flox_backtest_result_create(float, float, u8, float, float, float) -> cobj
 from C import flox_backtest_result_destroy(cobj)
@@ -87,11 +87,11 @@ class SimulatedExecutor:
     _handle: cobj
 
     def __init__(self):
-        self._handle = flox_executor_create()
+        self._handle = flox_simulated_executor_create()
 
     def close(self):
         if self._handle != cobj():
-            flox_executor_destroy(self._handle)
+            flox_simulated_executor_destroy(self._handle)
             self._handle = cobj()
 
     def submit_order(self, id: int, side: str, price: float, quantity: float,
@@ -110,54 +110,54 @@ class SimulatedExecutor:
             t = 5
         elif order_type == "trailing_stop":
             t = 6
-        flox_executor_submit_order(self._handle, u64(id), side_u, price, quantity,
+        flox_simulated_executor_submit_order(self._handle, u64(id), side_u, price, quantity,
                                    u8(t), u32(symbol))
 
     def cancel_order(self, order_id: int):
-        flox_executor_cancel_order(self._handle, u64(order_id))
+        flox_simulated_executor_cancel_order(self._handle, u64(order_id))
 
     def cancel_all(self, symbol: int):
-        flox_executor_cancel_all(self._handle, u32(symbol))
+        flox_simulated_executor_cancel_all(self._handle, u32(symbol))
 
     def on_bar(self, symbol: int, close_price: float):
-        flox_executor_on_bar(self._handle, u32(symbol), close_price)
+        flox_simulated_executor_on_bar(self._handle, u32(symbol), close_price)
 
     def on_trade(self, symbol: int, price: float, is_buy: bool):
-        flox_executor_on_trade(self._handle, u32(symbol), price,
+        flox_simulated_executor_on_trade(self._handle, u32(symbol), price,
                                u8(1 if is_buy else 0))
 
     def on_trade_qty(self, symbol: int, price: float, quantity: float, is_buy: bool):
-        flox_executor_on_trade_qty(self._handle, u32(symbol), price, quantity,
+        flox_simulated_executor_on_trade_qty(self._handle, u32(symbol), price, quantity,
                                    u8(1 if is_buy else 0))
 
     def on_best_levels(self, symbol: int, bid_price: float, bid_qty: float,
                        ask_price: float, ask_qty: float):
-        flox_executor_on_best_levels(self._handle, u32(symbol), bid_price, bid_qty,
+        flox_simulated_executor_on_best_levels(self._handle, u32(symbol), bid_price, bid_qty,
                                      ask_price, ask_qty)
 
     def advance_clock(self, timestamp_ns: int):
-        flox_executor_advance_clock(self._handle, i64(timestamp_ns))
+        flox_simulated_executor_advance_clock(self._handle, i64(timestamp_ns))
 
     def set_default_slippage(self, model: int, ticks: int = 0,
                              tick_size: float = 0.0, bps: float = 0.0,
                              impact_coeff: float = 0.0):
-        flox_executor_set_default_slippage(self._handle, i32(model), i32(ticks),
+        flox_simulated_executor_set_default_slippage(self._handle, i32(model), i32(ticks),
                                            tick_size, bps, impact_coeff)
 
     def set_symbol_slippage(self, symbol: int, model: int, ticks: int = 0,
                             tick_size: float = 0.0, bps: float = 0.0,
                             impact_coeff: float = 0.0):
-        flox_executor_set_symbol_slippage(self._handle, u32(symbol), i32(model),
+        flox_simulated_executor_set_symbol_slippage(self._handle, u32(symbol), i32(model),
                                           i32(ticks), tick_size, bps, impact_coeff)
 
     def set_queue_model(self, model: int, depth: int = 1):
-        flox_executor_set_queue_model(self._handle, i32(model), u32(depth))
+        flox_simulated_executor_set_queue_model(self._handle, i32(model), u32(depth))
 
     def handle(self) -> cobj:
         return self._handle
 
     def fill_count(self) -> int:
-        return int(flox_executor_fill_count(self._handle))
+        return int(flox_simulated_executor_fill_count(self._handle))
 
 
 class BacktestResult:

--- a/codon/flox/tools.codon
+++ b/codon/flox/tools.codon
@@ -14,15 +14,15 @@ from C import flox_book_spread(cobj, Ptr[f64]) -> u8
 from C import flox_book_is_crossed(cobj) -> u8
 from C import flox_book_clear(cobj)
 
-from C import flox_executor_create() -> cobj
-from C import flox_executor_destroy(cobj)
-from C import flox_executor_submit_order(cobj, u64, u8, f64, f64, u8, u32)
-from C import flox_executor_cancel_order(cobj, u64)
-from C import flox_executor_cancel_all(cobj, u32)
-from C import flox_executor_on_bar(cobj, u32, f64)
-from C import flox_executor_on_trade(cobj, u32, f64, u8)
-from C import flox_executor_advance_clock(cobj, i64)
-from C import flox_executor_fill_count(cobj) -> u32
+from C import flox_simulated_executor_create() -> cobj
+from C import flox_simulated_executor_destroy(cobj)
+from C import flox_simulated_executor_submit_order(cobj, u64, u8, f64, f64, u8, u32)
+from C import flox_simulated_executor_cancel_order(cobj, u64)
+from C import flox_simulated_executor_cancel_all(cobj, u32)
+from C import flox_simulated_executor_on_bar(cobj, u32, f64)
+from C import flox_simulated_executor_on_trade(cobj, u32, f64, u8)
+from C import flox_simulated_executor_advance_clock(cobj, i64)
+from C import flox_simulated_executor_fill_count(cobj) -> u32
 
 from C import flox_position_tracker_create(u8) -> cobj
 from C import flox_position_tracker_destroy(cobj)
@@ -238,33 +238,33 @@ class SimulatedExecutor:
     _h: cobj
 
     def __init__(self):
-        self._h = flox_executor_create()
+        self._h = flox_simulated_executor_create()
 
     def submit_order(self, order_id: int, side: str, price: float,
                      qty: float, order_type: int = 0, symbol: int = 1):
         s = u8(0) if side == "buy" else u8(1)
-        flox_executor_submit_order(self._h, u64(order_id), s, price, qty,
+        flox_simulated_executor_submit_order(self._h, u64(order_id), s, price, qty,
                                    u8(order_type), u32(symbol))
 
     def cancel_order(self, order_id: int):
-        flox_executor_cancel_order(self._h, u64(order_id))
+        flox_simulated_executor_cancel_order(self._h, u64(order_id))
 
     def cancel_all(self, symbol: int):
-        flox_executor_cancel_all(self._h, u32(symbol))
+        flox_simulated_executor_cancel_all(self._h, u32(symbol))
 
     def on_bar(self, symbol: int, close_price: float):
-        flox_executor_on_bar(self._h, u32(symbol), close_price)
+        flox_simulated_executor_on_bar(self._h, u32(symbol), close_price)
 
     def on_trade(self, symbol: int, price: float, is_buy: bool):
-        flox_executor_on_trade(self._h, u32(symbol), price,
+        flox_simulated_executor_on_trade(self._h, u32(symbol), price,
                                u8(1) if is_buy else u8(0))
 
     def advance_clock(self, timestamp_ns: int):
-        flox_executor_advance_clock(self._h, i64(timestamp_ns))
+        flox_simulated_executor_advance_clock(self._h, i64(timestamp_ns))
 
     @property
     def fill_count(self) -> int:
-        return int(flox_executor_fill_count(self._h))
+        return int(flox_simulated_executor_fill_count(self._h))
 
 
 class PositionTracker:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -13827,7 +13827,7 @@ typedef void* FloxRunnerHandle;
 typedef void* FloxLiveEngineHandle;
 typedef void* FloxBacktestRunnerHandle;
 typedef void* FloxBacktestResultHandle;
-typedef void* FloxExecutorHandle;
+typedef void* FloxSimulatedExecutorHandle;
 typedef void* FloxBookHandle;
 typedef void* FloxL3BookHandle;
 typedef void* FloxCompositeBookHandle;
@@ -14171,34 +14171,34 @@ All return `OrderId` (`uint64_t`), 0 on failure. `cancel` and `modify` return vo
 Used in backtesting to fill orders from simulated market data.
 
 ```c
-FloxExecutorHandle flox_executor_create(void);
-void               flox_executor_destroy(FloxExecutorHandle executor);
+FloxSimulatedExecutorHandle flox_simulated_executor_create(void);
+void               flox_simulated_executor_destroy(FloxSimulatedExecutorHandle executor);
 
-void flox_executor_submit_order(FloxExecutorHandle executor,
+void flox_simulated_executor_submit_order(FloxSimulatedExecutorHandle executor,
                                 uint64_t id, uint8_t side, double price,
                                 double quantity, uint8_t order_type, uint32_t symbol);
-void flox_executor_cancel_order(FloxExecutorHandle executor, uint64_t order_id);
-void flox_executor_cancel_all(FloxExecutorHandle executor, uint32_t symbol);
+void flox_simulated_executor_cancel_order(FloxSimulatedExecutorHandle executor, uint64_t order_id);
+void flox_simulated_executor_cancel_all(FloxSimulatedExecutorHandle executor, uint32_t symbol);
 
 // Feed market data
-void flox_executor_on_bar(FloxExecutorHandle executor, uint32_t symbol, double close_price);
-void flox_executor_on_trade(FloxExecutorHandle executor, uint32_t symbol,
+void flox_simulated_executor_on_bar(FloxSimulatedExecutorHandle executor, uint32_t symbol, double close_price);
+void flox_simulated_executor_on_trade(FloxSimulatedExecutorHandle executor, uint32_t symbol,
                             double price, uint8_t is_buy);
-void flox_executor_on_trade_qty(FloxExecutorHandle executor, uint32_t symbol,
+void flox_simulated_executor_on_trade_qty(FloxSimulatedExecutorHandle executor, uint32_t symbol,
                                 double price, double quantity, uint8_t is_buy);
-void flox_executor_on_best_levels(FloxExecutorHandle executor, uint32_t symbol,
+void flox_simulated_executor_on_best_levels(FloxSimulatedExecutorHandle executor, uint32_t symbol,
                                   double bid_price, double bid_qty,
                                   double ask_price, double ask_qty);
-void flox_executor_on_book_snapshot(FloxExecutorHandle executor, uint32_t symbol,
+void flox_simulated_executor_on_book_snapshot(FloxSimulatedExecutorHandle executor, uint32_t symbol,
                                     const double* bid_prices, const double* bid_qtys,
                                     uint32_t n_bids,
                                     const double* ask_prices, const double* ask_qtys,
                                     uint32_t n_asks);
-void flox_executor_advance_clock(FloxExecutorHandle executor, int64_t timestamp_ns);
+void flox_simulated_executor_advance_clock(FloxSimulatedExecutorHandle executor, int64_t timestamp_ns);
 
 // Fills
-uint32_t flox_executor_fill_count(FloxExecutorHandle executor);
-uint32_t flox_executor_get_fills(FloxExecutorHandle executor,
+uint32_t flox_simulated_executor_fill_count(FloxSimulatedExecutorHandle executor);
+uint32_t flox_simulated_executor_get_fills(FloxSimulatedExecutorHandle executor,
                                  FloxFill* fills_out, uint32_t max_fills);
 ```
 
@@ -14212,11 +14212,11 @@ typedef enum {
     FLOX_SLIPPAGE_VOLUME_IMPACT = 3
 } FloxSlippageModel;
 
-void flox_executor_set_default_slippage(FloxExecutorHandle executor,
+void flox_simulated_executor_set_default_slippage(FloxSimulatedExecutorHandle executor,
                                         int32_t model, int32_t ticks,
                                         double tick_size, double bps,
                                         double impact_coeff);
-void flox_executor_set_symbol_slippage(FloxExecutorHandle executor, uint32_t symbol,
+void flox_simulated_executor_set_symbol_slippage(FloxSimulatedExecutorHandle executor, uint32_t symbol,
                                        int32_t model, int32_t ticks,
                                        double tick_size, double bps,
                                        double impact_coeff);
@@ -14231,7 +14231,7 @@ typedef enum {
     FLOX_QUEUE_FULL = 2
 } FloxQueueModel;
 
-void flox_executor_set_queue_model(FloxExecutorHandle executor,
+void flox_simulated_executor_set_queue_model(FloxSimulatedExecutorHandle executor,
                                    int32_t model, uint32_t depth);
 ```
 
@@ -14254,7 +14254,7 @@ void flox_backtest_result_record_fill(FloxBacktestResultHandle result,
                                       uint64_t order_id, uint32_t symbol, uint8_t side,
                                       double price, double quantity, int64_t timestamp_ns);
 void flox_backtest_result_ingest_executor(FloxBacktestResultHandle result,
-                                          FloxExecutorHandle executor);
+                                          FloxSimulatedExecutorHandle executor);
 
 void     flox_backtest_result_stats(FloxBacktestResultHandle result, FloxBacktestStats* out);
 uint32_t flox_backtest_result_equity_curve(FloxBacktestResultHandle result,

--- a/docs/reference/api/backtest/queue_simulation.md
+++ b/docs/reference/api/backtest/queue_simulation.md
@@ -45,7 +45,7 @@ Queue simulation requires trade quantities. Use the overload `onTrade(symbol, pr
 
 In Python: call `executor.on_trade_qty(symbol, price, quantity, is_buy)`.
 
-In C API: `flox_executor_on_trade_qty(executor, symbol, price, quantity, is_buy)`.
+In C API: `flox_simulated_executor_on_trade_qty(executor, symbol, price, quantity, is_buy)`.
 
 In JavaScript: `executor.onTradeQty(symbol, price, quantity, isBuy)`.
 

--- a/docs/reference/api/backtest/slippage.md
+++ b/docs/reference/api/backtest/slippage.md
@@ -51,7 +51,7 @@ exec.setSymbolSlippage(kBtcUsd,
 | Language | Entry point |
 |----------|-------------|
 | Python | `SimulatedExecutor.set_default_slippage(model, ticks, tick_size, bps, impact_coeff)` / `set_symbol_slippage(symbol, ...)` |
-| C API | `flox_executor_set_default_slippage(exec, model, ticks, tick_size, bps, impact)` |
+| C API | `flox_simulated_executor_set_default_slippage(exec, model, ticks, tick_size, bps, impact)` |
 | Codon | `SimulatedExecutor.set_default_slippage(model, ticks, tick_size, bps, impact_coeff)` |
 | JavaScript | `executor.setDefaultSlippage("fixed_bps", 0, 0, 5.0, 0)` |
 

--- a/docs/reference/api/capi/flox_capi.md
+++ b/docs/reference/api/capi/flox_capi.md
@@ -17,7 +17,7 @@ typedef void* FloxRunnerHandle;
 typedef void* FloxLiveEngineHandle;
 typedef void* FloxBacktestRunnerHandle;
 typedef void* FloxBacktestResultHandle;
-typedef void* FloxExecutorHandle;
+typedef void* FloxSimulatedExecutorHandle;
 typedef void* FloxBookHandle;
 typedef void* FloxL3BookHandle;
 typedef void* FloxCompositeBookHandle;
@@ -361,34 +361,34 @@ All return `OrderId` (`uint64_t`), 0 on failure. `cancel` and `modify` return vo
 Used in backtesting to fill orders from simulated market data.
 
 ```c
-FloxExecutorHandle flox_executor_create(void);
-void               flox_executor_destroy(FloxExecutorHandle executor);
+FloxSimulatedExecutorHandle flox_simulated_executor_create(void);
+void               flox_simulated_executor_destroy(FloxSimulatedExecutorHandle executor);
 
-void flox_executor_submit_order(FloxExecutorHandle executor,
+void flox_simulated_executor_submit_order(FloxSimulatedExecutorHandle executor,
                                 uint64_t id, uint8_t side, double price,
                                 double quantity, uint8_t order_type, uint32_t symbol);
-void flox_executor_cancel_order(FloxExecutorHandle executor, uint64_t order_id);
-void flox_executor_cancel_all(FloxExecutorHandle executor, uint32_t symbol);
+void flox_simulated_executor_cancel_order(FloxSimulatedExecutorHandle executor, uint64_t order_id);
+void flox_simulated_executor_cancel_all(FloxSimulatedExecutorHandle executor, uint32_t symbol);
 
 // Feed market data
-void flox_executor_on_bar(FloxExecutorHandle executor, uint32_t symbol, double close_price);
-void flox_executor_on_trade(FloxExecutorHandle executor, uint32_t symbol,
+void flox_simulated_executor_on_bar(FloxSimulatedExecutorHandle executor, uint32_t symbol, double close_price);
+void flox_simulated_executor_on_trade(FloxSimulatedExecutorHandle executor, uint32_t symbol,
                             double price, uint8_t is_buy);
-void flox_executor_on_trade_qty(FloxExecutorHandle executor, uint32_t symbol,
+void flox_simulated_executor_on_trade_qty(FloxSimulatedExecutorHandle executor, uint32_t symbol,
                                 double price, double quantity, uint8_t is_buy);
-void flox_executor_on_best_levels(FloxExecutorHandle executor, uint32_t symbol,
+void flox_simulated_executor_on_best_levels(FloxSimulatedExecutorHandle executor, uint32_t symbol,
                                   double bid_price, double bid_qty,
                                   double ask_price, double ask_qty);
-void flox_executor_on_book_snapshot(FloxExecutorHandle executor, uint32_t symbol,
+void flox_simulated_executor_on_book_snapshot(FloxSimulatedExecutorHandle executor, uint32_t symbol,
                                     const double* bid_prices, const double* bid_qtys,
                                     uint32_t n_bids,
                                     const double* ask_prices, const double* ask_qtys,
                                     uint32_t n_asks);
-void flox_executor_advance_clock(FloxExecutorHandle executor, int64_t timestamp_ns);
+void flox_simulated_executor_advance_clock(FloxSimulatedExecutorHandle executor, int64_t timestamp_ns);
 
 // Fills
-uint32_t flox_executor_fill_count(FloxExecutorHandle executor);
-uint32_t flox_executor_get_fills(FloxExecutorHandle executor,
+uint32_t flox_simulated_executor_fill_count(FloxSimulatedExecutorHandle executor);
+uint32_t flox_simulated_executor_get_fills(FloxSimulatedExecutorHandle executor,
                                  FloxFill* fills_out, uint32_t max_fills);
 ```
 
@@ -402,11 +402,11 @@ typedef enum {
     FLOX_SLIPPAGE_VOLUME_IMPACT = 3
 } FloxSlippageModel;
 
-void flox_executor_set_default_slippage(FloxExecutorHandle executor,
+void flox_simulated_executor_set_default_slippage(FloxSimulatedExecutorHandle executor,
                                         int32_t model, int32_t ticks,
                                         double tick_size, double bps,
                                         double impact_coeff);
-void flox_executor_set_symbol_slippage(FloxExecutorHandle executor, uint32_t symbol,
+void flox_simulated_executor_set_symbol_slippage(FloxSimulatedExecutorHandle executor, uint32_t symbol,
                                        int32_t model, int32_t ticks,
                                        double tick_size, double bps,
                                        double impact_coeff);
@@ -421,7 +421,7 @@ typedef enum {
     FLOX_QUEUE_FULL = 2
 } FloxQueueModel;
 
-void flox_executor_set_queue_model(FloxExecutorHandle executor,
+void flox_simulated_executor_set_queue_model(FloxSimulatedExecutorHandle executor,
                                    int32_t model, uint32_t depth);
 ```
 
@@ -444,7 +444,7 @@ void flox_backtest_result_record_fill(FloxBacktestResultHandle result,
                                       uint64_t order_id, uint32_t symbol, uint8_t side,
                                       double price, double quantity, int64_t timestamp_ns);
 void flox_backtest_result_ingest_executor(FloxBacktestResultHandle result,
-                                          FloxExecutorHandle executor);
+                                          FloxSimulatedExecutorHandle executor);
 
 void     flox_backtest_result_stats(FloxBacktestResultHandle result, FloxBacktestStats* out);
 uint32_t flox_backtest_result_equity_curve(FloxBacktestResultHandle result,

--- a/include/flox/backtest/backtest_runner.h
+++ b/include/flox/backtest/backtest_runner.h
@@ -15,6 +15,7 @@
 #include "flox/backtest/simulated_clock.h"
 #include "flox/backtest/simulated_executor.h"
 #include "flox/execution/abstract_execution_listener.h"
+#include "flox/execution/abstract_executor.h"
 #include "flox/replay/abstract_event_reader.h"
 #include "flox/strategy/abstract_signal_handler.h"
 #include "flox/strategy/strategy.h"
@@ -95,6 +96,17 @@ class BacktestRunner : public ISignalHandler
   void addMarketDataSubscriber(IMarketDataSubscriber* subscriber);
   void addExecutionListener(IOrderExecutionListener* listener);
 
+  /// Replace the built-in SimulatedExecutor with a binding-supplied
+  /// IOrderExecutor. When set, all signals (submit / cancel / replace /
+  /// OCO / cancelAll) are routed to the custom executor instead of the
+  /// built-in simulator. The simulator is left intact for matching live
+  /// data into BacktestResult; the custom executor is responsible for
+  /// reporting fills via its own ExecutionListener path. Pass nullptr
+  /// to revert to the simulated executor.
+  /// Caller retains ownership; the runner does not delete the executor.
+  void setExecutor(IOrderExecutor* executor) noexcept { _customExecutor = executor; }
+  IOrderExecutor* customExecutor() const noexcept { return _customExecutor; }
+
   // ========== Non-interactive mode ==========
 
   /// Run backtest synchronously from start to end
@@ -163,6 +175,9 @@ class BacktestRunner : public ISignalHandler
   BacktestConfig _config;
   SimulatedClock _clock;
   SimulatedExecutor _executor;
+  // Optional binding-supplied executor. When non-null, signals are routed
+  // here instead of to the built-in SimulatedExecutor.
+  IOrderExecutor* _customExecutor{nullptr};
   IStrategy* _strategy{nullptr};
   std::vector<IMarketDataSubscriber*> _marketDataSubscribers;
   std::vector<IOrderExecutionListener*> _executionListeners;

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -24,7 +24,7 @@ extern "C"
   typedef void* FloxStrategyHandle;
   typedef void* FloxRegistryHandle;
   typedef void* FloxBookHandle;
-  typedef void* FloxExecutorHandle;
+  typedef void* FloxSimulatedExecutorHandle;
   typedef void* FloxPositionTrackerHandle;
   typedef void* FloxPositionGroupHandle;
   typedef void* FloxOrderTrackerHandle;
@@ -410,18 +410,18 @@ extern "C"
   // Simulated executor (backtesting)
   // ============================================================
 
-  FloxExecutorHandle flox_executor_create(void);
-  void flox_executor_destroy(FloxExecutorHandle executor);
-  void flox_executor_submit_order(FloxExecutorHandle executor, uint64_t id, uint8_t side,
-                                  double price, double quantity, uint8_t order_type,
-                                  uint32_t symbol);
-  void flox_executor_cancel_order(FloxExecutorHandle executor, uint64_t order_id);
-  void flox_executor_cancel_all(FloxExecutorHandle executor, uint32_t symbol);
-  void flox_executor_on_bar(FloxExecutorHandle executor, uint32_t symbol, double close_price);
-  void flox_executor_on_trade(FloxExecutorHandle executor, uint32_t symbol, double price,
-                              uint8_t is_buy);
-  void flox_executor_advance_clock(FloxExecutorHandle executor, int64_t timestamp_ns);
-  uint32_t flox_executor_fill_count(FloxExecutorHandle executor);
+  FloxSimulatedExecutorHandle flox_simulated_executor_create(void);
+  void flox_simulated_executor_destroy(FloxSimulatedExecutorHandle executor);
+  void flox_simulated_executor_submit_order(FloxSimulatedExecutorHandle executor, uint64_t id, uint8_t side,
+                                            double price, double quantity, uint8_t order_type,
+                                            uint32_t symbol);
+  void flox_simulated_executor_cancel_order(FloxSimulatedExecutorHandle executor, uint64_t order_id);
+  void flox_simulated_executor_cancel_all(FloxSimulatedExecutorHandle executor, uint32_t symbol);
+  void flox_simulated_executor_on_bar(FloxSimulatedExecutorHandle executor, uint32_t symbol, double close_price);
+  void flox_simulated_executor_on_trade(FloxSimulatedExecutorHandle executor, uint32_t symbol, double price,
+                                        uint8_t is_buy);
+  void flox_simulated_executor_advance_clock(FloxSimulatedExecutorHandle executor, int64_t timestamp_ns);
+  uint32_t flox_simulated_executor_fill_count(FloxSimulatedExecutorHandle executor);
 
   // ============================================================
   // Bar aggregation
@@ -593,8 +593,8 @@ extern "C"
     int64_t timestamp_ns;
   } FloxFill;
 
-  uint32_t flox_executor_get_fills(FloxExecutorHandle executor, FloxFill* fills_out,
-                                   uint32_t max_fills);
+  uint32_t flox_simulated_executor_get_fills(FloxSimulatedExecutorHandle executor, FloxFill* fills_out,
+                                             uint32_t max_fills);
 
   // ============================================================
   // Additional bar aggregation
@@ -707,36 +707,36 @@ extern "C"
   // a per-symbol override is set. `tick_size` is the venue tick size in
   // price units (e.g. 0.01 for 1-cent ticks); pass 0.0 to fall back to one
   // raw price unit.
-  void flox_executor_set_default_slippage(FloxExecutorHandle executor,
-                                          int32_t model, int32_t ticks,
-                                          double tick_size, double bps,
-                                          double impact_coeff);
-  void flox_executor_set_symbol_slippage(FloxExecutorHandle executor, uint32_t symbol,
-                                         int32_t model, int32_t ticks,
-                                         double tick_size, double bps,
-                                         double impact_coeff);
+  void flox_simulated_executor_set_default_slippage(FloxSimulatedExecutorHandle executor,
+                                                    int32_t model, int32_t ticks,
+                                                    double tick_size, double bps,
+                                                    double impact_coeff);
+  void flox_simulated_executor_set_symbol_slippage(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                                   int32_t model, int32_t ticks,
+                                                   double tick_size, double bps,
+                                                   double impact_coeff);
 
   // Configure queue simulation for limit orders.
-  void flox_executor_set_queue_model(FloxExecutorHandle executor, int32_t model,
-                                     uint32_t depth);
+  void flox_simulated_executor_set_queue_model(FloxSimulatedExecutorHandle executor, int32_t model,
+                                               uint32_t depth);
 
   // Feed a trade with quantity (enables queue-fill simulation for limit orders).
-  void flox_executor_on_trade_qty(FloxExecutorHandle executor, uint32_t symbol,
-                                  double price, double quantity, uint8_t is_buy);
+  void flox_simulated_executor_on_trade_qty(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                            double price, double quantity, uint8_t is_buy);
 
   // Feed a top-of-book snapshot (both best bid and best ask in one call).
   // For multi-level updates, build a BookUpdate on the C++ side; the C API
   // intentionally does not expose a stateful per-side helper because that
   // makes it too easy to accidentally clear the opposite side.
-  void flox_executor_on_best_levels(FloxExecutorHandle executor, uint32_t symbol,
-                                    double bid_price, double bid_qty, double ask_price,
-                                    double ask_qty);
+  void flox_simulated_executor_on_best_levels(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                              double bid_price, double bid_qty, double ask_price,
+                                              double ask_qty);
 
   // Feed a full L2 snapshot with parallel bid/ask arrays.
-  void flox_executor_on_book_snapshot(FloxExecutorHandle executor, uint32_t symbol,
-                                      const double* bid_prices, const double* bid_qtys,
-                                      uint32_t n_bids, const double* ask_prices,
-                                      const double* ask_qtys, uint32_t n_asks);
+  void flox_simulated_executor_on_book_snapshot(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                                const double* bid_prices, const double* bid_qtys,
+                                                uint32_t n_bids, const double* ask_prices,
+                                                const double* ask_qtys, uint32_t n_asks);
 
   // BacktestResult handle: aggregates fills into trades + stats + equity curve.
   typedef void* FloxBacktestResultHandle;
@@ -756,7 +756,7 @@ extern "C"
 
   // Drain all fills from a SimulatedExecutor into a BacktestResult in FIFO order.
   void flox_backtest_result_ingest_executor(FloxBacktestResultHandle result,
-                                            FloxExecutorHandle executor);
+                                            FloxSimulatedExecutorHandle executor);
 
   typedef struct
   {
@@ -1364,6 +1364,143 @@ extern "C"
   uint8_t flox_replay_source_seek_to(FloxReplaySourceHandle source, int64_t timestamp_ns);
 
   // ============================================================
+  // ExecutionListener — observe order lifecycle events.
+  //
+  // Bindings register callbacks that fire as orders move through the
+  // execution path (submitted → accepted → filled / canceled / rejected
+  // / etc.). Used as a backtest observer (SimulatedExecutor inside
+  // BacktestRunner emits these) or a live-broker fill surface.
+  //
+  // The order pointer is read-only and valid only for the duration of
+  // the callback; copy fields you need to retain. Any callback may be
+  // NULL (no-op).
+  // ============================================================
+
+  typedef struct
+  {
+    uint64_t id;
+    uint64_t client_order_id;
+    uint32_t symbol;
+    uint16_t strategy_id;
+    uint16_t order_tag;
+    uint8_t side;           // 0=BUY, 1=SELL
+    uint8_t type;           // OrderType enum
+    uint8_t time_in_force;  // TimeInForce enum
+    uint8_t flags;          // ExecutionFlags packed bits
+    int64_t price_raw;
+    int64_t quantity_raw;
+    int64_t filled_quantity_raw;
+    int64_t trigger_price_raw;
+    int64_t trailing_offset_raw;
+    int64_t created_at_ns;
+    int64_t exchange_ts_ns;
+  } FloxOrder;
+
+  typedef void (*FloxExecListenerOnOrderFn)(void* user_data, const FloxOrder* order);
+  typedef void (*FloxExecListenerOnPartialFillFn)(void* user_data,
+                                                  const FloxOrder* order,
+                                                  int64_t fill_quantity_raw);
+  typedef void (*FloxExecListenerOnRejectedFn)(void* user_data,
+                                               const FloxOrder* order,
+                                               const char* reason);
+  typedef void (*FloxExecListenerOnReplacedFn)(void* user_data,
+                                               const FloxOrder* old_order,
+                                               const FloxOrder* new_order);
+  typedef void (*FloxExecListenerOnTrailingUpdateFn)(void* user_data,
+                                                     const FloxOrder* order,
+                                                     int64_t new_trigger_price_raw);
+
+  typedef struct
+  {
+    FloxExecListenerOnOrderFn on_submitted;
+    FloxExecListenerOnOrderFn on_accepted;
+    FloxExecListenerOnPartialFillFn on_partially_filled;
+    FloxExecListenerOnOrderFn on_filled;
+    FloxExecListenerOnOrderFn on_pending_cancel;
+    FloxExecListenerOnOrderFn on_canceled;
+    FloxExecListenerOnOrderFn on_expired;
+    FloxExecListenerOnRejectedFn on_rejected;
+    FloxExecListenerOnReplacedFn on_replaced;
+    FloxExecListenerOnOrderFn on_pending_trigger;
+    FloxExecListenerOnOrderFn on_triggered;
+    FloxExecListenerOnTrailingUpdateFn on_trailing_stop_updated;
+    void* user_data;
+  } FloxExecutionListenerCallbacks;
+
+  typedef void* FloxExecutionListenerHandle;
+
+  FloxExecutionListenerHandle
+  flox_execution_listener_create(FloxExecutionListenerCallbacks callbacks);
+  void flox_execution_listener_destroy(FloxExecutionListenerHandle listener);
+
+  // ============================================================
+  // Executor — binding-supplied IOrderExecutor.
+  //
+  // Bindings provide an executor that places, cancels, replaces and
+  // OCO-submits orders on a real broker (or on a custom simulator). The
+  // engine routes every signal through this executor instead of the
+  // built-in SimulatedExecutor when one is attached.
+  //
+  // The concrete in-process SimulatedExecutor is exposed separately
+  // as flox_simulated_executor_*.
+  // ============================================================
+
+  typedef struct
+  {
+    uint8_t supports_stop_market;
+    uint8_t supports_stop_limit;
+    uint8_t supports_take_profit_market;
+    uint8_t supports_take_profit_limit;
+    uint8_t supports_trailing_stop;
+    uint8_t supports_iceberg;
+    uint8_t supports_oco;
+    uint8_t supports_gtc;
+    uint8_t supports_ioc;
+    uint8_t supports_fok;
+    uint8_t supports_gtd;
+    uint8_t supports_post_only;
+    uint8_t supports_reduce_only;
+    uint8_t supports_close_position;
+    uint8_t _pad[2];
+  } FloxExchangeCapabilities;
+
+  typedef void (*FloxExecutorSubmitFn)(void* user_data, const FloxOrder* order);
+  typedef void (*FloxExecutorCancelFn)(void* user_data, uint64_t order_id);
+  typedef void (*FloxExecutorCancelAllFn)(void* user_data, uint32_t symbol);
+  typedef void (*FloxExecutorReplaceFn)(void* user_data,
+                                        uint64_t old_order_id,
+                                        const FloxOrder* new_order);
+  typedef void (*FloxExecutorSubmitOCOFn)(void* user_data,
+                                          const FloxOrder* order1,
+                                          const FloxOrder* order2);
+  typedef void (*FloxExecutorCapabilitiesFn)(void* user_data,
+                                             FloxExchangeCapabilities* caps_out);
+  typedef void (*FloxExecutorLifecycleFn)(void* user_data);
+
+  typedef struct
+  {
+    FloxExecutorSubmitFn submit;
+    FloxExecutorCancelFn cancel;
+    FloxExecutorCancelAllFn cancel_all;
+    FloxExecutorReplaceFn replace;
+    FloxExecutorSubmitOCOFn submit_oco;
+    FloxExecutorCapabilitiesFn capabilities;
+    FloxExecutorLifecycleFn on_start;
+    FloxExecutorLifecycleFn on_stop;
+    void* user_data;
+  } FloxExecutorCallbacks;
+
+  typedef void* FloxExecutorHandle;
+
+  FloxExecutorHandle flox_executor_create(FloxExecutorCallbacks callbacks);
+  void flox_executor_destroy(FloxExecutorHandle executor);
+
+  // Query the executor's reported capabilities. Forwards to the binding's
+  // capabilities() callback. caps_out is zeroed if no callback registered.
+  void flox_executor_get_capabilities(FloxExecutorHandle executor,
+                                      FloxExchangeCapabilities* caps_out);
+
+  // ============================================================
   // FloxLiveEngine — Disruptor-based live trading engine.
   //
   // Uses real EventBus (SPSC ring buffer / Disruptor) internally.
@@ -1412,6 +1549,14 @@ extern "C"
   // start/stop while attached.
   void flox_live_engine_set_market_data_recorder(FloxLiveEngineHandle engine,
                                                  FloxMarketDataRecorderHandle recorder);
+
+  // Attach (or detach with NULL) a binding-supplied executor. When set,
+  // emitted signals are forwarded to the executor (submit / cancel /
+  // replace / cancel_all / submit_oco) instead of relying on the user's
+  // on_signal callback to route orders. on_start / on_stop fire balanced
+  // against engine start/stop.
+  void flox_live_engine_set_executor(FloxLiveEngineHandle engine,
+                                     FloxExecutorHandle executor);
 
   // Attach a strategy to both TradeBus and BookUpdateBus.
   // on_signal is called from the consumer thread when the strategy emits an order.
@@ -1505,6 +1650,13 @@ extern "C"
   // start/stop.
   void flox_runner_set_market_data_recorder(FloxRunnerHandle runner,
                                             FloxMarketDataRecorderHandle recorder);
+
+  // Attach (or detach with NULL) a binding-supplied executor. When set,
+  // emitted signals are forwarded to the executor in addition to the
+  // user's on_signal callback. on_start / on_stop fire balanced against
+  // runner start/stop.
+  void flox_runner_set_executor(FloxRunnerHandle runner,
+                                FloxExecutorHandle executor);
 
   void flox_runner_start(FloxRunnerHandle runner);
   void flox_runner_stop(FloxRunnerHandle runner);
@@ -1600,6 +1752,17 @@ extern "C"
   int flox_backtest_runner_run_replay_source(FloxBacktestRunnerHandle runner,
                                              FloxReplaySourceHandle source,
                                              FloxBacktestStats* stats_out);
+
+  // Attach a binding-side execution listener to BacktestRunner. Multiple
+  // listeners may be attached. Caller retains ownership of the listener.
+  void flox_backtest_runner_add_execution_listener(FloxBacktestRunnerHandle runner,
+                                                   FloxExecutionListenerHandle listener);
+
+  // Attach (or detach with NULL) a binding-supplied executor. When set,
+  // emitted signals are routed to the executor instead of the built-in
+  // SimulatedExecutor.
+  void flox_backtest_runner_set_executor(FloxBacktestRunnerHandle runner,
+                                         FloxExecutorHandle executor);
 
 #ifdef __cplusplus
 }

--- a/include/flox/capi/flox_capi_spec.hpp
+++ b/include/flox/capi/flox_capi_spec.hpp
@@ -32,7 +32,7 @@ extern "C"
   typedef void* FloxStrategyHandle;
   typedef void* FloxRegistryHandle;
   typedef void* FloxBookHandle;
-  typedef void* FloxExecutorHandle;
+  typedef void* FloxSimulatedExecutorHandle;
   typedef void* FloxPositionTrackerHandle;
   typedef void* FloxPositionGroupHandle;
   typedef void* FloxOrderTrackerHandle;
@@ -525,26 +525,26 @@ extern "C"
   // ============================================================
 
   FLOX_EXPORT(group = "simulated_executor")
-  FloxExecutorHandle flox_executor_create(void);
+  FloxSimulatedExecutorHandle flox_simulated_executor_create(void);
   FLOX_EXPORT(group = "simulated_executor")
-  void flox_executor_destroy(FloxExecutorHandle executor);
+  void flox_simulated_executor_destroy(FloxSimulatedExecutorHandle executor);
   FLOX_EXPORT(group = "simulated_executor")
-  void flox_executor_submit_order(FloxExecutorHandle executor, uint64_t id, uint8_t side,
-                                  double price, double quantity, uint8_t order_type,
-                                  uint32_t symbol);
+  void flox_simulated_executor_submit_order(FloxSimulatedExecutorHandle executor, uint64_t id, uint8_t side,
+                                            double price, double quantity, uint8_t order_type,
+                                            uint32_t symbol);
   FLOX_EXPORT(group = "simulated_executor")
-  void flox_executor_cancel_order(FloxExecutorHandle executor, uint64_t order_id);
+  void flox_simulated_executor_cancel_order(FloxSimulatedExecutorHandle executor, uint64_t order_id);
   FLOX_EXPORT(group = "simulated_executor")
-  void flox_executor_cancel_all(FloxExecutorHandle executor, uint32_t symbol);
+  void flox_simulated_executor_cancel_all(FloxSimulatedExecutorHandle executor, uint32_t symbol);
   FLOX_EXPORT(group = "simulated_executor")
-  void flox_executor_on_bar(FloxExecutorHandle executor, uint32_t symbol, double close_price);
+  void flox_simulated_executor_on_bar(FloxSimulatedExecutorHandle executor, uint32_t symbol, double close_price);
   FLOX_EXPORT(group = "simulated_executor")
-  void flox_executor_on_trade(FloxExecutorHandle executor, uint32_t symbol, double price,
-                              uint8_t is_buy);
+  void flox_simulated_executor_on_trade(FloxSimulatedExecutorHandle executor, uint32_t symbol, double price,
+                                        uint8_t is_buy);
   FLOX_EXPORT(group = "simulated_executor")
-  void flox_executor_advance_clock(FloxExecutorHandle executor, int64_t timestamp_ns);
+  void flox_simulated_executor_advance_clock(FloxSimulatedExecutorHandle executor, int64_t timestamp_ns);
   FLOX_EXPORT(group = "simulated_executor")
-  uint32_t flox_executor_fill_count(FloxExecutorHandle executor);
+  uint32_t flox_simulated_executor_fill_count(FloxSimulatedExecutorHandle executor);
 
   // ============================================================
   // Bar aggregation
@@ -785,8 +785,8 @@ extern "C"
   } FloxFill;
 
   FLOX_EXPORT(group = "executor_fill")
-  uint32_t flox_executor_get_fills(FloxExecutorHandle executor, FloxFill* fills_out,
-                                   uint32_t max_fills);
+  uint32_t flox_simulated_executor_get_fills(FloxSimulatedExecutorHandle executor, FloxFill* fills_out,
+                                             uint32_t max_fills);
 
   // ============================================================
   // Additional bar aggregation
@@ -926,41 +926,41 @@ extern "C"
   // price units (e.g. 0.01 for 1-cent ticks); pass 0.0 to fall back to one
   // raw price unit.
   FLOX_EXPORT(group = "backtest_slippage")
-  void flox_executor_set_default_slippage(FloxExecutorHandle executor,
-                                          int32_t model, int32_t ticks,
-                                          double tick_size, double bps,
-                                          double impact_coeff);
+  void flox_simulated_executor_set_default_slippage(FloxSimulatedExecutorHandle executor,
+                                                    int32_t model, int32_t ticks,
+                                                    double tick_size, double bps,
+                                                    double impact_coeff);
   FLOX_EXPORT(group = "backtest_slippage")
-  void flox_executor_set_symbol_slippage(FloxExecutorHandle executor, uint32_t symbol,
-                                         int32_t model, int32_t ticks,
-                                         double tick_size, double bps,
-                                         double impact_coeff);
+  void flox_simulated_executor_set_symbol_slippage(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                                   int32_t model, int32_t ticks,
+                                                   double tick_size, double bps,
+                                                   double impact_coeff);
 
   // Configure queue simulation for limit orders.
   FLOX_EXPORT(group = "backtest_slippage")
-  void flox_executor_set_queue_model(FloxExecutorHandle executor, int32_t model,
-                                     uint32_t depth);
+  void flox_simulated_executor_set_queue_model(FloxSimulatedExecutorHandle executor, int32_t model,
+                                               uint32_t depth);
 
   // Feed a trade with quantity (enables queue-fill simulation for limit orders).
   FLOX_EXPORT(group = "backtest_slippage")
-  void flox_executor_on_trade_qty(FloxExecutorHandle executor, uint32_t symbol,
-                                  double price, double quantity, uint8_t is_buy);
+  void flox_simulated_executor_on_trade_qty(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                            double price, double quantity, uint8_t is_buy);
 
   // Feed a top-of-book snapshot (both best bid and best ask in one call).
   // For multi-level updates, build a BookUpdate on the C++ side; the C API
   // intentionally does not expose a stateful per-side helper because that
   // makes it too easy to accidentally clear the opposite side.
   FLOX_EXPORT(group = "backtest_slippage")
-  void flox_executor_on_best_levels(FloxExecutorHandle executor, uint32_t symbol,
-                                    double bid_price, double bid_qty, double ask_price,
-                                    double ask_qty);
+  void flox_simulated_executor_on_best_levels(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                              double bid_price, double bid_qty, double ask_price,
+                                              double ask_qty);
 
   // Feed a full L2 snapshot with parallel bid/ask arrays.
   FLOX_EXPORT(group = "backtest_slippage")
-  void flox_executor_on_book_snapshot(FloxExecutorHandle executor, uint32_t symbol,
-                                      const double* bid_prices, const double* bid_qtys,
-                                      uint32_t n_bids, const double* ask_prices,
-                                      const double* ask_qtys, uint32_t n_asks);
+  void flox_simulated_executor_on_book_snapshot(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                                const double* bid_prices, const double* bid_qtys,
+                                                uint32_t n_bids, const double* ask_prices,
+                                                const double* ask_qtys, uint32_t n_asks);
 
   // BacktestResult handle: aggregates fills into trades + stats + equity curve.
   typedef void* FloxBacktestResultHandle;
@@ -984,7 +984,7 @@ extern "C"
   // Drain all fills from a SimulatedExecutor into a BacktestResult in FIFO order.
   FLOX_EXPORT(group = "backtest_slippage")
   void flox_backtest_result_ingest_executor(FloxBacktestResultHandle result,
-                                            FloxExecutorHandle executor);
+                                            FloxSimulatedExecutorHandle executor);
 
   typedef struct
   {
@@ -1712,6 +1712,162 @@ extern "C"
   uint8_t flox_replay_source_seek_to(FloxReplaySourceHandle source, int64_t timestamp_ns);
 
   // ============================================================
+  // ExecutionListener — observe order lifecycle events.
+  //
+  // Bindings register callbacks that fire as orders move through the
+  // execution path: submitted → accepted → (partially) filled / canceled
+  // / rejected / expired / replaced. Used as a backtest observer (the
+  // SimulatedExecutor inside BacktestRunner emits these events) or to
+  // surface live-broker fills back into binding code.
+  //
+  // The order pointer is read-only and valid only for the duration of
+  // the callback; copy the fields you need to retain.
+  // Any callback may be NULL (no-op).
+  // ============================================================
+
+  // ABI-stable order snapshot, mirrors flox::Order. Raw fields are
+  // fixed-point int64 (Price * 1e8, Quantity * 1e8) — matches the rest
+  // of the C API.
+  typedef struct
+  {
+    uint64_t id;
+    uint64_t client_order_id;
+    uint32_t symbol;
+    uint16_t strategy_id;
+    uint16_t order_tag;
+    uint8_t side;           // 0=BUY, 1=SELL
+    uint8_t type;           // OrderType enum (0=LIMIT, 1=MARKET, ...)
+    uint8_t time_in_force;  // TimeInForce enum
+    uint8_t flags;          // ExecutionFlags packed bits
+    int64_t price_raw;
+    int64_t quantity_raw;
+    int64_t filled_quantity_raw;
+    int64_t trigger_price_raw;
+    int64_t trailing_offset_raw;
+    int64_t created_at_ns;
+    int64_t exchange_ts_ns;
+  } FloxOrder;
+
+  typedef void (*FloxExecListenerOnOrderFn)(void* user_data, const FloxOrder* order);
+  typedef void (*FloxExecListenerOnPartialFillFn)(void* user_data,
+                                                  const FloxOrder* order,
+                                                  int64_t fill_quantity_raw);
+  typedef void (*FloxExecListenerOnRejectedFn)(void* user_data,
+                                               const FloxOrder* order,
+                                               const char* reason);
+  typedef void (*FloxExecListenerOnReplacedFn)(void* user_data,
+                                               const FloxOrder* old_order,
+                                               const FloxOrder* new_order);
+  typedef void (*FloxExecListenerOnTrailingUpdateFn)(void* user_data,
+                                                     const FloxOrder* order,
+                                                     int64_t new_trigger_price_raw);
+
+  typedef struct
+  {
+    FloxExecListenerOnOrderFn on_submitted;
+    FloxExecListenerOnOrderFn on_accepted;
+    FloxExecListenerOnPartialFillFn on_partially_filled;
+    FloxExecListenerOnOrderFn on_filled;
+    FloxExecListenerOnOrderFn on_pending_cancel;
+    FloxExecListenerOnOrderFn on_canceled;
+    FloxExecListenerOnOrderFn on_expired;
+    FloxExecListenerOnRejectedFn on_rejected;
+    FloxExecListenerOnReplacedFn on_replaced;
+    FloxExecListenerOnOrderFn on_pending_trigger;
+    FloxExecListenerOnOrderFn on_triggered;
+    FloxExecListenerOnTrailingUpdateFn on_trailing_stop_updated;
+    void* user_data;
+  } FloxExecutionListenerCallbacks;
+
+  typedef void* FloxExecutionListenerHandle;
+
+  FLOX_EXPORT(group = "execution")
+  FloxExecutionListenerHandle
+  flox_execution_listener_create(FloxExecutionListenerCallbacks callbacks);
+  FLOX_EXPORT(group = "execution")
+  void flox_execution_listener_destroy(FloxExecutionListenerHandle listener);
+
+  // Attaching listeners to BacktestRunner is declared with the rest of
+  // the BacktestRunner API below (after FloxBacktestRunnerHandle).
+
+  // ============================================================
+  // Executor — binding-supplied IOrderExecutor.
+  //
+  // Bindings provide an executor that places, cancels, replaces and
+  // OCO-submits orders on a real broker (or on a custom simulator). The
+  // engine routes every signal through this executor instead of the
+  // built-in SimulatedExecutor when one is attached.
+  //
+  // The concrete in-process SimulatedExecutor is exposed separately as
+  // flox_simulated_executor_*.
+  //
+  // The order pointer is read-only and valid only for the duration of
+  // the callback; copy fields you need to retain. Any callback may be
+  // NULL (no-op).
+  // ============================================================
+
+  // Mirror of flox::ExchangeCapabilities. Bindings fill this in their
+  // capabilities() callback so the engine knows which order types,
+  // time-in-force values and execution flags the venue supports.
+  typedef struct
+  {
+    uint8_t supports_stop_market;
+    uint8_t supports_stop_limit;
+    uint8_t supports_take_profit_market;
+    uint8_t supports_take_profit_limit;
+    uint8_t supports_trailing_stop;
+    uint8_t supports_iceberg;
+    uint8_t supports_oco;
+    uint8_t supports_gtc;
+    uint8_t supports_ioc;
+    uint8_t supports_fok;
+    uint8_t supports_gtd;
+    uint8_t supports_post_only;
+    uint8_t supports_reduce_only;
+    uint8_t supports_close_position;
+    uint8_t _pad[2];
+  } FloxExchangeCapabilities;
+
+  typedef void (*FloxExecutorSubmitFn)(void* user_data, const FloxOrder* order);
+  typedef void (*FloxExecutorCancelFn)(void* user_data, uint64_t order_id);
+  typedef void (*FloxExecutorCancelAllFn)(void* user_data, uint32_t symbol);
+  typedef void (*FloxExecutorReplaceFn)(void* user_data,
+                                        uint64_t old_order_id,
+                                        const FloxOrder* new_order);
+  typedef void (*FloxExecutorSubmitOCOFn)(void* user_data,
+                                          const FloxOrder* order1,
+                                          const FloxOrder* order2);
+  typedef void (*FloxExecutorCapabilitiesFn)(void* user_data,
+                                             FloxExchangeCapabilities* caps_out);
+  typedef void (*FloxExecutorLifecycleFn)(void* user_data);
+
+  typedef struct
+  {
+    FloxExecutorSubmitFn submit;
+    FloxExecutorCancelFn cancel;
+    FloxExecutorCancelAllFn cancel_all;
+    FloxExecutorReplaceFn replace;
+    FloxExecutorSubmitOCOFn submit_oco;
+    FloxExecutorCapabilitiesFn capabilities;
+    FloxExecutorLifecycleFn on_start;
+    FloxExecutorLifecycleFn on_stop;
+    void* user_data;
+  } FloxExecutorCallbacks;
+
+  typedef void* FloxExecutorHandle;
+
+  FLOX_EXPORT(group = "execution")
+  FloxExecutorHandle flox_executor_create(FloxExecutorCallbacks callbacks);
+  FLOX_EXPORT(group = "execution")
+  void flox_executor_destroy(FloxExecutorHandle executor);
+
+  // Query the executor's reported capabilities. Forwards to the binding's
+  // capabilities() callback. caps_out is zeroed if no callback registered.
+  FLOX_EXPORT(group = "execution")
+  void flox_executor_get_capabilities(FloxExecutorHandle executor,
+                                      FloxExchangeCapabilities* caps_out);
+
+  // ============================================================
   // FloxLiveEngine — Disruptor-based live trading engine.
   //
   // Uses real EventBus (SPSC ring buffer / Disruptor) internally.
@@ -1778,6 +1934,15 @@ extern "C"
   FLOX_EXPORT(group = "recorder")
   void flox_live_engine_set_market_data_recorder(FloxLiveEngineHandle engine,
                                                  FloxMarketDataRecorderHandle recorder);
+
+  // Attach (or detach with NULL) a binding-supplied executor. When set,
+  // emitted signals are forwarded to the executor (submit / cancel /
+  // replace / cancel_all / submit_oco) instead of relying on the user's
+  // on_signal callback to route the order to a broker. on_start /
+  // on_stop fire balanced against engine start/stop.
+  FLOX_EXPORT(group = "execution")
+  void flox_live_engine_set_executor(FloxLiveEngineHandle engine,
+                                     FloxExecutorHandle executor);
 
   FLOX_EXPORT(group = "floxliveengine_disruptor")
   void flox_live_engine_start(FloxLiveEngineHandle engine);
@@ -1879,6 +2044,15 @@ extern "C"
   FLOX_EXPORT(group = "recorder")
   void flox_runner_set_market_data_recorder(FloxRunnerHandle runner,
                                             FloxMarketDataRecorderHandle recorder);
+
+  // Attach (or detach with NULL) a binding-supplied executor. When set,
+  // emitted signals are forwarded to the executor (submit / cancel /
+  // replace / cancel_all / submit_oco) in addition to the user's
+  // on_signal callback. on_start / on_stop fire balanced against runner
+  // start/stop.
+  FLOX_EXPORT(group = "execution")
+  void flox_runner_set_executor(FloxRunnerHandle runner,
+                                FloxExecutorHandle executor);
 
   FLOX_EXPORT(group = "strategyrunner_synchronous")
   void flox_runner_start(FloxRunnerHandle runner);
@@ -1986,6 +2160,23 @@ extern "C"
   int flox_backtest_runner_run_replay_source(FloxBacktestRunnerHandle runner,
                                              FloxReplaySourceHandle source,
                                              FloxBacktestStats* stats_out);
+
+  // Attach a binding-side execution listener to the runner. Multiple
+  // listeners may be attached; each one fires for every order event
+  // emitted by the SimulatedExecutor. Caller retains ownership.
+  FLOX_EXPORT(group = "execution")
+  void flox_backtest_runner_add_execution_listener(FloxBacktestRunnerHandle runner,
+                                                   FloxExecutionListenerHandle listener);
+
+  // Attach (or detach with NULL) a binding-supplied executor. When set,
+  // emitted signals are routed to the executor instead of the built-in
+  // SimulatedExecutor. The simulator stays in the runner so backtest
+  // result accounting still works against simulator fills; if you want
+  // the binding's executor to drive PnL accounting, surface fills via
+  // a separate ExecutionListener path.
+  FLOX_EXPORT(group = "execution")
+  void flox_backtest_runner_set_executor(FloxBacktestRunnerHandle runner,
+                                         FloxExecutorHandle executor);
 
 #ifdef __cplusplus
 }

--- a/mcp/flox_mcp/data/c-api.snapshot
+++ b/mcp/flox_mcp/data/c-api.snapshot
@@ -10,16 +10,18 @@ flox_aggregate_volume_bars|uint32_t|const int64_t *|const double *|const double 
 flox_backtest_result_create|FloxBacktestResultHandle|double|double|uint8_t|double|double|double
 flox_backtest_result_destroy|void|FloxBacktestResultHandle
 flox_backtest_result_equity_curve|uint32_t|FloxBacktestResultHandle|FloxEquityPoint *|uint32_t
-flox_backtest_result_ingest_executor|void|FloxBacktestResultHandle|FloxExecutorHandle
+flox_backtest_result_ingest_executor|void|FloxBacktestResultHandle|FloxSimulatedExecutorHandle
 flox_backtest_result_record_fill|void|FloxBacktestResultHandle|uint64_t|uint32_t|uint8_t|double|double|int64_t
 flox_backtest_result_stats|void|FloxBacktestResultHandle|FloxBacktestStats *
 flox_backtest_result_write_equity_curve_csv|uint8_t|FloxBacktestResultHandle|const char *
+flox_backtest_runner_add_execution_listener|void|FloxBacktestRunnerHandle|FloxExecutionListenerHandle
 flox_backtest_runner_create|FloxBacktestRunnerHandle|FloxRegistryHandle|double|double
 flox_backtest_runner_destroy|void|FloxBacktestRunnerHandle
 flox_backtest_runner_run_bars|int|FloxBacktestRunnerHandle|const int64_t *|const int64_t *|const double *|const double *|const double *|const double *|const double *|uint32_t|const char *|uint8_t|uint64_t|FloxBacktestStats *
 flox_backtest_runner_run_csv|int|FloxBacktestRunnerHandle|const char *|const char *|FloxBacktestStats *
 flox_backtest_runner_run_ohlcv|int|FloxBacktestRunnerHandle|const int64_t *|const double *|uint32_t|const char *|FloxBacktestStats *
 flox_backtest_runner_run_replay_source|int|FloxBacktestRunnerHandle|FloxReplaySourceHandle|FloxBacktestStats *
+flox_backtest_runner_set_executor|void|FloxBacktestRunnerHandle|FloxExecutorHandle
 flox_backtest_runner_set_strategy|void|FloxBacktestRunnerHandle|FloxStrategyHandle
 flox_best_ask_raw|int64_t|FloxStrategyHandle|uint32_t
 flox_best_bid_raw|int64_t|FloxStrategyHandle|uint32_t
@@ -92,22 +94,11 @@ flox_emit_take_profit_limit|uint64_t|FloxStrategyHandle|uint32_t|uint8_t|int64_t
 flox_emit_take_profit_market|uint64_t|FloxStrategyHandle|uint32_t|uint8_t|int64_t|int64_t
 flox_emit_trailing_stop|uint64_t|FloxStrategyHandle|uint32_t|uint8_t|int64_t|int64_t
 flox_emit_trailing_stop_percent|uint64_t|FloxStrategyHandle|uint32_t|uint8_t|int32_t|int64_t
-flox_executor_advance_clock|void|FloxExecutorHandle|int64_t
-flox_executor_cancel_all|void|FloxExecutorHandle|uint32_t
-flox_executor_cancel_order|void|FloxExecutorHandle|uint64_t
-flox_executor_create|FloxExecutorHandle
+flox_execution_listener_create|FloxExecutionListenerHandle|FloxExecutionListenerCallbacks
+flox_execution_listener_destroy|void|FloxExecutionListenerHandle
+flox_executor_create|FloxExecutorHandle|FloxExecutorCallbacks
 flox_executor_destroy|void|FloxExecutorHandle
-flox_executor_fill_count|uint32_t|FloxExecutorHandle
-flox_executor_get_fills|uint32_t|FloxExecutorHandle|FloxFill *|uint32_t
-flox_executor_on_bar|void|FloxExecutorHandle|uint32_t|double
-flox_executor_on_best_levels|void|FloxExecutorHandle|uint32_t|double|double|double|double
-flox_executor_on_book_snapshot|void|FloxExecutorHandle|uint32_t|const double *|const double *|uint32_t|const double *|const double *|uint32_t
-flox_executor_on_trade|void|FloxExecutorHandle|uint32_t|double|uint8_t
-flox_executor_on_trade_qty|void|FloxExecutorHandle|uint32_t|double|double|uint8_t
-flox_executor_set_default_slippage|void|FloxExecutorHandle|int32_t|int32_t|double|double|double
-flox_executor_set_queue_model|void|FloxExecutorHandle|int32_t|uint32_t
-flox_executor_set_symbol_slippage|void|FloxExecutorHandle|uint32_t|int32_t|int32_t|double|double|double
-flox_executor_submit_order|void|FloxExecutorHandle|uint64_t|uint8_t|double|double|uint8_t|uint32_t
+flox_executor_get_capabilities|void|FloxExecutorHandle|FloxExchangeCapabilities *
 flox_footprint_add_trade|void|FloxFootprintHandle|double|double|uint8_t
 flox_footprint_clear|void|FloxFootprintHandle
 flox_footprint_create|FloxFootprintHandle|double
@@ -179,6 +170,7 @@ flox_live_engine_destroy|void|FloxLiveEngineHandle
 flox_live_engine_publish_bar|void|FloxLiveEngineHandle|uint32_t|uint8_t|uint64_t|double|double|double|double|double|double|int64_t|int64_t|uint8_t
 flox_live_engine_publish_book_snapshot|void|FloxLiveEngineHandle|uint32_t|const double *|const double *|uint32_t|const double *|const double *|uint32_t|int64_t
 flox_live_engine_publish_trade|void|FloxLiveEngineHandle|uint32_t|double|double|uint8_t|int64_t
+flox_live_engine_set_executor|void|FloxLiveEngineHandle|FloxExecutorHandle
 flox_live_engine_set_kill_switch|void|FloxLiveEngineHandle|FloxKillSwitchHandle
 flox_live_engine_set_market_data_recorder|void|FloxLiveEngineHandle|FloxMarketDataRecorderHandle
 flox_live_engine_set_order_validator|void|FloxLiveEngineHandle|FloxOrderValidatorHandle
@@ -262,6 +254,7 @@ flox_runner_destroy|void|FloxRunnerHandle
 flox_runner_on_bar|void|FloxRunnerHandle|uint32_t|uint8_t|uint64_t|double|double|double|double|double|double|int64_t|int64_t|uint8_t
 flox_runner_on_book_snapshot|void|FloxRunnerHandle|uint32_t|const double *|const double *|uint32_t|const double *|const double *|uint32_t|int64_t
 flox_runner_on_trade|void|FloxRunnerHandle|uint32_t|double|double|uint8_t|int64_t
+flox_runner_set_executor|void|FloxRunnerHandle|FloxExecutorHandle
 flox_runner_set_kill_switch|void|FloxRunnerHandle|FloxKillSwitchHandle
 flox_runner_set_market_data_recorder|void|FloxRunnerHandle|FloxMarketDataRecorderHandle
 flox_runner_set_order_validator|void|FloxRunnerHandle|FloxOrderValidatorHandle
@@ -286,6 +279,22 @@ flox_segment_validate|uint8_t|const char *
 flox_segment_validate_full|FloxSegmentValidation|const char *|uint8_t|uint8_t
 flox_segment_validate_full_p|void|const char *|uint8_t|uint8_t|void *
 flox_set_log_callback|void|FloxLogCallback|void *
+flox_simulated_executor_advance_clock|void|FloxSimulatedExecutorHandle|int64_t
+flox_simulated_executor_cancel_all|void|FloxSimulatedExecutorHandle|uint32_t
+flox_simulated_executor_cancel_order|void|FloxSimulatedExecutorHandle|uint64_t
+flox_simulated_executor_create|FloxSimulatedExecutorHandle
+flox_simulated_executor_destroy|void|FloxSimulatedExecutorHandle
+flox_simulated_executor_fill_count|uint32_t|FloxSimulatedExecutorHandle
+flox_simulated_executor_get_fills|uint32_t|FloxSimulatedExecutorHandle|FloxFill *|uint32_t
+flox_simulated_executor_on_bar|void|FloxSimulatedExecutorHandle|uint32_t|double
+flox_simulated_executor_on_best_levels|void|FloxSimulatedExecutorHandle|uint32_t|double|double|double|double
+flox_simulated_executor_on_book_snapshot|void|FloxSimulatedExecutorHandle|uint32_t|const double *|const double *|uint32_t|const double *|const double *|uint32_t
+flox_simulated_executor_on_trade|void|FloxSimulatedExecutorHandle|uint32_t|double|uint8_t
+flox_simulated_executor_on_trade_qty|void|FloxSimulatedExecutorHandle|uint32_t|double|double|uint8_t
+flox_simulated_executor_set_default_slippage|void|FloxSimulatedExecutorHandle|int32_t|int32_t|double|double|double
+flox_simulated_executor_set_queue_model|void|FloxSimulatedExecutorHandle|int32_t|uint32_t
+flox_simulated_executor_set_symbol_slippage|void|FloxSimulatedExecutorHandle|uint32_t|int32_t|int32_t|double|double|double
+flox_simulated_executor_submit_order|void|FloxSimulatedExecutorHandle|uint64_t|uint8_t|double|double|uint8_t|uint32_t
 flox_stat_bootstrap_ci|void|const double *|size_t|double|uint32_t|double *|double *|double *
 flox_stat_correlation|double|const double *|const double *|size_t
 flox_stat_permutation_test|double|const double *|size_t|const double *|size_t|uint32_t

--- a/node/src/backtest.h
+++ b/node/src/backtest.h
@@ -25,15 +25,15 @@ class SimulatedExecutorWrap : public Napi::ObjectWrap<SimulatedExecutorWrap>
   }
 
   SimulatedExecutorWrap(const Napi::CallbackInfo& info)
-      : Napi::ObjectWrap<SimulatedExecutorWrap>(info), _h(flox_executor_create()) {}
+      : Napi::ObjectWrap<SimulatedExecutorWrap>(info), _h(flox_simulated_executor_create()) {}
   ~SimulatedExecutorWrap()
   {
     if (_h)
     {
-      flox_executor_destroy(_h);
+      flox_simulated_executor_destroy(_h);
     }
   }
-  FloxExecutorHandle handle() const { return _h; }
+  FloxSimulatedExecutorHandle handle() const { return _h; }
 
  private:
   void SubmitOrder(const Napi::CallbackInfo& info)
@@ -50,13 +50,13 @@ class SimulatedExecutorWrap : public Napi::ObjectWrap<SimulatedExecutorWrap>
     {
       t = 1;
     }
-    flox_executor_submit_order(_h, id, s, price, qty, t, sym);
+    flox_simulated_executor_submit_order(_h, id, s, price, qty, t, sym);
   }
-  void CancelOrder(const Napi::CallbackInfo& info) { flox_executor_cancel_order(_h, info[0].As<Napi::Number>().Int64Value()); }
-  void CancelAll(const Napi::CallbackInfo& info) { flox_executor_cancel_all(_h, info[0].As<Napi::Number>().Uint32Value()); }
-  void OnBar(const Napi::CallbackInfo& info) { flox_executor_on_bar(_h, info[0].As<Napi::Number>().Uint32Value(), info[1].As<Napi::Number>().DoubleValue()); }
-  void OnTrade(const Napi::CallbackInfo& info) { flox_executor_on_trade(_h, info[0].As<Napi::Number>().Uint32Value(), info[1].As<Napi::Number>().DoubleValue(), info[2].As<Napi::Boolean>().Value() ? 1 : 0); }
-  void AdvanceClock(const Napi::CallbackInfo& info) { flox_executor_advance_clock(_h, info[0].As<Napi::Number>().Int64Value()); }
+  void CancelOrder(const Napi::CallbackInfo& info) { flox_simulated_executor_cancel_order(_h, info[0].As<Napi::Number>().Int64Value()); }
+  void CancelAll(const Napi::CallbackInfo& info) { flox_simulated_executor_cancel_all(_h, info[0].As<Napi::Number>().Uint32Value()); }
+  void OnBar(const Napi::CallbackInfo& info) { flox_simulated_executor_on_bar(_h, info[0].As<Napi::Number>().Uint32Value(), info[1].As<Napi::Number>().DoubleValue()); }
+  void OnTrade(const Napi::CallbackInfo& info) { flox_simulated_executor_on_trade(_h, info[0].As<Napi::Number>().Uint32Value(), info[1].As<Napi::Number>().DoubleValue(), info[2].As<Napi::Boolean>().Value() ? 1 : 0); }
+  void AdvanceClock(const Napi::CallbackInfo& info) { flox_simulated_executor_advance_clock(_h, info[0].As<Napi::Number>().Int64Value()); }
   void SetDefaultSlippage(const Napi::CallbackInfo& info)
   {
     std::string model = info[0].As<Napi::String>().Utf8Value();
@@ -77,7 +77,7 @@ class SimulatedExecutorWrap : public Napi::ObjectWrap<SimulatedExecutorWrap>
     double tickSize = info.Length() > 2 ? info[2].As<Napi::Number>().DoubleValue() : 0.0;
     double bps = info.Length() > 3 ? info[3].As<Napi::Number>().DoubleValue() : 0.0;
     double impact = info.Length() > 4 ? info[4].As<Napi::Number>().DoubleValue() : 0.0;
-    flox_executor_set_default_slippage(_h, m, ticks, tickSize, bps, impact);
+    flox_simulated_executor_set_default_slippage(_h, m, ticks, tickSize, bps, impact);
   }
   void SetQueueModel(const Napi::CallbackInfo& info)
   {
@@ -92,10 +92,10 @@ class SimulatedExecutorWrap : public Napi::ObjectWrap<SimulatedExecutorWrap>
       m = 2;
     }
     uint32_t depth = info.Length() > 1 ? info[1].As<Napi::Number>().Uint32Value() : 1;
-    flox_executor_set_queue_model(_h, m, depth);
+    flox_simulated_executor_set_queue_model(_h, m, depth);
   }
-  Napi::Value FillCount(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), flox_executor_fill_count(_h)); }
-  FloxExecutorHandle _h;
+  Napi::Value FillCount(const Napi::CallbackInfo& info) { return Napi::Number::New(info.Env(), flox_simulated_executor_fill_count(_h)); }
+  FloxSimulatedExecutorHandle _h;
 };
 
 class BacktestResultWrap : public Napi::ObjectWrap<BacktestResultWrap>

--- a/src/backtest/backtest_runner.cpp
+++ b/src/backtest/backtest_runner.cpp
@@ -453,6 +453,11 @@ void BacktestRunner::onSignal(const Signal& signal)
   ++_signalCount;
   _signalEmitted = true;
 
+  // Route to custom executor if attached, else to the built-in simulator.
+  IOrderExecutor& exec = (_customExecutor != nullptr)
+                             ? *_customExecutor
+                             : static_cast<IOrderExecutor&>(_executor);
+
   switch (signal.type)
   {
     case SignalType::Market:
@@ -462,18 +467,18 @@ void BacktestRunner::onSignal(const Signal& signal)
     case SignalType::TakeProfitMarket:
     case SignalType::TakeProfitLimit:
     case SignalType::TrailingStop:
-      _executor.submitOrder(signalToOrder(signal));
+      exec.submitOrder(signalToOrder(signal));
       break;
     case SignalType::Cancel:
-      _executor.cancelOrder(signal.orderId);
+      exec.cancelOrder(signal.orderId);
       break;
     case SignalType::CancelAll:
-      _executor.cancelAllOrders(signal.symbol);
+      exec.cancelAllOrders(signal.symbol);
       break;
     case SignalType::Modify:
     {
       Order newOrder{.id = _nextOrderId++, .price = signal.newPrice, .quantity = signal.newQuantity};
-      _executor.replaceOrder(signal.orderId, newOrder);
+      exec.replaceOrder(signal.orderId, newOrder);
       break;
     }
     case SignalType::OCO:
@@ -493,7 +498,7 @@ void BacktestRunner::onSignal(const Signal& signal)
                    .flags = {.reduceOnly = signal.reduceOnly, .postOnly = signal.postOnly}};
 
       OCOParams params{.order1 = order1, .order2 = order2};
-      _executor.submitOCO(params);
+      exec.submitOCO(params);
       break;
     }
   }

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -72,6 +72,10 @@
 #include "flox/book/events/book_update_event.h"
 #include "flox/book/events/trade_event.h"
 #include "flox/book/l3/l3_order_book.h"
+#include "flox/execution/abstract_execution_listener.h"
+#include "flox/execution/abstract_executor.h"
+#include "flox/execution/exchange_capabilities.h"
+#include "flox/execution/order.h"
 #include "flox/execution/order_tracker.h"
 #include "flox/position/position_group.h"
 #include "flox/position/position_tracker.h"
@@ -1030,27 +1034,27 @@ void flox_book_clear(FloxBookHandle h)
 // Simulated executor
 // ============================================================
 
-struct FloxExecutorImpl
+struct FloxSimulatedExecutorImpl
 {
   SimulatedClock clock;
   SimulatedExecutor executor;
-  FloxExecutorImpl() : executor(clock) {}
+  FloxSimulatedExecutorImpl() : executor(clock) {}
 };
 
-FloxExecutorHandle flox_executor_create(void)
+FloxSimulatedExecutorHandle flox_simulated_executor_create(void)
 {
-  return new FloxExecutorImpl();
+  return new FloxSimulatedExecutorImpl();
 }
 
-void flox_executor_destroy(FloxExecutorHandle executor)
+void flox_simulated_executor_destroy(FloxSimulatedExecutorHandle executor)
 {
-  delete static_cast<FloxExecutorImpl*>(executor);
+  delete static_cast<FloxSimulatedExecutorImpl*>(executor);
 }
 
-void flox_executor_submit_order(FloxExecutorHandle h, uint64_t id, uint8_t side, double price,
-                                double quantity, uint8_t order_type, uint32_t symbol)
+void flox_simulated_executor_submit_order(FloxSimulatedExecutorHandle h, uint64_t id, uint8_t side, double price,
+                                          double quantity, uint8_t order_type, uint32_t symbol)
 {
-  auto* impl = static_cast<FloxExecutorImpl*>(h);
+  auto* impl = static_cast<FloxSimulatedExecutorImpl*>(h);
   Order order{};
   order.id = id;
   order.side = side == 0 ? Side::BUY : Side::SELL;
@@ -1061,35 +1065,35 @@ void flox_executor_submit_order(FloxExecutorHandle h, uint64_t id, uint8_t side,
   impl->executor.submitOrder(order);
 }
 
-void flox_executor_cancel_order(FloxExecutorHandle h, uint64_t order_id)
+void flox_simulated_executor_cancel_order(FloxSimulatedExecutorHandle h, uint64_t order_id)
 {
-  static_cast<FloxExecutorImpl*>(h)->executor.cancelOrder(order_id);
+  static_cast<FloxSimulatedExecutorImpl*>(h)->executor.cancelOrder(order_id);
 }
 
-void flox_executor_cancel_all(FloxExecutorHandle h, uint32_t symbol)
+void flox_simulated_executor_cancel_all(FloxSimulatedExecutorHandle h, uint32_t symbol)
 {
-  static_cast<FloxExecutorImpl*>(h)->executor.cancelAllOrders(symbol);
+  static_cast<FloxSimulatedExecutorImpl*>(h)->executor.cancelAllOrders(symbol);
 }
 
-void flox_executor_on_bar(FloxExecutorHandle h, uint32_t symbol, double close_price)
+void flox_simulated_executor_on_bar(FloxSimulatedExecutorHandle h, uint32_t symbol, double close_price)
 {
-  static_cast<FloxExecutorImpl*>(h)->executor.onBar(symbol, Price::fromDouble(close_price));
+  static_cast<FloxSimulatedExecutorImpl*>(h)->executor.onBar(symbol, Price::fromDouble(close_price));
 }
 
-void flox_executor_on_trade(FloxExecutorHandle h, uint32_t symbol, double price, uint8_t is_buy)
+void flox_simulated_executor_on_trade(FloxSimulatedExecutorHandle h, uint32_t symbol, double price, uint8_t is_buy)
 {
-  static_cast<FloxExecutorImpl*>(h)->executor.onTrade(symbol, Price::fromDouble(price),
-                                                      is_buy != 0);
+  static_cast<FloxSimulatedExecutorImpl*>(h)->executor.onTrade(symbol, Price::fromDouble(price),
+                                                               is_buy != 0);
 }
 
-void flox_executor_advance_clock(FloxExecutorHandle h, int64_t timestamp_ns)
+void flox_simulated_executor_advance_clock(FloxSimulatedExecutorHandle h, int64_t timestamp_ns)
 {
-  static_cast<FloxExecutorImpl*>(h)->clock.advanceTo(timestamp_ns);
+  static_cast<FloxSimulatedExecutorImpl*>(h)->clock.advanceTo(timestamp_ns);
 }
 
-uint32_t flox_executor_fill_count(FloxExecutorHandle h)
+uint32_t flox_simulated_executor_fill_count(FloxSimulatedExecutorHandle h)
 {
-  return static_cast<uint32_t>(static_cast<FloxExecutorImpl*>(h)->executor.fills().size());
+  return static_cast<uint32_t>(static_cast<FloxSimulatedExecutorImpl*>(h)->executor.fills().size());
 }
 
 // ============================================================
@@ -1633,9 +1637,9 @@ void flox_composite_book_check_staleness(FloxCompositeBookHandle h, int64_t now_
 // Executor fill access
 // ============================================================
 
-uint32_t flox_executor_get_fills(FloxExecutorHandle h, FloxFill* fills_out, uint32_t max_fills)
+uint32_t flox_simulated_executor_get_fills(FloxSimulatedExecutorHandle h, FloxFill* fills_out, uint32_t max_fills)
 {
-  auto& fills = static_cast<FloxExecutorImpl*>(h)->executor.fills();
+  auto& fills = static_cast<FloxSimulatedExecutorImpl*>(h)->executor.fills();
   uint32_t count = static_cast<uint32_t>(std::min(fills.size(), static_cast<size_t>(max_fills)));
   for (uint32_t i = 0; i < count; i++)
   {
@@ -1951,49 +1955,49 @@ SlippageProfile makeSlippageProfile(int32_t model, int32_t ticks, double tick_si
 }
 }  // namespace
 
-void flox_executor_set_default_slippage(FloxExecutorHandle h, int32_t model, int32_t ticks,
-                                        double tick_size, double bps, double impact_coeff)
+void flox_simulated_executor_set_default_slippage(FloxSimulatedExecutorHandle h, int32_t model, int32_t ticks,
+                                                  double tick_size, double bps, double impact_coeff)
 {
-  static_cast<FloxExecutorImpl*>(h)->executor.setDefaultSlippage(
+  static_cast<FloxSimulatedExecutorImpl*>(h)->executor.setDefaultSlippage(
       makeSlippageProfile(model, ticks, tick_size, bps, impact_coeff));
 }
 
-void flox_executor_set_symbol_slippage(FloxExecutorHandle h, uint32_t symbol, int32_t model,
-                                       int32_t ticks, double tick_size, double bps,
-                                       double impact_coeff)
+void flox_simulated_executor_set_symbol_slippage(FloxSimulatedExecutorHandle h, uint32_t symbol, int32_t model,
+                                                 int32_t ticks, double tick_size, double bps,
+                                                 double impact_coeff)
 {
-  static_cast<FloxExecutorImpl*>(h)->executor.setSymbolSlippage(
+  static_cast<FloxSimulatedExecutorImpl*>(h)->executor.setSymbolSlippage(
       symbol, makeSlippageProfile(model, ticks, tick_size, bps, impact_coeff));
 }
 
-void flox_executor_set_queue_model(FloxExecutorHandle h, int32_t model, uint32_t depth)
+void flox_simulated_executor_set_queue_model(FloxSimulatedExecutorHandle h, int32_t model, uint32_t depth)
 {
-  static_cast<FloxExecutorImpl*>(h)->executor.setQueueModel(
+  static_cast<FloxSimulatedExecutorImpl*>(h)->executor.setQueueModel(
       static_cast<QueueModel>(model), depth);
 }
 
-void flox_executor_on_trade_qty(FloxExecutorHandle h, uint32_t symbol, double price,
-                                double quantity, uint8_t is_buy)
+void flox_simulated_executor_on_trade_qty(FloxSimulatedExecutorHandle h, uint32_t symbol, double price,
+                                          double quantity, uint8_t is_buy)
 {
-  static_cast<FloxExecutorImpl*>(h)->executor.onTrade(
+  static_cast<FloxSimulatedExecutorImpl*>(h)->executor.onTrade(
       symbol, Price::fromDouble(price), Quantity::fromDouble(quantity), is_buy != 0);
 }
 
-void flox_executor_on_best_levels(FloxExecutorHandle h, uint32_t symbol, double bid_price,
-                                  double bid_qty, double ask_price, double ask_qty)
+void flox_simulated_executor_on_best_levels(FloxSimulatedExecutorHandle h, uint32_t symbol, double bid_price,
+                                            double bid_qty, double ask_price, double ask_qty)
 {
   std::pmr::monotonic_buffer_resource pool(512);
   std::pmr::vector<BookLevel> bids(&pool);
   std::pmr::vector<BookLevel> asks(&pool);
   bids.emplace_back(Price::fromDouble(bid_price), Quantity::fromDouble(bid_qty));
   asks.emplace_back(Price::fromDouble(ask_price), Quantity::fromDouble(ask_qty));
-  static_cast<FloxExecutorImpl*>(h)->executor.onBookUpdate(symbol, bids, asks);
+  static_cast<FloxSimulatedExecutorImpl*>(h)->executor.onBookUpdate(symbol, bids, asks);
 }
 
-void flox_executor_on_book_snapshot(FloxExecutorHandle h, uint32_t symbol,
-                                    const double* bid_prices, const double* bid_qtys,
-                                    uint32_t n_bids, const double* ask_prices,
-                                    const double* ask_qtys, uint32_t n_asks)
+void flox_simulated_executor_on_book_snapshot(FloxSimulatedExecutorHandle h, uint32_t symbol,
+                                              const double* bid_prices, const double* bid_qtys,
+                                              uint32_t n_bids, const double* ask_prices,
+                                              const double* ask_qtys, uint32_t n_asks)
 {
   std::pmr::monotonic_buffer_resource pool(1024);
   std::pmr::vector<BookLevel> bids(&pool);
@@ -2008,7 +2012,7 @@ void flox_executor_on_book_snapshot(FloxExecutorHandle h, uint32_t symbol,
   {
     asks.emplace_back(Price::fromDouble(ask_prices[i]), Quantity::fromDouble(ask_qtys[i]));
   }
-  static_cast<FloxExecutorImpl*>(h)->executor.onBookUpdate(symbol, bids, asks);
+  static_cast<FloxSimulatedExecutorImpl*>(h)->executor.onBookUpdate(symbol, bids, asks);
 }
 
 struct FloxBacktestResultImpl
@@ -2054,10 +2058,10 @@ void flox_backtest_result_record_fill(FloxBacktestResultHandle h, uint64_t order
   static_cast<FloxBacktestResultImpl*>(h)->result->recordFill(fill);
 }
 
-void flox_backtest_result_ingest_executor(FloxBacktestResultHandle h, FloxExecutorHandle eh)
+void flox_backtest_result_ingest_executor(FloxBacktestResultHandle h, FloxSimulatedExecutorHandle eh)
 {
   auto* impl = static_cast<FloxBacktestResultImpl*>(h);
-  for (const auto& fill : static_cast<FloxExecutorImpl*>(eh)->executor.fills())
+  for (const auto& fill : static_cast<FloxSimulatedExecutorImpl*>(eh)->executor.fills())
   {
     impl->result->recordFill(fill);
   }
@@ -2844,6 +2848,283 @@ struct FloxReplaySourceImpl
   FloxReplaySourceCallbacks cb;
 };
 
+// Pack a flox::Order into the ABI-stable FloxOrder for binding callbacks.
+inline FloxOrder packOrder(const flox::Order& o) noexcept
+{
+  FloxOrder fo{};
+  fo.id = o.id;
+  fo.client_order_id = o.clientOrderId;
+  fo.symbol = o.symbol;
+  fo.strategy_id = o.strategyId;
+  fo.order_tag = o.orderTag;
+  fo.side = (o.side == flox::Side::BUY) ? 0u : 1u;
+  fo.type = static_cast<uint8_t>(o.type);
+  fo.time_in_force = static_cast<uint8_t>(o.timeInForce);
+  // Pack ExecutionFlags bit-by-bit for ABI stability.
+  uint8_t flags = 0;
+  flags |= (o.flags.reduceOnly ? 0x01 : 0);
+  flags |= (o.flags.closePosition ? 0x02 : 0);
+  flags |= (o.flags.postOnly ? 0x04 : 0);
+  flags |= static_cast<uint8_t>((o.flags.holdSide & 0x03) << 3);
+  fo.flags = flags;
+  fo.price_raw = o.price.raw();
+  fo.quantity_raw = o.quantity.raw();
+  fo.filled_quantity_raw = o.filledQuantity.raw();
+  fo.trigger_price_raw = o.triggerPrice.raw();
+  fo.trailing_offset_raw = o.trailingOffset.raw();
+  fo.created_at_ns = o.createdAt.time_since_epoch().count();
+  fo.exchange_ts_ns = o.exchangeTimestamp.has_value()
+                          ? o.exchangeTimestamp->time_since_epoch().count()
+                          : 0;
+  return fo;
+}
+
+struct FloxExecutionListenerImpl
+{
+  FloxExecutionListenerCallbacks cb;
+};
+
+// Adapter that exposes a binding's FloxExecutionListenerCallbacks as a
+// flox::IOrderExecutionListener — pluggable into BacktestRunner.
+class CapiExecutionListener : public flox::IOrderExecutionListener
+{
+ public:
+  CapiExecutionListener(flox::SubscriberId id, FloxExecutionListenerImpl* impl)
+      : flox::IOrderExecutionListener(id), _impl(impl)
+  {
+  }
+
+  void onOrderSubmitted(const flox::Order& o) override
+  {
+    if (_impl && _impl->cb.on_submitted)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.on_submitted(_impl->cb.user_data, &fo);
+    }
+  }
+  void onOrderAccepted(const flox::Order& o) override
+  {
+    if (_impl && _impl->cb.on_accepted)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.on_accepted(_impl->cb.user_data, &fo);
+    }
+  }
+  void onOrderPartiallyFilled(const flox::Order& o, flox::Quantity q) override
+  {
+    if (_impl && _impl->cb.on_partially_filled)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.on_partially_filled(_impl->cb.user_data, &fo, q.raw());
+    }
+  }
+  void onOrderFilled(const flox::Order& o) override
+  {
+    if (_impl && _impl->cb.on_filled)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.on_filled(_impl->cb.user_data, &fo);
+    }
+  }
+  void onOrderPendingCancel(const flox::Order& o) override
+  {
+    if (_impl && _impl->cb.on_pending_cancel)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.on_pending_cancel(_impl->cb.user_data, &fo);
+    }
+  }
+  void onOrderCanceled(const flox::Order& o) override
+  {
+    if (_impl && _impl->cb.on_canceled)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.on_canceled(_impl->cb.user_data, &fo);
+    }
+  }
+  void onOrderExpired(const flox::Order& o) override
+  {
+    if (_impl && _impl->cb.on_expired)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.on_expired(_impl->cb.user_data, &fo);
+    }
+  }
+  void onOrderRejected(const flox::Order& o, const std::string& reason) override
+  {
+    if (_impl && _impl->cb.on_rejected)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.on_rejected(_impl->cb.user_data, &fo, reason.c_str());
+    }
+  }
+  void onOrderReplaced(const flox::Order& oldOrder, const flox::Order& newOrder) override
+  {
+    if (_impl && _impl->cb.on_replaced)
+    {
+      auto fo_old = packOrder(oldOrder);
+      auto fo_new = packOrder(newOrder);
+      _impl->cb.on_replaced(_impl->cb.user_data, &fo_old, &fo_new);
+    }
+  }
+  void onOrderPendingTrigger(const flox::Order& o) override
+  {
+    if (_impl && _impl->cb.on_pending_trigger)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.on_pending_trigger(_impl->cb.user_data, &fo);
+    }
+  }
+  void onOrderTriggered(const flox::Order& o) override
+  {
+    if (_impl && _impl->cb.on_triggered)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.on_triggered(_impl->cb.user_data, &fo);
+    }
+  }
+  void onTrailingStopUpdated(const flox::Order& o, flox::Price newTrigger) override
+  {
+    if (_impl && _impl->cb.on_trailing_stop_updated)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.on_trailing_stop_updated(_impl->cb.user_data, &fo, newTrigger.raw());
+    }
+  }
+
+ private:
+  FloxExecutionListenerImpl* _impl;
+};
+
+// Unpack an ABI-stable FloxOrder back into a flox::Order. Used by the
+// CapiExecutor adapter when reconstructing orders for the binding's
+// submit / replace / OCO callbacks (engine-side already constructs an
+// Order from a Signal; we round-trip it through FloxOrder for the C ABI).
+inline flox::Order unpackOrder(const FloxOrder& fo) noexcept
+{
+  flox::Order o{};
+  o.id = fo.id;
+  o.clientOrderId = fo.client_order_id;
+  o.symbol = fo.symbol;
+  o.strategyId = fo.strategy_id;
+  o.orderTag = fo.order_tag;
+  o.side = (fo.side == 0) ? flox::Side::BUY : flox::Side::SELL;
+  o.type = static_cast<flox::OrderType>(fo.type);
+  o.timeInForce = static_cast<flox::TimeInForce>(fo.time_in_force);
+  o.flags.reduceOnly = (fo.flags & 0x01) ? 1 : 0;
+  o.flags.closePosition = (fo.flags & 0x02) ? 1 : 0;
+  o.flags.postOnly = (fo.flags & 0x04) ? 1 : 0;
+  o.flags.holdSide = static_cast<uint8_t>((fo.flags >> 3) & 0x03);
+  o.price = flox::Price::fromRaw(fo.price_raw);
+  o.quantity = flox::Quantity::fromRaw(fo.quantity_raw);
+  o.filledQuantity = flox::Quantity::fromRaw(fo.filled_quantity_raw);
+  o.triggerPrice = flox::Price::fromRaw(fo.trigger_price_raw);
+  o.trailingOffset = flox::Price::fromRaw(fo.trailing_offset_raw);
+  o.createdAt = flox::TimePoint{std::chrono::nanoseconds{fo.created_at_ns}};
+  if (fo.exchange_ts_ns != 0)
+  {
+    o.exchangeTimestamp = flox::TimePoint{std::chrono::nanoseconds{fo.exchange_ts_ns}};
+  }
+  return o;
+}
+
+struct FloxExecutorImpl
+{
+  FloxExecutorCallbacks cb;
+};
+
+// Adapter that exposes a binding's FloxExecutorCallbacks as a
+// flox::IOrderExecutor — pluggable into BacktestRunner via setExecutor()
+// and into FloxLiveEngineImpl's executor slot.
+class CapiExecutor : public flox::IOrderExecutor
+{
+ public:
+  explicit CapiExecutor(FloxExecutorImpl* impl) : _impl(impl) {}
+
+  void start() override
+  {
+    if (_impl && _impl->cb.on_start)
+    {
+      _impl->cb.on_start(_impl->cb.user_data);
+    }
+  }
+  void stop() override
+  {
+    if (_impl && _impl->cb.on_stop)
+    {
+      _impl->cb.on_stop(_impl->cb.user_data);
+    }
+  }
+
+  void submitOrder(const flox::Order& o) override
+  {
+    if (_impl && _impl->cb.submit)
+    {
+      auto fo = packOrder(o);
+      _impl->cb.submit(_impl->cb.user_data, &fo);
+    }
+  }
+  void cancelOrder(flox::OrderId orderId) override
+  {
+    if (_impl && _impl->cb.cancel)
+    {
+      _impl->cb.cancel(_impl->cb.user_data, static_cast<uint64_t>(orderId));
+    }
+  }
+  void cancelAllOrders(flox::SymbolId symbol) override
+  {
+    if (_impl && _impl->cb.cancel_all)
+    {
+      _impl->cb.cancel_all(_impl->cb.user_data, static_cast<uint32_t>(symbol));
+    }
+  }
+  void replaceOrder(flox::OrderId oldId, const flox::Order& newOrder) override
+  {
+    if (_impl && _impl->cb.replace)
+    {
+      auto fo = packOrder(newOrder);
+      _impl->cb.replace(_impl->cb.user_data, static_cast<uint64_t>(oldId), &fo);
+    }
+  }
+  void submitOCO(const flox::OCOParams& params) override
+  {
+    if (_impl && _impl->cb.submit_oco)
+    {
+      auto fo1 = packOrder(params.order1);
+      auto fo2 = packOrder(params.order2);
+      _impl->cb.submit_oco(_impl->cb.user_data, &fo1, &fo2);
+    }
+  }
+  flox::ExchangeCapabilities capabilities() const override
+  {
+    if (_impl == nullptr || _impl->cb.capabilities == nullptr)
+    {
+      return flox::ExchangeCapabilities{};
+    }
+    FloxExchangeCapabilities cc{};
+    _impl->cb.capabilities(_impl->cb.user_data, &cc);
+    flox::ExchangeCapabilities out{};
+    out.supportsStopMarket = (cc.supports_stop_market != 0);
+    out.supportsStopLimit = (cc.supports_stop_limit != 0);
+    out.supportsTakeProfitMarket = (cc.supports_take_profit_market != 0);
+    out.supportsTakeProfitLimit = (cc.supports_take_profit_limit != 0);
+    out.supportsTrailingStop = (cc.supports_trailing_stop != 0);
+    out.supportsIceberg = (cc.supports_iceberg != 0);
+    out.supportsOCO = (cc.supports_oco != 0);
+    out.supportsGTC = (cc.supports_gtc != 0);
+    out.supportsIOC = (cc.supports_ioc != 0);
+    out.supportsFOK = (cc.supports_fok != 0);
+    out.supportsGTD = (cc.supports_gtd != 0);
+    out.supportsPostOnly = (cc.supports_post_only != 0);
+    out.supportsReduceOnly = (cc.supports_reduce_only != 0);
+    out.supportsClosePosition = (cc.supports_close_position != 0);
+    return out;
+  }
+
+ private:
+  FloxExecutorImpl* _impl;
+};
+
 // Adapter that exposes a binding's FloxReplaySourceCallbacks as a
 // flox::replay::IMultiSegmentReader so BacktestRunner can drive it via
 // the existing forEach contract.
@@ -2941,6 +3222,56 @@ class CapiReplaySourceReader : public flox::replay::IMultiSegmentReader
   std::vector<flox::replay::SegmentInfo> _empty_segments;
 };
 
+// Build a FloxOrder from a Signal for the binding-side executor hook.
+// Maps SignalType → OrderType for the order types that turn into orders;
+// flow-control signals (Cancel/CancelAll/Modify/OCO) don't go through
+// this path because they call cancel/replace/submit_oco on the executor.
+inline FloxOrder signalToFloxOrder(const Signal& sig) noexcept
+{
+  FloxOrder fo{};
+  fo.id = sig.orderId;
+  fo.symbol = sig.symbol;
+  fo.side = (sig.side == Side::BUY) ? 0 : 1;
+  fo.time_in_force = static_cast<uint8_t>(sig.timeInForce);
+  uint8_t flags = 0;
+  flags |= (sig.reduceOnly ? 0x01 : 0);
+  flags |= (sig.postOnly ? 0x04 : 0);
+  fo.flags = flags;
+  fo.price_raw = sig.price.raw();
+  fo.quantity_raw = sig.quantity.raw();
+  fo.trigger_price_raw = sig.triggerPrice.raw();
+  fo.trailing_offset_raw = sig.trailingOffset.raw();
+
+  switch (sig.type)
+  {
+    case SignalType::Market:
+      fo.type = static_cast<uint8_t>(OrderType::MARKET);
+      break;
+    case SignalType::Limit:
+      fo.type = static_cast<uint8_t>(OrderType::LIMIT);
+      break;
+    case SignalType::StopMarket:
+      fo.type = static_cast<uint8_t>(OrderType::STOP_MARKET);
+      break;
+    case SignalType::StopLimit:
+      fo.type = static_cast<uint8_t>(OrderType::STOP_LIMIT);
+      break;
+    case SignalType::TakeProfitMarket:
+      fo.type = static_cast<uint8_t>(OrderType::TAKE_PROFIT_MARKET);
+      break;
+    case SignalType::TakeProfitLimit:
+      fo.type = static_cast<uint8_t>(OrderType::TAKE_PROFIT_LIMIT);
+      break;
+    case SignalType::TrailingStop:
+      fo.type = static_cast<uint8_t>(OrderType::TRAILING_STOP);
+      break;
+    default:
+      fo.type = static_cast<uint8_t>(OrderType::MARKET);
+      break;
+  }
+  return fo;
+}
+
 class RunnerSignalHandler : public ISignalHandler
 {
  public:
@@ -2967,6 +3298,10 @@ class RunnerSignalHandler : public ISignalHandler
   void setStorageSink(FloxStorageSinkImpl* s) noexcept
   {
     _sink.store(s, std::memory_order_release);
+  }
+  void setExecutor(FloxExecutorImpl* e) noexcept
+  {
+    _executor.store(e, std::memory_order_release);
   }
 
   void onSignal(const Signal& sig) override
@@ -3055,6 +3390,67 @@ class RunnerSignalHandler : public ISignalHandler
 
     _cb(_ud, &fs);
 
+    // Binding-supplied executor — alternative path for order routing.
+    // Runs after the user on_signal so existing on_signal-based wiring
+    // (where the user submits orders directly) keeps working unchanged.
+    // If a user has both an executor and on_signal-based submission, the
+    // order will be sent twice — that's the user's responsibility.
+    if (auto* exec = _executor.load(std::memory_order_acquire);
+        exec != nullptr)
+    {
+      switch (sig.type)
+      {
+        case SignalType::Market:
+        case SignalType::Limit:
+        case SignalType::StopMarket:
+        case SignalType::StopLimit:
+        case SignalType::TakeProfitMarket:
+        case SignalType::TakeProfitLimit:
+        case SignalType::TrailingStop:
+          if (exec->cb.submit != nullptr)
+          {
+            FloxOrder fo = signalToFloxOrder(sig);
+            exec->cb.submit(exec->cb.user_data, &fo);
+          }
+          break;
+        case SignalType::Cancel:
+          if (exec->cb.cancel != nullptr)
+          {
+            exec->cb.cancel(exec->cb.user_data, sig.orderId);
+          }
+          break;
+        case SignalType::CancelAll:
+          if (exec->cb.cancel_all != nullptr)
+          {
+            exec->cb.cancel_all(exec->cb.user_data, sig.symbol);
+          }
+          break;
+        case SignalType::Modify:
+          if (exec->cb.replace != nullptr)
+          {
+            FloxOrder fo{};
+            fo.id = sig.orderId;
+            fo.symbol = sig.symbol;
+            fo.side = (sig.side == Side::BUY) ? 0 : 1;
+            fo.type = static_cast<uint8_t>(OrderType::LIMIT);
+            fo.price_raw = sig.newPrice.raw();
+            fo.quantity_raw = sig.newQuantity.raw();
+            exec->cb.replace(exec->cb.user_data, sig.orderId, &fo);
+          }
+          break;
+        case SignalType::OCO:
+          if (exec->cb.submit_oco != nullptr)
+          {
+            FloxOrder fo1 = signalToFloxOrder(sig);
+            fo1.type = static_cast<uint8_t>(OrderType::LIMIT);
+            FloxOrder fo2 = fo1;
+            fo2.price_raw = sig.triggerPrice.raw();
+            exec->cb.submit_oco(exec->cb.user_data, &fo1, &fo2);
+          }
+          break;
+      }
+    }
+
     // Post-emission observers, fired in declared order: PnL → Storage.
     // Return type is void; observers cannot drop the signal (it's already
     // been delivered). The user callback runs first so the binding's
@@ -3079,6 +3475,7 @@ class RunnerSignalHandler : public ISignalHandler
   std::atomic<FloxOrderValidatorImpl*> _validator{nullptr};
   std::atomic<FloxPnLTrackerImpl*> _pnl{nullptr};
   std::atomic<FloxStorageSinkImpl*> _sink{nullptr};
+  std::atomic<FloxExecutorImpl*> _executor{nullptr};
 };
 
 struct FloxRunnerImpl
@@ -3093,6 +3490,10 @@ struct FloxRunnerImpl
   // Tracks whether on_start has fired without a matching on_stop, so that
   // attaching mid-run or detaching emits the right lifecycle callback.
   std::atomic<bool> recorderRunning{false};
+
+  // Optional binding-supplied executor. Same lifecycle pattern as recorder.
+  std::atomic<FloxExecutorImpl*> executor{nullptr};
+  std::atomic<bool> executorRunning{false};
 
   FloxRunnerImpl(SymbolRegistry* reg, FloxOnSignalCallback cb, void* ud)
       : registry(reg), handler(cb, ud)
@@ -3113,6 +3514,27 @@ struct FloxRunnerImpl
   }
   void setPnLTracker(FloxPnLTrackerImpl* p) { handler.setPnLTracker(p); }
   void setStorageSink(FloxStorageSinkImpl* s) { handler.setStorageSink(s); }
+
+  // Attach / detach a binding-supplied executor. Lifecycle (on_start /
+  // on_stop) is balanced against runner start/stop, with hot-swap
+  // semantics so attach-while-running and detach fire the lifecycle
+  // callbacks correctly.
+  void setExecutor(FloxExecutorImpl* e)
+  {
+    auto* prev = executor.exchange(e, std::memory_order_acq_rel);
+    handler.setExecutor(e);
+    if (executorRunning.load(std::memory_order_acquire))
+    {
+      if (prev != nullptr && prev->cb.on_stop != nullptr)
+      {
+        prev->cb.on_stop(prev->cb.user_data);
+      }
+      if (e != nullptr && e->cb.on_start != nullptr)
+      {
+        e->cb.on_start(e->cb.user_data);
+      }
+    }
+  }
 
   // Attach / detach a market data recorder. If the runner is already started
   // (recorderRunning == true), fire on_stop on the outgoing recorder and
@@ -3145,10 +3567,22 @@ struct FloxRunnerImpl
     {
       r->cb.on_start(r->cb.user_data);
     }
+    executorRunning.store(true, std::memory_order_release);
+    if (auto* e = executor.load(std::memory_order_acquire);
+        e != nullptr && e->cb.on_start != nullptr)
+    {
+      e->cb.on_start(e->cb.user_data);
+    }
   }
 
   void stop()
   {
+    if (auto* e = executor.load(std::memory_order_acquire);
+        e != nullptr && e->cb.on_stop != nullptr)
+    {
+      e->cb.on_stop(e->cb.user_data);
+    }
+    executorRunning.store(false, std::memory_order_release);
     if (auto* r = recorder.load(std::memory_order_acquire);
         r != nullptr && r->cb.on_stop != nullptr)
     {
@@ -3312,6 +3746,8 @@ struct FloxLiveEngineImpl
   std::atomic<FloxStorageSinkImpl*> storageSink{nullptr};
   std::atomic<FloxMarketDataRecorderImpl*> recorder{nullptr};
   std::atomic<bool> recorderRunning{false};
+  std::atomic<FloxExecutorImpl*> executor{nullptr};
+  std::atomic<bool> executorRunning{false};
 
   explicit FloxLiveEngineImpl(SymbolRegistry* reg)
       : registry(reg),
@@ -3329,6 +3765,7 @@ struct FloxLiveEngineImpl
     h->setOrderValidator(orderValidator.load(std::memory_order_acquire));
     h->setPnLTracker(pnlTracker.load(std::memory_order_acquire));
     h->setStorageSink(storageSink.load(std::memory_order_acquire));
+    h->setExecutor(executor.load(std::memory_order_acquire));
     s->setSignalHandler(h.get());
     handlers.push_back(std::move(h));
     tradeBus->subscribe(s);
@@ -3398,6 +3835,30 @@ struct FloxLiveEngineImpl
     }
   }
 
+  // Attach / detach a binding-supplied executor. Updates every existing
+  // signal handler (each strategy has its own) and remembers the setting
+  // so subsequently-added strategies inherit it. Lifecycle balanced
+  // against engine.start()/stop().
+  void setExecutor(FloxExecutorImpl* e)
+  {
+    auto* prev = executor.exchange(e, std::memory_order_acq_rel);
+    for (auto& h : handlers)
+    {
+      h->setExecutor(e);
+    }
+    if (executorRunning.load(std::memory_order_acquire))
+    {
+      if (prev != nullptr && prev->cb.on_stop != nullptr)
+      {
+        prev->cb.on_stop(prev->cb.user_data);
+      }
+      if (e != nullptr && e->cb.on_start != nullptr)
+      {
+        e->cb.on_start(e->cb.user_data);
+      }
+    }
+  }
+
   void start()
   {
     tradeBus->start();
@@ -3413,10 +3874,22 @@ struct FloxLiveEngineImpl
     {
       r->cb.on_start(r->cb.user_data);
     }
+    executorRunning.store(true, std::memory_order_release);
+    if (auto* e = executor.load(std::memory_order_acquire);
+        e != nullptr && e->cb.on_start != nullptr)
+    {
+      e->cb.on_start(e->cb.user_data);
+    }
   }
 
   void stop()
   {
+    if (auto* e = executor.load(std::memory_order_acquire);
+        e != nullptr && e->cb.on_stop != nullptr)
+    {
+      e->cb.on_stop(e->cb.user_data);
+    }
+    executorRunning.store(false, std::memory_order_release);
     if (auto* r = recorder.load(std::memory_order_acquire);
         r != nullptr && r->cb.on_stop != nullptr)
     {
@@ -3629,6 +4102,12 @@ struct FloxBacktestRunnerImpl
 {
   SymbolRegistry* registry;
   std::unique_ptr<BacktestRunner> runner;
+  // Adapters created when bindings register execution listeners. Owned
+  // here so they outlive the listener registration on the runner.
+  std::vector<std::unique_ptr<CapiExecutionListener>> executionListenerAdapters;
+  // Adapter for the binding-supplied executor. Owned so it outlives the
+  // runner's non-owning pointer. Replaced on every set call.
+  std::unique_ptr<CapiExecutor> executorAdapter;
 
   explicit FloxBacktestRunnerImpl(SymbolRegistry* reg, double feeRate, double initialCapital)
       : registry(reg)
@@ -3638,6 +4117,30 @@ struct FloxBacktestRunnerImpl
     cfg.initialCapital = initialCapital;
     cfg.usePercentageFee = true;
     runner = std::make_unique<BacktestRunner>(cfg);
+  }
+
+  void addExecutionListener(FloxExecutionListenerImpl* impl)
+  {
+    if (impl == nullptr)
+    {
+      return;
+    }
+    auto id = static_cast<flox::SubscriberId>(executionListenerAdapters.size() + 1);
+    auto adapter = std::make_unique<CapiExecutionListener>(id, impl);
+    runner->addExecutionListener(adapter.get());
+    executionListenerAdapters.push_back(std::move(adapter));
+  }
+
+  void setExecutor(FloxExecutorImpl* impl)
+  {
+    if (impl == nullptr)
+    {
+      runner->setExecutor(nullptr);
+      executorAdapter.reset();
+      return;
+    }
+    executorAdapter = std::make_unique<CapiExecutor>(impl);
+    runner->setExecutor(executorAdapter.get());
   }
 
   void setStrategy(BridgeStrategy* bridge)
@@ -3919,6 +4422,44 @@ uint8_t flox_replay_source_seek_to(FloxReplaySourceHandle source, int64_t timest
   return s->cb.seek_to(s->cb.user_data, timestamp_ns);
 }
 
+FloxExecutionListenerHandle
+flox_execution_listener_create(FloxExecutionListenerCallbacks callbacks)
+{
+  return static_cast<FloxExecutionListenerHandle>(
+      new FloxExecutionListenerImpl{callbacks});
+}
+
+void flox_execution_listener_destroy(FloxExecutionListenerHandle listener)
+{
+  delete static_cast<FloxExecutionListenerImpl*>(listener);
+}
+
+FloxExecutorHandle flox_executor_create(FloxExecutorCallbacks callbacks)
+{
+  return static_cast<FloxExecutorHandle>(new FloxExecutorImpl{callbacks});
+}
+
+void flox_executor_destroy(FloxExecutorHandle executor)
+{
+  delete static_cast<FloxExecutorImpl*>(executor);
+}
+
+void flox_executor_get_capabilities(FloxExecutorHandle executor,
+                                    FloxExchangeCapabilities* caps_out)
+{
+  if (caps_out == nullptr)
+  {
+    return;
+  }
+  *caps_out = FloxExchangeCapabilities{};
+  auto* impl = static_cast<FloxExecutorImpl*>(executor);
+  if (impl == nullptr || impl->cb.capabilities == nullptr)
+  {
+    return;
+  }
+  impl->cb.capabilities(impl->cb.user_data, caps_out);
+}
+
 // ============================================================
 // Logger callback adapter
 // ============================================================
@@ -4014,6 +4555,12 @@ void flox_runner_set_storage_sink(FloxRunnerHandle runner, FloxStorageSinkHandle
 {
   toRunner(runner)->setStorageSink(
       static_cast<capi_impl::FloxStorageSinkImpl*>(sink));
+}
+
+void flox_runner_set_executor(FloxRunnerHandle runner, FloxExecutorHandle executor)
+{
+  toRunner(runner)->setExecutor(
+      static_cast<capi_impl::FloxExecutorImpl*>(executor));
 }
 
 void flox_runner_set_market_data_recorder(FloxRunnerHandle runner,
@@ -4125,6 +4672,13 @@ void flox_live_engine_set_market_data_recorder(FloxLiveEngineHandle engine,
 {
   toLiveEngine(engine)->setMarketDataRecorder(
       static_cast<capi_impl::FloxMarketDataRecorderImpl*>(recorder));
+}
+
+void flox_live_engine_set_executor(FloxLiveEngineHandle engine,
+                                   FloxExecutorHandle executor)
+{
+  toLiveEngine(engine)->setExecutor(
+      static_cast<capi_impl::FloxExecutorImpl*>(executor));
 }
 
 void flox_live_engine_start(FloxLiveEngineHandle engine)
@@ -4240,4 +4794,18 @@ int flox_backtest_runner_run_replay_source(FloxBacktestRunnerHandle h,
 {
   return toBacktestRunner(h)->runReplaySource(
       static_cast<capi_impl::FloxReplaySourceImpl*>(source), out);
+}
+
+void flox_backtest_runner_add_execution_listener(FloxBacktestRunnerHandle h,
+                                                 FloxExecutionListenerHandle listener)
+{
+  toBacktestRunner(h)->addExecutionListener(
+      static_cast<capi_impl::FloxExecutionListenerImpl*>(listener));
+}
+
+void flox_backtest_runner_set_executor(FloxBacktestRunnerHandle h,
+                                       FloxExecutorHandle executor)
+{
+  toBacktestRunner(h)->setExecutor(
+      static_cast<capi_impl::FloxExecutorImpl*>(executor));
 }

--- a/src/quickjs/js_bindings.cpp
+++ b/src/quickjs/js_bindings.cpp
@@ -1129,17 +1129,17 @@ static JSValue js_book_apply_delta(JSContext* ctx, JSValueConst, int, JSValueCon
 
 static JSValue js_executor_create(JSContext* ctx, JSValueConst, int, JSValueConst*)
 {
-  return createHandleObject(ctx, flox_executor_create());
+  return createHandleObject(ctx, flox_simulated_executor_create());
 }
 static JSValue js_executor_destroy(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
 {
-  flox_executor_destroy(static_cast<FloxExecutorHandle>(getHandle(ctx, argv[0])));
+  flox_simulated_executor_destroy(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])));
   return JS_UNDEFINED;
 }
 static JSValue js_executor_submit(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
 {
-  auto h = static_cast<FloxExecutorHandle>(getHandle(ctx, argv[0]));
-  flox_executor_submit_order(h, static_cast<uint64_t>(toInt64(ctx, argv[1])),
+  auto h = static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0]));
+  flox_simulated_executor_submit_order(h, static_cast<uint64_t>(toInt64(ctx, argv[1])),
                              static_cast<uint8_t>(toUint32(ctx, argv[2])),
                              toDouble(ctx, argv[3]), toDouble(ctx, argv[4]),
                              static_cast<uint8_t>(toUint32(ctx, argv[5])),
@@ -1148,34 +1148,34 @@ static JSValue js_executor_submit(JSContext* ctx, JSValueConst, int, JSValueCons
 }
 static JSValue js_executor_on_bar(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
 {
-  flox_executor_on_bar(static_cast<FloxExecutorHandle>(getHandle(ctx, argv[0])),
+  flox_simulated_executor_on_bar(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
                        toUint32(ctx, argv[1]), toDouble(ctx, argv[2]));
   return JS_UNDEFINED;
 }
 static JSValue js_executor_on_trade(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
 {
-  flox_executor_on_trade(static_cast<FloxExecutorHandle>(getHandle(ctx, argv[0])),
+  flox_simulated_executor_on_trade(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
                          toUint32(ctx, argv[1]), toDouble(ctx, argv[2]),
                          static_cast<uint8_t>(toUint32(ctx, argv[3])));
   return JS_UNDEFINED;
 }
 static JSValue js_executor_advance(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
 {
-  flox_executor_advance_clock(static_cast<FloxExecutorHandle>(getHandle(ctx, argv[0])),
+  flox_simulated_executor_advance_clock(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
                               toInt64(ctx, argv[1]));
   return JS_UNDEFINED;
 }
 static JSValue js_executor_fill_count(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
 {
   return JS_NewUint32(
-      ctx, flox_executor_fill_count(static_cast<FloxExecutorHandle>(getHandle(ctx, argv[0]))));
+      ctx, flox_simulated_executor_fill_count(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0]))));
 }
 
 static JSValue js_executor_set_default_slippage(JSContext* ctx, JSValueConst, int,
                                                 JSValueConst* argv)
 {
-  flox_executor_set_default_slippage(
-      static_cast<FloxExecutorHandle>(getHandle(ctx, argv[0])),
+  flox_simulated_executor_set_default_slippage(
+      static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
       static_cast<int32_t>(toInt64(ctx, argv[1])),
       static_cast<int32_t>(toInt64(ctx, argv[2])), toDouble(ctx, argv[3]),
       toDouble(ctx, argv[4]), toDouble(ctx, argv[5]));
@@ -1184,8 +1184,8 @@ static JSValue js_executor_set_default_slippage(JSContext* ctx, JSValueConst, in
 static JSValue js_executor_set_symbol_slippage(JSContext* ctx, JSValueConst, int,
                                                JSValueConst* argv)
 {
-  flox_executor_set_symbol_slippage(
-      static_cast<FloxExecutorHandle>(getHandle(ctx, argv[0])), toUint32(ctx, argv[1]),
+  flox_simulated_executor_set_symbol_slippage(
+      static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])), toUint32(ctx, argv[1]),
       static_cast<int32_t>(toInt64(ctx, argv[2])),
       static_cast<int32_t>(toInt64(ctx, argv[3])), toDouble(ctx, argv[4]),
       toDouble(ctx, argv[5]), toDouble(ctx, argv[6]));
@@ -1194,7 +1194,7 @@ static JSValue js_executor_set_symbol_slippage(JSContext* ctx, JSValueConst, int
 static JSValue js_executor_set_queue_model(JSContext* ctx, JSValueConst, int,
                                            JSValueConst* argv)
 {
-  flox_executor_set_queue_model(static_cast<FloxExecutorHandle>(getHandle(ctx, argv[0])),
+  flox_simulated_executor_set_queue_model(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
                                 static_cast<int32_t>(toInt64(ctx, argv[1])),
                                 toUint32(ctx, argv[2]));
   return JS_UNDEFINED;
@@ -1202,7 +1202,7 @@ static JSValue js_executor_set_queue_model(JSContext* ctx, JSValueConst, int,
 static JSValue js_executor_on_trade_qty(JSContext* ctx, JSValueConst, int,
                                         JSValueConst* argv)
 {
-  flox_executor_on_trade_qty(static_cast<FloxExecutorHandle>(getHandle(ctx, argv[0])),
+  flox_simulated_executor_on_trade_qty(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
                              toUint32(ctx, argv[1]), toDouble(ctx, argv[2]),
                              toDouble(ctx, argv[3]),
                              static_cast<uint8_t>(toUint32(ctx, argv[4])));
@@ -1211,7 +1211,7 @@ static JSValue js_executor_on_trade_qty(JSContext* ctx, JSValueConst, int,
 static JSValue js_executor_on_best_levels(JSContext* ctx, JSValueConst, int,
                                           JSValueConst* argv)
 {
-  flox_executor_on_best_levels(static_cast<FloxExecutorHandle>(getHandle(ctx, argv[0])),
+  flox_simulated_executor_on_best_levels(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
                                toUint32(ctx, argv[1]), toDouble(ctx, argv[2]),
                                toDouble(ctx, argv[3]), toDouble(ctx, argv[4]),
                                toDouble(ctx, argv[5]));
@@ -1249,7 +1249,7 @@ static JSValue js_backtest_result_ingest(JSContext* ctx, JSValueConst, int,
 {
   flox_backtest_result_ingest_executor(
       static_cast<FloxBacktestResultHandle>(getHandle(ctx, argv[0])),
-      static_cast<FloxExecutorHandle>(getHandle(ctx, argv[1])));
+      static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[1])));
   return JS_UNDEFINED;
 }
 static JSValue js_backtest_result_stats(JSContext* ctx, JSValueConst, int,
@@ -2747,20 +2747,20 @@ void registerFloxBindings(JSContext* ctx)
   addGlobalFunc(ctx, "__flox_book_is_crossed", js_book_is_crossed, 1);
 
   // Executor
-  addGlobalFunc(ctx, "__flox_executor_create", js_executor_create, 0);
-  addGlobalFunc(ctx, "__flox_executor_destroy", js_executor_destroy, 1);
-  addGlobalFunc(ctx, "__flox_executor_submit", js_executor_submit, 7);
-  addGlobalFunc(ctx, "__flox_executor_on_bar", js_executor_on_bar, 3);
-  addGlobalFunc(ctx, "__flox_executor_on_trade", js_executor_on_trade, 4);
-  addGlobalFunc(ctx, "__flox_executor_advance_clock", js_executor_advance, 2);
-  addGlobalFunc(ctx, "__flox_executor_fill_count", js_executor_fill_count, 1);
-  addGlobalFunc(ctx, "__flox_executor_set_default_slippage",
+  addGlobalFunc(ctx, "__flox_simulated_executor_create", js_executor_create, 0);
+  addGlobalFunc(ctx, "__flox_simulated_executor_destroy", js_executor_destroy, 1);
+  addGlobalFunc(ctx, "__flox_simulated_executor_submit", js_executor_submit, 7);
+  addGlobalFunc(ctx, "__flox_simulated_executor_on_bar", js_executor_on_bar, 3);
+  addGlobalFunc(ctx, "__flox_simulated_executor_on_trade", js_executor_on_trade, 4);
+  addGlobalFunc(ctx, "__flox_simulated_executor_advance_clock", js_executor_advance, 2);
+  addGlobalFunc(ctx, "__flox_simulated_executor_fill_count", js_executor_fill_count, 1);
+  addGlobalFunc(ctx, "__flox_simulated_executor_set_default_slippage",
                 js_executor_set_default_slippage, 6);
-  addGlobalFunc(ctx, "__flox_executor_set_symbol_slippage",
+  addGlobalFunc(ctx, "__flox_simulated_executor_set_symbol_slippage",
                 js_executor_set_symbol_slippage, 7);
-  addGlobalFunc(ctx, "__flox_executor_set_queue_model", js_executor_set_queue_model, 3);
-  addGlobalFunc(ctx, "__flox_executor_on_trade_qty", js_executor_on_trade_qty, 5);
-  addGlobalFunc(ctx, "__flox_executor_on_best_levels", js_executor_on_best_levels, 6);
+  addGlobalFunc(ctx, "__flox_simulated_executor_set_queue_model", js_executor_set_queue_model, 3);
+  addGlobalFunc(ctx, "__flox_simulated_executor_on_trade_qty", js_executor_on_trade_qty, 5);
+  addGlobalFunc(ctx, "__flox_simulated_executor_on_best_levels", js_executor_on_best_levels, 6);
 
   // Backtest result
   addGlobalFunc(ctx, "__flox_backtest_result_create", js_backtest_result_create, 6);

--- a/src/quickjs/js_bindings.cpp
+++ b/src/quickjs/js_bindings.cpp
@@ -1140,29 +1140,29 @@ static JSValue js_executor_submit(JSContext* ctx, JSValueConst, int, JSValueCons
 {
   auto h = static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0]));
   flox_simulated_executor_submit_order(h, static_cast<uint64_t>(toInt64(ctx, argv[1])),
-                             static_cast<uint8_t>(toUint32(ctx, argv[2])),
-                             toDouble(ctx, argv[3]), toDouble(ctx, argv[4]),
-                             static_cast<uint8_t>(toUint32(ctx, argv[5])),
-                             toUint32(ctx, argv[6]));
+                                       static_cast<uint8_t>(toUint32(ctx, argv[2])),
+                                       toDouble(ctx, argv[3]), toDouble(ctx, argv[4]),
+                                       static_cast<uint8_t>(toUint32(ctx, argv[5])),
+                                       toUint32(ctx, argv[6]));
   return JS_UNDEFINED;
 }
 static JSValue js_executor_on_bar(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
 {
   flox_simulated_executor_on_bar(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
-                       toUint32(ctx, argv[1]), toDouble(ctx, argv[2]));
+                                 toUint32(ctx, argv[1]), toDouble(ctx, argv[2]));
   return JS_UNDEFINED;
 }
 static JSValue js_executor_on_trade(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
 {
   flox_simulated_executor_on_trade(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
-                         toUint32(ctx, argv[1]), toDouble(ctx, argv[2]),
-                         static_cast<uint8_t>(toUint32(ctx, argv[3])));
+                                   toUint32(ctx, argv[1]), toDouble(ctx, argv[2]),
+                                   static_cast<uint8_t>(toUint32(ctx, argv[3])));
   return JS_UNDEFINED;
 }
 static JSValue js_executor_advance(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
 {
   flox_simulated_executor_advance_clock(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
-                              toInt64(ctx, argv[1]));
+                                        toInt64(ctx, argv[1]));
   return JS_UNDEFINED;
 }
 static JSValue js_executor_fill_count(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
@@ -1195,26 +1195,26 @@ static JSValue js_executor_set_queue_model(JSContext* ctx, JSValueConst, int,
                                            JSValueConst* argv)
 {
   flox_simulated_executor_set_queue_model(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
-                                static_cast<int32_t>(toInt64(ctx, argv[1])),
-                                toUint32(ctx, argv[2]));
+                                          static_cast<int32_t>(toInt64(ctx, argv[1])),
+                                          toUint32(ctx, argv[2]));
   return JS_UNDEFINED;
 }
 static JSValue js_executor_on_trade_qty(JSContext* ctx, JSValueConst, int,
                                         JSValueConst* argv)
 {
   flox_simulated_executor_on_trade_qty(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
-                             toUint32(ctx, argv[1]), toDouble(ctx, argv[2]),
-                             toDouble(ctx, argv[3]),
-                             static_cast<uint8_t>(toUint32(ctx, argv[4])));
+                                       toUint32(ctx, argv[1]), toDouble(ctx, argv[2]),
+                                       toDouble(ctx, argv[3]),
+                                       static_cast<uint8_t>(toUint32(ctx, argv[4])));
   return JS_UNDEFINED;
 }
 static JSValue js_executor_on_best_levels(JSContext* ctx, JSValueConst, int,
                                           JSValueConst* argv)
 {
   flox_simulated_executor_on_best_levels(static_cast<FloxSimulatedExecutorHandle>(getHandle(ctx, argv[0])),
-                               toUint32(ctx, argv[1]), toDouble(ctx, argv[2]),
-                               toDouble(ctx, argv[3]), toDouble(ctx, argv[4]),
-                               toDouble(ctx, argv[5]));
+                                         toUint32(ctx, argv[1]), toDouble(ctx, argv[2]),
+                                         toDouble(ctx, argv[3]), toDouble(ctx, argv[4]),
+                                         toDouble(ctx, argv[5]));
   return JS_UNDEFINED;
 }
 

--- a/src/quickjs/js_strategy.cpp
+++ b/src/quickjs/js_strategy.cpp
@@ -94,37 +94,37 @@ void FloxJsStrategy::loadStdlib()
     const _queueMap = { none: 0, tob: 1, full: 2 };
 
     class SimulatedExecutor {
-      constructor() { this._h = __flox_executor_create(); }
-      destroy() { __flox_executor_destroy(this._h); }
+      constructor() { this._h = __flox_simulated_executor_create(); }
+      destroy() { __flox_simulated_executor_destroy(this._h); }
       submitOrder(id, side, price, qty, type, symbol) {
         // JS convention: type 0 = market (default), 1 = limit.
         // C API convention: LIMIT=0, MARKET=1.
         var cType = (type === 1) ? 0 : 1;
-        __flox_executor_submit(this._h, id, side === "buy" ? 0 : 1, price, qty, cType, symbol || 1);
+        __flox_simulated_executor_submit(this._h, id, side === "buy" ? 0 : 1, price, qty, cType, symbol || 1);
       }
-      onBar(symbol, closePrice) { __flox_executor_on_bar(this._h, symbol, closePrice); }
-      onTrade(symbol, price, isBuy) { __flox_executor_on_trade(this._h, symbol, price, isBuy ? 1 : 0); }
+      onBar(symbol, closePrice) { __flox_simulated_executor_on_bar(this._h, symbol, closePrice); }
+      onTrade(symbol, price, isBuy) { __flox_simulated_executor_on_trade(this._h, symbol, price, isBuy ? 1 : 0); }
       onTradeQty(symbol, price, quantity, isBuy) {
-        __flox_executor_on_trade_qty(this._h, symbol, price, quantity, isBuy ? 1 : 0);
+        __flox_simulated_executor_on_trade_qty(this._h, symbol, price, quantity, isBuy ? 1 : 0);
       }
       onBestLevels(symbol, bidPrice, bidQty, askPrice, askQty) {
-        __flox_executor_on_best_levels(this._h, symbol, bidPrice, bidQty, askPrice, askQty);
+        __flox_simulated_executor_on_best_levels(this._h, symbol, bidPrice, bidQty, askPrice, askQty);
       }
-      advanceClock(timestampNs) { __flox_executor_advance_clock(this._h, timestampNs); }
+      advanceClock(timestampNs) { __flox_simulated_executor_advance_clock(this._h, timestampNs); }
       setDefaultSlippage(model, ticks, tickSize, bps, impactCoeff) {
-        __flox_executor_set_default_slippage(this._h, _slippageMap[model] || 0,
+        __flox_simulated_executor_set_default_slippage(this._h, _slippageMap[model] || 0,
                                              ticks || 0, tickSize || 0,
                                              bps || 0, impactCoeff || 0);
       }
       setSymbolSlippage(symbol, model, ticks, tickSize, bps, impactCoeff) {
-        __flox_executor_set_symbol_slippage(this._h, symbol, _slippageMap[model] || 0,
+        __flox_simulated_executor_set_symbol_slippage(this._h, symbol, _slippageMap[model] || 0,
                                             ticks || 0, tickSize || 0,
                                             bps || 0, impactCoeff || 0);
       }
       setQueueModel(model, depth) {
-        __flox_executor_set_queue_model(this._h, _queueMap[model] || 0, depth || 1);
+        __flox_simulated_executor_set_queue_model(this._h, _queueMap[model] || 0, depth || 1);
       }
-      get fillCount() { return __flox_executor_fill_count(this._h); }
+      get fillCount() { return __flox_simulated_executor_fill_count(this._h); }
       get handle() { return this._h; }
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,10 @@ if(FLOX_ENABLE_CAPI)
   target_link_libraries(test_capi_market_data_recorder PRIVATE flox_capi)
   add_flox_test(test_capi_replay_source)
   target_link_libraries(test_capi_replay_source PRIVATE flox_capi)
+  add_flox_test(test_capi_execution_listener)
+  target_link_libraries(test_capi_execution_listener PRIVATE flox_capi)
+  add_flox_test(test_capi_executor)
+  target_link_libraries(test_capi_executor PRIVATE flox_capi)
   # test_capi_logger needs to share a single ILogger global with flox_capi.
   # If we use add_flox_test, the test exe links the static `flox` library
   # alongside flox_capi.dylib (which itself statically embeds `flox`) —

--- a/tests/test_capi_backtest.cpp
+++ b/tests/test_capi_backtest.cpp
@@ -16,29 +16,29 @@
 
 TEST(CapiBacktest, SlippageFixedBps)
 {
-  auto exec = flox_executor_create();
-  flox_executor_set_default_slippage(exec, FLOX_SLIPPAGE_FIXED_BPS, 0, 0.0, 100.0, 0.0);
-  flox_executor_on_best_levels(exec, 1, 100.0, 10.0, 100.0, 10.0);
-  flox_executor_submit_order(exec, /*id=*/1, /*side=buy=*/0, 0.0, 1.0, /*type=market=*/1, 1);
-  ASSERT_EQ(flox_executor_fill_count(exec), 1u);
-  flox_executor_destroy(exec);
+  auto exec = flox_simulated_executor_create();
+  flox_simulated_executor_set_default_slippage(exec, FLOX_SLIPPAGE_FIXED_BPS, 0, 0.0, 100.0, 0.0);
+  flox_simulated_executor_on_best_levels(exec, 1, 100.0, 10.0, 100.0, 10.0);
+  flox_simulated_executor_submit_order(exec, /*id=*/1, /*side=buy=*/0, 0.0, 1.0, /*type=market=*/1, 1);
+  ASSERT_EQ(flox_simulated_executor_fill_count(exec), 1u);
+  flox_simulated_executor_destroy(exec);
 }
 
 TEST(CapiBacktest, QueueFillOnTradeAhead)
 {
-  auto exec = flox_executor_create();
-  flox_executor_set_queue_model(exec, FLOX_QUEUE_TOB, 1);
+  auto exec = flox_simulated_executor_create();
+  flox_simulated_executor_set_queue_model(exec, FLOX_QUEUE_TOB, 1);
 
   // Best ask at 101, no bids. Buy limit at 99 sits behind everyone else's
   // bid-side queue of size 0 (fresh level), waiting for a sell print at 99.
-  flox_executor_on_best_levels(exec, 1, 99.0, 0.0, 101.0, 5.0);
+  flox_simulated_executor_on_best_levels(exec, 1, 99.0, 0.0, 101.0, 5.0);
 
-  flox_executor_submit_order(exec, 42, /*buy=*/0, 99.0, 2.0, /*type=limit=*/0, 1);
-  EXPECT_EQ(flox_executor_fill_count(exec), 0u);
+  flox_simulated_executor_submit_order(exec, 42, /*buy=*/0, 99.0, 2.0, /*type=limit=*/0, 1);
+  EXPECT_EQ(flox_simulated_executor_fill_count(exec), 0u);
 
-  flox_executor_on_trade_qty(exec, 1, 99.0, 2.0, /*is_buy=*/0);
-  EXPECT_EQ(flox_executor_fill_count(exec), 1u);
-  flox_executor_destroy(exec);
+  flox_simulated_executor_on_trade_qty(exec, 1, 99.0, 2.0, /*is_buy=*/0);
+  EXPECT_EQ(flox_simulated_executor_fill_count(exec), 1u);
+  flox_simulated_executor_destroy(exec);
 }
 
 TEST(CapiBacktest, ResultStatsAndEquityCurve)

--- a/tests/test_capi_execution_listener.cpp
+++ b/tests/test_capi_execution_listener.cpp
@@ -1,0 +1,296 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+// Tests for the ExecutionListener hook (T023). A binding-supplied
+// listener observes order lifecycle events from BacktestRunner's
+// SimulatedExecutor — fills, cancels, rejects, etc.
+
+#include "flox/capi/flox_capi.h"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+struct State
+{
+  std::atomic<int> submitted{0};
+  std::atomic<int> accepted{0};
+  std::atomic<int> partially_filled{0};
+  std::atomic<int> filled{0};
+  std::atomic<int> pending_cancel{0};
+  std::atomic<int> canceled{0};
+  std::atomic<int> expired{0};
+  std::atomic<int> rejected{0};
+  std::atomic<int> replaced{0};
+  std::atomic<int> pending_trigger{0};
+  std::atomic<int> triggered{0};
+  std::atomic<int> trailing_updated{0};
+
+  // Last seen order on filled — for sanity of payload packing.
+  uint64_t last_filled_id{0};
+  uint32_t last_filled_symbol{0};
+  uint8_t last_filled_side{0};
+  int64_t last_filled_price_raw{0};
+  int64_t last_filled_qty_raw{0};
+
+  // Last reason text from rejection.
+  std::string last_reject_reason;
+};
+
+void on_submitted(void* ud, const FloxOrder*) { static_cast<State*>(ud)->submitted++; }
+void on_accepted(void* ud, const FloxOrder*) { static_cast<State*>(ud)->accepted++; }
+void on_partial(void* ud, const FloxOrder*, int64_t)
+{
+  static_cast<State*>(ud)->partially_filled++;
+}
+void on_filled(void* ud, const FloxOrder* o)
+{
+  auto* s = static_cast<State*>(ud);
+  s->filled++;
+  s->last_filled_id = o->id;
+  s->last_filled_symbol = o->symbol;
+  s->last_filled_side = o->side;
+  s->last_filled_price_raw = o->price_raw;
+  s->last_filled_qty_raw = o->quantity_raw;
+}
+void on_pending_cancel(void* ud, const FloxOrder*) { static_cast<State*>(ud)->pending_cancel++; }
+void on_canceled(void* ud, const FloxOrder*) { static_cast<State*>(ud)->canceled++; }
+void on_expired(void* ud, const FloxOrder*) { static_cast<State*>(ud)->expired++; }
+void on_rejected(void* ud, const FloxOrder*, const char* reason)
+{
+  auto* s = static_cast<State*>(ud);
+  s->rejected++;
+  if (reason != nullptr)
+  {
+    s->last_reject_reason = reason;
+  }
+}
+void on_replaced(void* ud, const FloxOrder*, const FloxOrder*)
+{
+  static_cast<State*>(ud)->replaced++;
+}
+void on_pending_trigger(void* ud, const FloxOrder*) { static_cast<State*>(ud)->pending_trigger++; }
+void on_triggered(void* ud, const FloxOrder*) { static_cast<State*>(ud)->triggered++; }
+void on_trailing_updated(void* ud, const FloxOrder*, int64_t)
+{
+  static_cast<State*>(ud)->trailing_updated++;
+}
+
+FloxExecutionListenerCallbacks make_cb(State& s)
+{
+  FloxExecutionListenerCallbacks cb{};
+  cb.on_submitted = on_submitted;
+  cb.on_accepted = on_accepted;
+  cb.on_partially_filled = on_partial;
+  cb.on_filled = on_filled;
+  cb.on_pending_cancel = on_pending_cancel;
+  cb.on_canceled = on_canceled;
+  cb.on_expired = on_expired;
+  cb.on_rejected = on_rejected;
+  cb.on_replaced = on_replaced;
+  cb.on_pending_trigger = on_pending_trigger;
+  cb.on_triggered = on_triggered;
+  cb.on_trailing_stop_updated = on_trailing_updated;
+  cb.user_data = &s;
+  return cb;
+}
+
+}  // namespace
+
+TEST(CapiExecutionListener, CreateAndDestroy)
+{
+  State s;
+  auto* listener = flox_execution_listener_create(make_cb(s));
+  EXPECT_NE(listener, nullptr);
+  flox_execution_listener_destroy(listener);
+}
+
+TEST(CapiExecutionListener, ReceivesFillsFromBacktestRunner)
+{
+  // Drive a market-buy strategy through a single-bar OHLCV backtest;
+  // SimulatedExecutor fills the order at bar close and emits on_filled.
+  State s;
+  auto* listener = flox_execution_listener_create(make_cb(s));
+
+  auto* registry = flox_registry_create();
+  uint32_t sym = flox_registry_add_symbol(registry, "test", "BTC", 0.01);
+
+  auto* btr = flox_backtest_runner_create(registry, /*fee=*/0.0,
+                                          /*initial_capital=*/10000.0);
+  flox_backtest_runner_add_execution_listener(btr, listener);
+
+  // Strategy that fires a single market buy on the first trade.
+  static std::atomic<bool> fired{false};
+  fired.store(false);
+  struct StratState
+  {
+    FloxStrategyHandle h;
+    uint32_t sym;
+  } sst{nullptr, sym};
+
+  auto on_bar = +[](void* ud, const FloxSymbolContext* /*ctx*/, const FloxBarData* /*b*/)
+  {
+    if (fired.exchange(true))
+    {
+      return;
+    }
+    auto* st = static_cast<StratState*>(ud);
+    flox_emit_market_buy(st->h, st->sym, /*qty_raw=*/100000000LL /* = 1.0 */);
+  };
+
+  FloxStrategyCallbacks scb{};
+  scb.on_bar = on_bar;
+  scb.user_data = &sst;
+  uint32_t syms[] = {sym};
+  auto* strat = flox_strategy_create(/*id=*/1, syms, 1, registry, scb);
+  sst.h = strat;
+  flox_backtest_runner_set_strategy(btr, strat);
+
+  // Three bars; market-buy fires on first, fills as bars feed the executor.
+  int64_t starts[3] = {1'000'000'000, 2'000'000'000, 3'000'000'000};
+  int64_t ends[3] = {1'999'999'999, 2'999'999'999, 3'999'999'999};
+  double opens[3] = {100.0, 101.0, 102.0};
+  double highs[3] = {101.0, 102.0, 103.0};
+  double lows[3] = {99.0, 100.5, 101.5};
+  double closes[3] = {100.5, 101.5, 102.5};
+  double volumes[3] = {10.0, 10.0, 10.0};
+
+  FloxBacktestStats stats{};
+  int rc = flox_backtest_runner_run_bars(btr, starts, ends, opens, highs, lows,
+                                         closes, volumes, 3, "BTC",
+                                         /*bar_type=*/0, /*bar_type_param=*/0,
+                                         &stats);
+  EXPECT_EQ(rc, 1);
+
+  EXPECT_GE(s.filled.load(), 1) << "market buy should fill at least once";
+  EXPECT_EQ(s.last_filled_symbol, sym);
+  EXPECT_EQ(s.last_filled_side, 0u) << "BUY → side=0";
+  EXPECT_EQ(s.last_filled_qty_raw, 100000000LL);
+
+  flox_strategy_destroy(strat);
+  flox_backtest_runner_destroy(btr);
+  flox_registry_destroy(registry);
+  flox_execution_listener_destroy(listener);
+}
+
+TEST(CapiExecutionListener, MultipleListenersAllReceiveEvents)
+{
+  // Two listeners; both should see every order event.
+  State a, b;
+  auto* la = flox_execution_listener_create(make_cb(a));
+  auto* lb = flox_execution_listener_create(make_cb(b));
+
+  auto* registry = flox_registry_create();
+  uint32_t sym = flox_registry_add_symbol(registry, "test", "BTC", 0.01);
+  auto* btr = flox_backtest_runner_create(registry, 0.0, 10000.0);
+  flox_backtest_runner_add_execution_listener(btr, la);
+  flox_backtest_runner_add_execution_listener(btr, lb);
+
+  static std::atomic<bool> fired{false};
+  fired.store(false);
+  struct St
+  {
+    FloxStrategyHandle h;
+    uint32_t sym;
+  } st{nullptr, sym};
+  auto on_bar = +[](void* ud, const FloxSymbolContext*, const FloxBarData*)
+  {
+    if (fired.exchange(true))
+    {
+      return;
+    }
+    auto* s = static_cast<St*>(ud);
+    flox_emit_market_buy(s->h, s->sym, 100000000LL);
+  };
+
+  FloxStrategyCallbacks scb{};
+  scb.on_bar = on_bar;
+  scb.user_data = &st;
+  uint32_t syms[] = {sym};
+  auto* strat = flox_strategy_create(1, syms, 1, registry, scb);
+  st.h = strat;
+  flox_backtest_runner_set_strategy(btr, strat);
+
+  int64_t starts[2] = {1'000'000'000, 2'000'000'000};
+  int64_t ends[2] = {1'999'999'999, 2'999'999'999};
+  double opens[2] = {100.0, 101.0};
+  double highs[2] = {101.0, 102.0};
+  double lows[2] = {99.0, 100.5};
+  double closes[2] = {100.5, 101.5};
+  double volumes[2] = {10.0, 10.0};
+  FloxBacktestStats stats{};
+  flox_backtest_runner_run_bars(btr, starts, ends, opens, highs, lows, closes,
+                                volumes, 2, "BTC", 0, 0, &stats);
+
+  EXPECT_EQ(a.filled.load(), b.filled.load());
+  EXPECT_GE(a.filled.load(), 1);
+
+  flox_strategy_destroy(strat);
+  flox_backtest_runner_destroy(btr);
+  flox_registry_destroy(registry);
+  flox_execution_listener_destroy(la);
+  flox_execution_listener_destroy(lb);
+}
+
+TEST(CapiExecutionListener, NullCallbacksAreNoOp)
+{
+  // Listener with all callbacks null shouldn't crash even when many
+  // events fire.
+  FloxExecutionListenerCallbacks cb{};  // all null
+  auto* listener = flox_execution_listener_create(cb);
+  ASSERT_NE(listener, nullptr);
+
+  auto* registry = flox_registry_create();
+  uint32_t sym = flox_registry_add_symbol(registry, "test", "BTC", 0.01);
+  auto* btr = flox_backtest_runner_create(registry, 0.0, 10000.0);
+  flox_backtest_runner_add_execution_listener(btr, listener);
+
+  static std::atomic<bool> fired{false};
+  fired.store(false);
+  struct St
+  {
+    FloxStrategyHandle h;
+    uint32_t sym;
+  } st{nullptr, sym};
+  auto on_bar = +[](void* ud, const FloxSymbolContext*, const FloxBarData*)
+  {
+    if (fired.exchange(true))
+    {
+      return;
+    }
+    auto* s = static_cast<St*>(ud);
+    flox_emit_market_buy(s->h, s->sym, 100000000LL);
+  };
+
+  FloxStrategyCallbacks scb{};
+  scb.on_bar = on_bar;
+  scb.user_data = &st;
+  uint32_t syms[] = {sym};
+  auto* strat = flox_strategy_create(1, syms, 1, registry, scb);
+  st.h = strat;
+  flox_backtest_runner_set_strategy(btr, strat);
+
+  int64_t starts[1] = {1'000'000'000};
+  int64_t ends[1] = {1'999'999'999};
+  double opens[1] = {100.0}, highs[1] = {101.0}, lows[1] = {99.0};
+  double closes[1] = {100.5}, volumes[1] = {10.0};
+  FloxBacktestStats stats{};
+  int rc = flox_backtest_runner_run_bars(btr, starts, ends, opens, highs, lows,
+                                         closes, volumes, 1, "BTC", 0, 0, &stats);
+  EXPECT_EQ(rc, 1);
+
+  flox_strategy_destroy(strat);
+  flox_backtest_runner_destroy(btr);
+  flox_registry_destroy(registry);
+  flox_execution_listener_destroy(listener);
+}

--- a/tests/test_capi_executor.cpp
+++ b/tests/test_capi_executor.cpp
@@ -1,0 +1,359 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+// Tests for the Executor hook (T023). A binding-supplied executor
+// receives signals (submit / cancel / replace / cancel_all / submit_oco)
+// instead of the built-in SimulatedExecutor. Lifecycle (on_start /
+// on_stop) is balanced against runner / live engine / backtest start.
+
+#include "flox/capi/flox_capi.h"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <vector>
+
+namespace
+{
+
+struct ExecState
+{
+  std::atomic<int> submit{0};
+  std::atomic<int> cancel{0};
+  std::atomic<int> cancel_all{0};
+  std::atomic<int> replace{0};
+  std::atomic<int> oco{0};
+  std::atomic<int> caps_calls{0};
+  std::atomic<int> on_start{0};
+  std::atomic<int> on_stop{0};
+
+  // Last seen payloads.
+  uint64_t last_submit_id{0};
+  uint32_t last_submit_symbol{0};
+  uint8_t last_submit_side{0};
+  uint8_t last_submit_type{0};
+  int64_t last_submit_price_raw{0};
+  int64_t last_submit_qty_raw{0};
+
+  uint64_t last_cancel_id{0};
+  uint32_t last_cancel_all_symbol{0};
+  uint64_t last_replace_old_id{0};
+};
+
+void ex_submit(void* ud, const FloxOrder* o)
+{
+  auto* s = static_cast<ExecState*>(ud);
+  s->submit++;
+  s->last_submit_id = o->id;
+  s->last_submit_symbol = o->symbol;
+  s->last_submit_side = o->side;
+  s->last_submit_type = o->type;
+  s->last_submit_price_raw = o->price_raw;
+  s->last_submit_qty_raw = o->quantity_raw;
+}
+void ex_cancel(void* ud, uint64_t id)
+{
+  auto* s = static_cast<ExecState*>(ud);
+  s->cancel++;
+  s->last_cancel_id = id;
+}
+void ex_cancel_all(void* ud, uint32_t sym)
+{
+  auto* s = static_cast<ExecState*>(ud);
+  s->cancel_all++;
+  s->last_cancel_all_symbol = sym;
+}
+void ex_replace(void* ud, uint64_t old_id, const FloxOrder*)
+{
+  auto* s = static_cast<ExecState*>(ud);
+  s->replace++;
+  s->last_replace_old_id = old_id;
+}
+void ex_oco(void* ud, const FloxOrder*, const FloxOrder*) { static_cast<ExecState*>(ud)->oco++; }
+void ex_caps(void* ud, FloxExchangeCapabilities* out)
+{
+  static_cast<ExecState*>(ud)->caps_calls++;
+  out->supports_stop_market = 1;
+  out->supports_stop_limit = 1;
+  out->supports_oco = 1;
+  out->supports_trailing_stop = 1;
+  out->supports_iceberg = 0;
+  out->supports_post_only = 1;
+  out->supports_reduce_only = 1;
+  out->supports_close_position = 0;
+  out->supports_gtc = 1;
+  out->supports_ioc = 1;
+  out->supports_fok = 0;
+  out->supports_gtd = 0;
+  out->supports_take_profit_market = 1;
+  out->supports_take_profit_limit = 1;
+}
+void ex_on_start(void* ud) { static_cast<ExecState*>(ud)->on_start++; }
+void ex_on_stop(void* ud) { static_cast<ExecState*>(ud)->on_stop++; }
+
+FloxExecutorCallbacks make_cb(ExecState& s)
+{
+  FloxExecutorCallbacks cb{};
+  cb.submit = ex_submit;
+  cb.cancel = ex_cancel;
+  cb.cancel_all = ex_cancel_all;
+  cb.replace = ex_replace;
+  cb.submit_oco = ex_oco;
+  cb.capabilities = ex_caps;
+  cb.on_start = ex_on_start;
+  cb.on_stop = ex_on_stop;
+  cb.user_data = &s;
+  return cb;
+}
+
+}  // namespace
+
+TEST(CapiExecutor, CreateDestroyCapabilities)
+{
+  ExecState s;
+  auto* exec = flox_executor_create(make_cb(s));
+  ASSERT_NE(exec, nullptr);
+
+  FloxExchangeCapabilities caps{};
+  flox_executor_get_capabilities(exec, &caps);
+  EXPECT_EQ(s.caps_calls.load(), 1);
+  EXPECT_EQ(caps.supports_stop_market, 1);
+  EXPECT_EQ(caps.supports_oco, 1);
+  EXPECT_EQ(caps.supports_iceberg, 0);
+
+  flox_executor_destroy(exec);
+}
+
+TEST(CapiExecutor, GetCapabilitiesWithNullCallbackZeroes)
+{
+  // Executor with null capabilities callback — get should zero-init out.
+  FloxExecutorCallbacks cb{};
+  cb.user_data = nullptr;
+  auto* exec = flox_executor_create(cb);
+  FloxExchangeCapabilities caps{};
+  // Pre-fill with garbage to make sure the API zeroes it.
+  caps.supports_oco = 1;
+  flox_executor_get_capabilities(exec, &caps);
+  EXPECT_EQ(caps.supports_oco, 0);
+  flox_executor_destroy(exec);
+}
+
+namespace
+{
+
+// Helper: build a runner + strategy that fires a market buy on the first
+// trade event. Used by the runner-level executor tests.
+struct RunnerCtx
+{
+  FloxRegistryHandle registry{nullptr};
+  FloxStrategyHandle strategy{nullptr};
+  FloxRunnerHandle runner{nullptr};
+  uint32_t symbol{0};
+  ~RunnerCtx()
+  {
+    if (runner)
+    {
+      flox_runner_destroy(runner);
+    }
+    if (strategy)
+    {
+      flox_strategy_destroy(strategy);
+    }
+    if (registry)
+    {
+      flox_registry_destroy(registry);
+    }
+  }
+};
+
+void noop_signal(void*, const FloxSignal*) {}
+
+void make_market_buy_runner(RunnerCtx& s)
+{
+  s.registry = flox_registry_create();
+  s.symbol = flox_registry_add_symbol(s.registry, "test", "BTC", 0.01);
+
+  static std::atomic<bool> fired{false};
+  fired.store(false);
+
+  static FloxStrategyHandle strat_capture;
+  static uint32_t sym_capture;
+  auto on_trade = +[](void* /*ud*/, const FloxSymbolContext*, const FloxTradeData*)
+  {
+    if (fired.exchange(true))
+    {
+      return;
+    }
+    flox_emit_market_buy(strat_capture, sym_capture, 100000000LL);
+  };
+
+  FloxStrategyCallbacks scb{};
+  scb.on_trade = on_trade;
+  uint32_t syms[] = {s.symbol};
+  s.strategy = flox_strategy_create(/*id=*/1, syms, 1, s.registry, scb);
+  strat_capture = s.strategy;
+  sym_capture = s.symbol;
+  s.runner = flox_runner_create(s.registry, noop_signal, nullptr);
+  flox_runner_add_strategy(s.runner, s.strategy);
+}
+
+}  // namespace
+
+TEST(CapiExecutor, RunnerForwardsMarketBuyToExecutor)
+{
+  ExecState s;
+  RunnerCtx ctx;
+  make_market_buy_runner(ctx);
+
+  auto* exec = flox_executor_create(make_cb(s));
+  flox_runner_set_executor(ctx.runner, exec);
+  flox_runner_start(ctx.runner);
+  EXPECT_EQ(s.on_start.load(), 1);
+
+  flox_runner_on_trade(ctx.runner, ctx.symbol, /*price=*/100.0, /*qty=*/1.0,
+                       /*is_buy=*/1, /*ts=*/1'000);
+
+  EXPECT_EQ(s.submit.load(), 1) << "executor should see the market buy";
+  EXPECT_EQ(s.last_submit_symbol, ctx.symbol);
+  EXPECT_EQ(s.last_submit_side, 0u) << "BUY → side=0";
+  EXPECT_EQ(s.last_submit_type, 1u) << "MARKET → type=1";
+  EXPECT_EQ(s.last_submit_qty_raw, 100000000LL);
+
+  flox_runner_stop(ctx.runner);
+  EXPECT_EQ(s.on_stop.load(), 1);
+
+  flox_executor_destroy(exec);
+}
+
+TEST(CapiExecutor, RunnerForwardsCancelAndCancelAll)
+{
+  ExecState s;
+  RunnerCtx ctx;
+  ctx.registry = flox_registry_create();
+  ctx.symbol = flox_registry_add_symbol(ctx.registry, "test", "BTC", 0.01);
+
+  FloxStrategyCallbacks scb{};
+  uint32_t syms[] = {ctx.symbol};
+  ctx.strategy = flox_strategy_create(1, syms, 1, ctx.registry, scb);
+  ctx.runner = flox_runner_create(ctx.registry, noop_signal, nullptr);
+  flox_runner_add_strategy(ctx.runner, ctx.strategy);
+
+  auto* exec = flox_executor_create(make_cb(s));
+  flox_runner_set_executor(ctx.runner, exec);
+  flox_runner_start(ctx.runner);
+
+  flox_emit_cancel(ctx.strategy, /*order_id=*/42);
+  EXPECT_EQ(s.cancel.load(), 1);
+  EXPECT_EQ(s.last_cancel_id, 42u);
+
+  flox_emit_cancel_all(ctx.strategy, ctx.symbol);
+  EXPECT_EQ(s.cancel_all.load(), 1);
+  EXPECT_EQ(s.last_cancel_all_symbol, ctx.symbol);
+
+  flox_emit_modify(ctx.strategy, /*order_id=*/7,
+                   /*new_price_raw=*/10000000000LL, /*new_qty_raw=*/200000000LL);
+  EXPECT_EQ(s.replace.load(), 1);
+  EXPECT_EQ(s.last_replace_old_id, 7u);
+
+  flox_runner_stop(ctx.runner);
+  flox_executor_destroy(exec);
+}
+
+TEST(CapiExecutor, NullDetachesExecutor)
+{
+  ExecState s;
+  RunnerCtx ctx;
+  make_market_buy_runner(ctx);
+
+  auto* exec = flox_executor_create(make_cb(s));
+  flox_runner_set_executor(ctx.runner, exec);
+  flox_runner_start(ctx.runner);
+  EXPECT_EQ(s.on_start.load(), 1);
+
+  // Detach mid-run — outgoing executor sees on_stop.
+  flox_runner_set_executor(ctx.runner, nullptr);
+  EXPECT_EQ(s.on_stop.load(), 1);
+
+  flox_runner_on_trade(ctx.runner, ctx.symbol, 100.0, 1.0, 1, 1'000);
+  EXPECT_EQ(s.submit.load(), 0) << "no submit after detach";
+
+  flox_runner_stop(ctx.runner);
+  // No additional on_stop; the runner stopped after detachment.
+  EXPECT_EQ(s.on_stop.load(), 1);
+  flox_executor_destroy(exec);
+}
+
+TEST(CapiExecutor, BacktestRunnerSetExecutorRoutesSignals)
+{
+  ExecState s;
+  auto* exec = flox_executor_create(make_cb(s));
+
+  auto* registry = flox_registry_create();
+  uint32_t sym = flox_registry_add_symbol(registry, "test", "BTC", 0.01);
+  auto* btr = flox_backtest_runner_create(registry, 0.0, 10000.0);
+  flox_backtest_runner_set_executor(btr, exec);
+
+  static std::atomic<bool> fired{false};
+  fired.store(false);
+  struct St
+  {
+    FloxStrategyHandle h;
+    uint32_t sym;
+  } st{nullptr, sym};
+  auto on_bar = +[](void* ud, const FloxSymbolContext*, const FloxBarData*)
+  {
+    if (fired.exchange(true))
+    {
+      return;
+    }
+    auto* p = static_cast<St*>(ud);
+    flox_emit_market_buy(p->h, p->sym, 100000000LL);
+  };
+  FloxStrategyCallbacks scb{};
+  scb.on_bar = on_bar;
+  scb.user_data = &st;
+  uint32_t syms[] = {sym};
+  auto* strat = flox_strategy_create(1, syms, 1, registry, scb);
+  st.h = strat;
+  flox_backtest_runner_set_strategy(btr, strat);
+
+  int64_t starts[1] = {1'000'000'000};
+  int64_t ends[1] = {1'999'999'999};
+  double opens[1] = {100.0}, highs[1] = {101.0}, lows[1] = {99.0};
+  double closes[1] = {100.5}, volumes[1] = {10.0};
+  FloxBacktestStats stats{};
+  int rc = flox_backtest_runner_run_bars(btr, starts, ends, opens, highs, lows,
+                                         closes, volumes, 1, "BTC", 0, 0, &stats);
+  EXPECT_EQ(rc, 1);
+  EXPECT_GE(s.submit.load(), 1)
+      << "BacktestRunner must route through the binding executor when set";
+
+  flox_strategy_destroy(strat);
+  flox_backtest_runner_destroy(btr);
+  flox_registry_destroy(registry);
+  flox_executor_destroy(exec);
+}
+
+TEST(CapiExecutor, NullCallbacksAreNoOp)
+{
+  // Executor with all callbacks null shouldn't crash even when the
+  // runner forwards events.
+  FloxExecutorCallbacks cb{};
+  auto* exec = flox_executor_create(cb);
+  ASSERT_NE(exec, nullptr);
+
+  RunnerCtx ctx;
+  make_market_buy_runner(ctx);
+  flox_runner_set_executor(ctx.runner, exec);
+  flox_runner_start(ctx.runner);
+  flox_runner_on_trade(ctx.runner, ctx.symbol, 100.0, 1.0, 1, 1'000);
+  flox_emit_cancel(ctx.strategy, 1);
+  flox_runner_stop(ctx.runner);
+
+  flox_executor_destroy(exec);
+}

--- a/tests/test_capi_infra.cpp
+++ b/tests/test_capi_infra.cpp
@@ -59,15 +59,15 @@ TEST(CapiBookTest, CreateAndQuery)
 
 TEST(CapiExecutorTest, SubmitAndFill)
 {
-  FloxExecutorHandle exec = flox_executor_create();
+  FloxSimulatedExecutorHandle exec = flox_simulated_executor_create();
   ASSERT_NE(exec, nullptr);
 
-  flox_executor_submit_order(exec, 1, 0, 100.0, 1.0, 0, 1);
-  flox_executor_on_bar(exec, 1, 100.0);
+  flox_simulated_executor_submit_order(exec, 1, 0, 100.0, 1.0, 0, 1);
+  flox_simulated_executor_on_bar(exec, 1, 100.0);
 
-  EXPECT_GE(flox_executor_fill_count(exec), 0u);
+  EXPECT_GE(flox_simulated_executor_fill_count(exec), 0u);
 
-  flox_executor_destroy(exec);
+  flox_simulated_executor_destroy(exec);
 }
 
 // ============================================================

--- a/tools/codegen/golden/flox_capi.codon
+++ b/tools/codegen/golden/flox_capi.codon
@@ -15,12 +15,12 @@ from C import flox_stat_permutation_test(Ptr[float], int, Ptr[float], int, u32) 
 from C import flox_stat_bootstrap_ci(Ptr[float], int, float, u32, Ptr[float], Ptr[float], Ptr[float])
 
 # ── backtest_slippage ──
-from C import flox_executor_set_default_slippage(cobj, i32, i32, float, float, float)
-from C import flox_executor_set_symbol_slippage(cobj, u32, i32, i32, float, float, float)
-from C import flox_executor_set_queue_model(cobj, i32, u32)
-from C import flox_executor_on_trade_qty(cobj, u32, float, float, u8)
-from C import flox_executor_on_best_levels(cobj, u32, float, float, float, float)
-from C import flox_executor_on_book_snapshot(cobj, u32, Ptr[float], Ptr[float], u32, Ptr[float], Ptr[float], u32)
+from C import flox_simulated_executor_set_default_slippage(cobj, i32, i32, float, float, float)
+from C import flox_simulated_executor_set_symbol_slippage(cobj, u32, i32, i32, float, float, float)
+from C import flox_simulated_executor_set_queue_model(cobj, i32, u32)
+from C import flox_simulated_executor_on_trade_qty(cobj, u32, float, float, u8)
+from C import flox_simulated_executor_on_best_levels(cobj, u32, float, float, float, float)
+from C import flox_simulated_executor_on_book_snapshot(cobj, u32, Ptr[float], Ptr[float], u32, Ptr[float], Ptr[float], u32)
 from C import flox_backtest_result_create(float, float, u8, float, float, float) -> cobj
 from C import flox_backtest_result_destroy(cobj)
 from C import flox_backtest_result_record_fill(cobj, u64, u32, u8, float, float, i64)
@@ -98,8 +98,19 @@ from C import flox_data_recorder_is_recording(cobj) -> u8
 # ── datawriter ──
 from C import flox_data_writer_stats(cobj) -> cobj
 
+# ── execution ──
+from C import flox_execution_listener_create(cobj) -> cobj
+from C import flox_execution_listener_destroy(cobj)
+from C import flox_executor_create(cobj) -> cobj
+from C import flox_executor_destroy(cobj)
+from C import flox_executor_get_capabilities(cobj, cobj)
+from C import flox_live_engine_set_executor(cobj, cobj)
+from C import flox_runner_set_executor(cobj, cobj)
+from C import flox_backtest_runner_add_execution_listener(cobj, cobj)
+from C import flox_backtest_runner_set_executor(cobj, cobj)
+
 # ── executor_fill ──
-from C import flox_executor_get_fills(cobj, cobj, u32) -> u32
+from C import flox_simulated_executor_get_fills(cobj, cobj, u32) -> u32
 
 # ── fixed_point ──
 from C import flox_price_from_double(float) -> i64
@@ -347,15 +358,15 @@ from C import flox_emit_limit_sell_tif(cobj, u32, i64, i64, u8) -> u64
 from C import flox_emit_close_position(cobj, u32) -> u64
 
 # ── simulated_executor ──
-from C import flox_executor_create() -> cobj
-from C import flox_executor_destroy(cobj)
-from C import flox_executor_submit_order(cobj, u64, u8, float, float, u8, u32)
-from C import flox_executor_cancel_order(cobj, u64)
-from C import flox_executor_cancel_all(cobj, u32)
-from C import flox_executor_on_bar(cobj, u32, float)
-from C import flox_executor_on_trade(cobj, u32, float, u8)
-from C import flox_executor_advance_clock(cobj, i64)
-from C import flox_executor_fill_count(cobj) -> u32
+from C import flox_simulated_executor_create() -> cobj
+from C import flox_simulated_executor_destroy(cobj)
+from C import flox_simulated_executor_submit_order(cobj, u64, u8, float, float, u8, u32)
+from C import flox_simulated_executor_cancel_order(cobj, u64)
+from C import flox_simulated_executor_cancel_all(cobj, u32)
+from C import flox_simulated_executor_on_bar(cobj, u32, float)
+from C import flox_simulated_executor_on_trade(cobj, u32, float, u8)
+from C import flox_simulated_executor_advance_clock(cobj, i64)
+from C import flox_simulated_executor_fill_count(cobj) -> u32
 
 # ── statistics ──
 from C import flox_stat_correlation(Ptr[float], Ptr[float], int) -> float

--- a/tools/codegen/golden/flox_capi.h
+++ b/tools/codegen/golden/flox_capi.h
@@ -28,7 +28,7 @@ extern "C"
   typedef void* FloxStrategyHandle;
   typedef void* FloxRegistryHandle;
   typedef void* FloxBookHandle;
-  typedef void* FloxExecutorHandle;
+  typedef void* FloxSimulatedExecutorHandle;
   typedef void* FloxPositionTrackerHandle;
   typedef void* FloxPositionGroupHandle;
   typedef void* FloxOrderTrackerHandle;
@@ -51,6 +51,8 @@ extern "C"
   typedef void* FloxStorageSinkHandle;
   typedef void* FloxMarketDataRecorderHandle;
   typedef void* FloxReplaySourceHandle;
+  typedef void* FloxExecutionListenerHandle;
+  typedef void* FloxExecutorHandle;
   typedef void* FloxLiveEngineHandle;
   typedef void* FloxRunnerHandle;
   typedef void* FloxBacktestRunnerHandle;
@@ -362,6 +364,45 @@ extern "C"
     const FloxBookLevel* asks;
   } FloxReplayEvent;
 
+  typedef struct
+  {
+    uint64_t id;
+    uint64_t client_order_id;
+    uint32_t symbol;
+    uint16_t strategy_id;
+    uint16_t order_tag;
+    uint8_t side;
+    uint8_t type;
+    uint8_t time_in_force;
+    uint8_t flags;
+    int64_t price_raw;
+    int64_t quantity_raw;
+    int64_t filled_quantity_raw;
+    int64_t trigger_price_raw;
+    int64_t trailing_offset_raw;
+    int64_t created_at_ns;
+    int64_t exchange_ts_ns;
+  } FloxOrder;
+
+  typedef struct
+  {
+    uint8_t supports_stop_market;
+    uint8_t supports_stop_limit;
+    uint8_t supports_take_profit_market;
+    uint8_t supports_take_profit_limit;
+    uint8_t supports_trailing_stop;
+    uint8_t supports_iceberg;
+    uint8_t supports_oco;
+    uint8_t supports_gtc;
+    uint8_t supports_ioc;
+    uint8_t supports_fok;
+    uint8_t supports_gtd;
+    uint8_t supports_post_only;
+    uint8_t supports_reduce_only;
+    uint8_t supports_close_position;
+    uint8_t _pad[2];
+  } FloxExchangeCapabilities;
+
   // ============================================================
   // Callback function pointer types
   // ============================================================
@@ -385,6 +426,18 @@ extern "C"
   typedef uint8_t (*FloxReplaySourceNextFn)(void*, FloxReplayEvent*);
   typedef uint8_t (*FloxReplaySourceSeekFn)(void*, int64_t);
   typedef void (*FloxReplaySourceLifecycleFn)(void*);
+  typedef void (*FloxExecListenerOnOrderFn)(void*, const FloxOrder*);
+  typedef void (*FloxExecListenerOnPartialFillFn)(void*, const FloxOrder*, int64_t);
+  typedef void (*FloxExecListenerOnRejectedFn)(void*, const FloxOrder*, const char*);
+  typedef void (*FloxExecListenerOnReplacedFn)(void*, const FloxOrder*, const FloxOrder*);
+  typedef void (*FloxExecListenerOnTrailingUpdateFn)(void*, const FloxOrder*, int64_t);
+  typedef void (*FloxExecutorSubmitFn)(void*, const FloxOrder*);
+  typedef void (*FloxExecutorCancelFn)(void*, uint64_t);
+  typedef void (*FloxExecutorCancelAllFn)(void*, uint32_t);
+  typedef void (*FloxExecutorReplaceFn)(void*, uint64_t, const FloxOrder*);
+  typedef void (*FloxExecutorSubmitOCOFn)(void*, const FloxOrder*, const FloxOrder*);
+  typedef void (*FloxExecutorCapabilitiesFn)(void*, FloxExchangeCapabilities*);
+  typedef void (*FloxExecutorLifecycleFn)(void*);
 
   // ============================================================
   // Callback bundles
@@ -448,6 +501,36 @@ extern "C"
     void* user_data;
   } FloxReplaySourceCallbacks;
 
+  typedef struct
+  {
+    FloxExecListenerOnOrderFn on_submitted;
+    FloxExecListenerOnOrderFn on_accepted;
+    FloxExecListenerOnPartialFillFn on_partially_filled;
+    FloxExecListenerOnOrderFn on_filled;
+    FloxExecListenerOnOrderFn on_pending_cancel;
+    FloxExecListenerOnOrderFn on_canceled;
+    FloxExecListenerOnOrderFn on_expired;
+    FloxExecListenerOnRejectedFn on_rejected;
+    FloxExecListenerOnReplacedFn on_replaced;
+    FloxExecListenerOnOrderFn on_pending_trigger;
+    FloxExecListenerOnOrderFn on_triggered;
+    FloxExecListenerOnTrailingUpdateFn on_trailing_stop_updated;
+    void* user_data;
+  } FloxExecutionListenerCallbacks;
+
+  typedef struct
+  {
+    FloxExecutorSubmitFn submit;
+    FloxExecutorCancelFn cancel;
+    FloxExecutorCancelAllFn cancel_all;
+    FloxExecutorReplaceFn replace;
+    FloxExecutorSubmitOCOFn submit_oco;
+    FloxExecutorCapabilitiesFn capabilities;
+    FloxExecutorLifecycleFn on_start;
+    FloxExecutorLifecycleFn on_stop;
+    void* user_data;
+  } FloxExecutorCallbacks;
+
   // ============================================================
   // Fixed-point conversion helpers
   // ============================================================
@@ -482,20 +565,24 @@ extern "C"
   // Backtest Slippage
   // ============================================================
 
-  void flox_executor_set_default_slippage(FloxExecutorHandle executor, int32_t model, int32_t ticks,
-                                          double tick_size, double bps, double impact_coeff);
-  void flox_executor_set_symbol_slippage(FloxExecutorHandle executor, uint32_t symbol, int32_t model,
-                                         int32_t ticks, double tick_size, double bps,
-                                         double impact_coeff);
-  void flox_executor_set_queue_model(FloxExecutorHandle executor, int32_t model, uint32_t depth);
-  void flox_executor_on_trade_qty(FloxExecutorHandle executor, uint32_t symbol, double price,
-                                  double quantity, uint8_t is_buy);
-  void flox_executor_on_best_levels(FloxExecutorHandle executor, uint32_t symbol, double bid_price,
-                                    double bid_qty, double ask_price, double ask_qty);
-  void flox_executor_on_book_snapshot(FloxExecutorHandle executor, uint32_t symbol,
-                                      const double* bid_prices, const double* bid_qtys,
-                                      uint32_t n_bids, const double* ask_prices,
-                                      const double* ask_qtys, uint32_t n_asks);
+  void flox_simulated_executor_set_default_slippage(FloxSimulatedExecutorHandle executor,
+                                                    int32_t model, int32_t ticks, double tick_size,
+                                                    double bps, double impact_coeff);
+  void flox_simulated_executor_set_symbol_slippage(FloxSimulatedExecutorHandle executor,
+                                                   uint32_t symbol, int32_t model, int32_t ticks,
+                                                   double tick_size, double bps, double impact_coeff);
+  void flox_simulated_executor_set_queue_model(FloxSimulatedExecutorHandle executor, int32_t model,
+                                               uint32_t depth);
+  void flox_simulated_executor_on_trade_qty(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                            double price, double quantity, uint8_t is_buy);
+  void flox_simulated_executor_on_best_levels(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                              double bid_price, double bid_qty, double ask_price,
+                                              double ask_qty);
+  void flox_simulated_executor_on_book_snapshot(FloxSimulatedExecutorHandle executor,
+                                                uint32_t symbol, const double* bid_prices,
+                                                const double* bid_qtys, uint32_t n_bids,
+                                                const double* ask_prices, const double* ask_qtys,
+                                                uint32_t n_asks);
   FloxBacktestResultHandle flox_backtest_result_create(double initial_capital, double fee_rate,
                                                        uint8_t use_percentage_fee,
                                                        double fixed_fee_per_trade,
@@ -506,7 +593,7 @@ extern "C"
                                         uint32_t symbol, uint8_t side, double price, double quantity,
                                         int64_t timestamp_ns);
   void flox_backtest_result_ingest_executor(FloxBacktestResultHandle result,
-                                            FloxExecutorHandle executor);
+                                            FloxSimulatedExecutorHandle executor);
   void flox_backtest_result_stats(FloxBacktestResultHandle result, FloxBacktestStats* out);
   uint32_t flox_backtest_result_equity_curve(FloxBacktestResultHandle result,
                                              FloxEquityPoint* points_out, uint32_t max_points);
@@ -653,11 +740,28 @@ extern "C"
   FloxWriterStats flox_data_writer_stats(FloxDataWriterHandle writer);
 
   // ============================================================
+  // Execution
+  // ============================================================
+
+  FloxExecutionListenerHandle flox_execution_listener_create(FloxExecutionListenerCallbacks callbacks);
+  void flox_execution_listener_destroy(FloxExecutionListenerHandle listener);
+  FloxExecutorHandle flox_executor_create(FloxExecutorCallbacks callbacks);
+  void flox_executor_destroy(FloxExecutorHandle executor);
+  void flox_executor_get_capabilities(FloxExecutorHandle executor,
+                                      FloxExchangeCapabilities* caps_out);
+  void flox_live_engine_set_executor(FloxLiveEngineHandle engine, FloxExecutorHandle executor);
+  void flox_runner_set_executor(FloxRunnerHandle runner, FloxExecutorHandle executor);
+  void flox_backtest_runner_add_execution_listener(FloxBacktestRunnerHandle runner,
+                                                   FloxExecutionListenerHandle listener);
+  void flox_backtest_runner_set_executor(FloxBacktestRunnerHandle runner,
+                                         FloxExecutorHandle executor);
+
+  // ============================================================
   // Executor Fill
   // ============================================================
 
-  uint32_t flox_executor_get_fills(FloxExecutorHandle executor, FloxFill* fills_out,
-                                   uint32_t max_fills);
+  uint32_t flox_simulated_executor_get_fills(FloxSimulatedExecutorHandle executor,
+                                             FloxFill* fills_out, uint32_t max_fills);
 
   // ============================================================
   // Floxliveengine Disruptor
@@ -1064,17 +1168,20 @@ extern "C"
   // Simulated Executor
   // ============================================================
 
-  FloxExecutorHandle flox_executor_create(void);
-  void flox_executor_destroy(FloxExecutorHandle executor);
-  void flox_executor_submit_order(FloxExecutorHandle executor, uint64_t id, uint8_t side,
-                                  double price, double quantity, uint8_t order_type, uint32_t symbol);
-  void flox_executor_cancel_order(FloxExecutorHandle executor, uint64_t order_id);
-  void flox_executor_cancel_all(FloxExecutorHandle executor, uint32_t symbol);
-  void flox_executor_on_bar(FloxExecutorHandle executor, uint32_t symbol, double close_price);
-  void flox_executor_on_trade(FloxExecutorHandle executor, uint32_t symbol, double price,
-                              uint8_t is_buy);
-  void flox_executor_advance_clock(FloxExecutorHandle executor, int64_t timestamp_ns);
-  uint32_t flox_executor_fill_count(FloxExecutorHandle executor);
+  FloxSimulatedExecutorHandle flox_simulated_executor_create(void);
+  void flox_simulated_executor_destroy(FloxSimulatedExecutorHandle executor);
+  void flox_simulated_executor_submit_order(FloxSimulatedExecutorHandle executor, uint64_t id,
+                                            uint8_t side, double price, double quantity,
+                                            uint8_t order_type, uint32_t symbol);
+  void flox_simulated_executor_cancel_order(FloxSimulatedExecutorHandle executor, uint64_t order_id);
+  void flox_simulated_executor_cancel_all(FloxSimulatedExecutorHandle executor, uint32_t symbol);
+  void flox_simulated_executor_on_bar(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                      double close_price);
+  void flox_simulated_executor_on_trade(FloxSimulatedExecutorHandle executor, uint32_t symbol,
+                                        double price, uint8_t is_buy);
+  void flox_simulated_executor_advance_clock(FloxSimulatedExecutorHandle executor,
+                                             int64_t timestamp_ns);
+  uint32_t flox_simulated_executor_fill_count(FloxSimulatedExecutorHandle executor);
 
   // ============================================================
   // Statistics

--- a/tools/codegen/golden/flox_capi.md
+++ b/tools/codegen/golden/flox_capi.md
@@ -2,7 +2,7 @@
 
 Generated from `include/flox/capi/flox_capi_spec.hpp`. Source of truth for FFI consumers (Codon, QuickJS, Rust, Go cgo, Python ctypes). The pybind11 (Python) and NAPI (Node) bindings wrap this surface but expose richer language-native APIs that live in `python/` and `node/` respectively — see those for the Python/TS-flavored interfaces.
 
-**Surface:** 319 functions, 29 handles, 33 structs, 19 callback typedefs, 2 enums, 43 groups.
+**Surface:** 328 functions, 31 handles, 37 structs, 31 callback typedefs, 2 enums, 44 groups.
 
 ## Opaque handles
 
@@ -11,7 +11,7 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `FloxStrategyHandle`
 - `FloxRegistryHandle`
 - `FloxBookHandle`
-- `FloxExecutorHandle`
+- `FloxSimulatedExecutorHandle`
 - `FloxPositionTrackerHandle`
 - `FloxPositionGroupHandle`
 - `FloxOrderTrackerHandle`
@@ -34,6 +34,8 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `FloxStorageSinkHandle`
 - `FloxMarketDataRecorderHandle`
 - `FloxReplaySourceHandle`
+- `FloxExecutionListenerHandle`
+- `FloxExecutorHandle`
 - `FloxLiveEngineHandle`
 - `FloxRunnerHandle`
 - `FloxBacktestRunnerHandle`
@@ -74,6 +76,18 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `typedef uint8_t (*FloxReplaySourceNextFn)(void *, FloxReplayEvent *);`
 - `typedef uint8_t (*FloxReplaySourceSeekFn)(void *, int64_t);`
 - `typedef void (*FloxReplaySourceLifecycleFn)(void *);`
+- `typedef void (*FloxExecListenerOnOrderFn)(void *, const FloxOrder *);`
+- `typedef void (*FloxExecListenerOnPartialFillFn)(void *, const FloxOrder *, int64_t);`
+- `typedef void (*FloxExecListenerOnRejectedFn)(void *, const FloxOrder *, const char *);`
+- `typedef void (*FloxExecListenerOnReplacedFn)(void *, const FloxOrder *, const FloxOrder *);`
+- `typedef void (*FloxExecListenerOnTrailingUpdateFn)(void *, const FloxOrder *, int64_t);`
+- `typedef void (*FloxExecutorSubmitFn)(void *, const FloxOrder *);`
+- `typedef void (*FloxExecutorCancelFn)(void *, uint64_t);`
+- `typedef void (*FloxExecutorCancelAllFn)(void *, uint32_t);`
+- `typedef void (*FloxExecutorReplaceFn)(void *, uint64_t, const FloxOrder *);`
+- `typedef void (*FloxExecutorSubmitOCOFn)(void *, const FloxOrder *, const FloxOrder *);`
+- `typedef void (*FloxExecutorCapabilitiesFn)(void *, FloxExchangeCapabilities *);`
+- `typedef void (*FloxExecutorLifecycleFn)(void *);`
 
 ## Structs
 
@@ -453,6 +467,79 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 | `next` | `FloxReplaySourceNextFn` |
 | `user_data` | `void *` |
 
+### `FloxOrder`
+
+| field | type |
+|---|---|
+| `id` | `uint64_t` |
+| `client_order_id` | `uint64_t` |
+| `symbol` | `uint32_t` |
+| `strategy_id` | `uint16_t` |
+| `order_tag` | `uint16_t` |
+| `side` | `uint8_t` |
+| `type` | `uint8_t` |
+| `time_in_force` | `uint8_t` |
+| `flags` | `uint8_t` |
+| `price_raw` | `int64_t` |
+| `quantity_raw` | `int64_t` |
+| `filled_quantity_raw` | `int64_t` |
+| `trigger_price_raw` | `int64_t` |
+| `trailing_offset_raw` | `int64_t` |
+| `created_at_ns` | `int64_t` |
+| `exchange_ts_ns` | `int64_t` |
+
+### `FloxExecutionListenerCallbacks`
+
+| field | type |
+|---|---|
+| `on_submitted` | `FloxExecListenerOnOrderFn` |
+| `on_accepted` | `FloxExecListenerOnOrderFn` |
+| `on_partially_filled` | `FloxExecListenerOnPartialFillFn` |
+| `on_filled` | `FloxExecListenerOnOrderFn` |
+| `on_pending_cancel` | `FloxExecListenerOnOrderFn` |
+| `on_canceled` | `FloxExecListenerOnOrderFn` |
+| `on_expired` | `FloxExecListenerOnOrderFn` |
+| `on_rejected` | `FloxExecListenerOnRejectedFn` |
+| `on_replaced` | `FloxExecListenerOnReplacedFn` |
+| `on_pending_trigger` | `FloxExecListenerOnOrderFn` |
+| `on_triggered` | `FloxExecListenerOnOrderFn` |
+| `on_trailing_stop_updated` | `FloxExecListenerOnTrailingUpdateFn` |
+| `user_data` | `void *` |
+
+### `FloxExchangeCapabilities`
+
+| field | type |
+|---|---|
+| `supports_stop_market` | `uint8_t` |
+| `supports_stop_limit` | `uint8_t` |
+| `supports_take_profit_market` | `uint8_t` |
+| `supports_take_profit_limit` | `uint8_t` |
+| `supports_trailing_stop` | `uint8_t` |
+| `supports_iceberg` | `uint8_t` |
+| `supports_oco` | `uint8_t` |
+| `supports_gtc` | `uint8_t` |
+| `supports_ioc` | `uint8_t` |
+| `supports_fok` | `uint8_t` |
+| `supports_gtd` | `uint8_t` |
+| `supports_post_only` | `uint8_t` |
+| `supports_reduce_only` | `uint8_t` |
+| `supports_close_position` | `uint8_t` |
+| `_pad` | `uint8_t[2]` |
+
+### `FloxExecutorCallbacks`
+
+| field | type |
+|---|---|
+| `submit` | `FloxExecutorSubmitFn` |
+| `cancel` | `FloxExecutorCancelFn` |
+| `cancel_all` | `FloxExecutorCancelAllFn` |
+| `replace` | `FloxExecutorReplaceFn` |
+| `submit_oco` | `FloxExecutorSubmitOCOFn` |
+| `capabilities` | `FloxExecutorCapabilitiesFn` |
+| `on_start` | `FloxExecutorLifecycleFn` |
+| `on_stop` | `FloxExecutorLifecycleFn` |
+| `user_data` | `void *` |
+
 ## Functions
 
 ### additional_bar
@@ -467,16 +554,16 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 
 ### backtest_slippage
 
-- `void flox_executor_set_default_slippage(FloxExecutorHandle executor, int32_t model, int32_t ticks, double tick_size, double bps, double impact_coeff)`
-- `void flox_executor_set_symbol_slippage(FloxExecutorHandle executor, uint32_t symbol, int32_t model, int32_t ticks, double tick_size, double bps, double impact_coeff)`
-- `void flox_executor_set_queue_model(FloxExecutorHandle executor, int32_t model, uint32_t depth)`
-- `void flox_executor_on_trade_qty(FloxExecutorHandle executor, uint32_t symbol, double price, double quantity, uint8_t is_buy)`
-- `void flox_executor_on_best_levels(FloxExecutorHandle executor, uint32_t symbol, double bid_price, double bid_qty, double ask_price, double ask_qty)`
-- `void flox_executor_on_book_snapshot(FloxExecutorHandle executor, uint32_t symbol, const double * bid_prices, const double * bid_qtys, uint32_t n_bids, const double * ask_prices, const double * ask_qtys, uint32_t n_asks)`
+- `void flox_simulated_executor_set_default_slippage(FloxSimulatedExecutorHandle executor, int32_t model, int32_t ticks, double tick_size, double bps, double impact_coeff)`
+- `void flox_simulated_executor_set_symbol_slippage(FloxSimulatedExecutorHandle executor, uint32_t symbol, int32_t model, int32_t ticks, double tick_size, double bps, double impact_coeff)`
+- `void flox_simulated_executor_set_queue_model(FloxSimulatedExecutorHandle executor, int32_t model, uint32_t depth)`
+- `void flox_simulated_executor_on_trade_qty(FloxSimulatedExecutorHandle executor, uint32_t symbol, double price, double quantity, uint8_t is_buy)`
+- `void flox_simulated_executor_on_best_levels(FloxSimulatedExecutorHandle executor, uint32_t symbol, double bid_price, double bid_qty, double ask_price, double ask_qty)`
+- `void flox_simulated_executor_on_book_snapshot(FloxSimulatedExecutorHandle executor, uint32_t symbol, const double * bid_prices, const double * bid_qtys, uint32_t n_bids, const double * ask_prices, const double * ask_qtys, uint32_t n_asks)`
 - `FloxBacktestResultHandle flox_backtest_result_create(double initial_capital, double fee_rate, uint8_t use_percentage_fee, double fixed_fee_per_trade, double risk_free_rate, double annualization_factor)`
 - `void flox_backtest_result_destroy(FloxBacktestResultHandle result)`
 - `void flox_backtest_result_record_fill(FloxBacktestResultHandle result, uint64_t order_id, uint32_t symbol, uint8_t side, double price, double quantity, int64_t timestamp_ns)`
-- `void flox_backtest_result_ingest_executor(FloxBacktestResultHandle result, FloxExecutorHandle executor)`
+- `void flox_backtest_result_ingest_executor(FloxBacktestResultHandle result, FloxSimulatedExecutorHandle executor)`
 - `void flox_backtest_result_stats(FloxBacktestResultHandle result, FloxBacktestStats * out)`
 - `uint32_t flox_backtest_result_equity_curve(FloxBacktestResultHandle result, FloxEquityPoint * points_out, uint32_t max_points)`
 - `uint8_t flox_backtest_result_write_equity_curve_csv(FloxBacktestResultHandle result, const char * path)`
@@ -559,9 +646,21 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 
 - `FloxWriterStats flox_data_writer_stats(FloxDataWriterHandle writer)`
 
+### execution
+
+- `FloxExecutionListenerHandle flox_execution_listener_create(FloxExecutionListenerCallbacks callbacks)`
+- `void flox_execution_listener_destroy(FloxExecutionListenerHandle listener)`
+- `FloxExecutorHandle flox_executor_create(FloxExecutorCallbacks callbacks)`
+- `void flox_executor_destroy(FloxExecutorHandle executor)`
+- `void flox_executor_get_capabilities(FloxExecutorHandle executor, FloxExchangeCapabilities * caps_out)`
+- `void flox_live_engine_set_executor(FloxLiveEngineHandle engine, FloxExecutorHandle executor)`
+- `void flox_runner_set_executor(FloxRunnerHandle runner, FloxExecutorHandle executor)`
+- `void flox_backtest_runner_add_execution_listener(FloxBacktestRunnerHandle runner, FloxExecutionListenerHandle listener)`
+- `void flox_backtest_runner_set_executor(FloxBacktestRunnerHandle runner, FloxExecutorHandle executor)`
+
 ### executor_fill
 
-- `uint32_t flox_executor_get_fills(FloxExecutorHandle executor, FloxFill * fills_out, uint32_t max_fills)`
+- `uint32_t flox_simulated_executor_get_fills(FloxSimulatedExecutorHandle executor, FloxFill * fills_out, uint32_t max_fills)`
 
 ### fixed_point
 
@@ -831,15 +930,15 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 
 ### simulated_executor
 
-- `FloxExecutorHandle flox_executor_create(void)`
-- `void flox_executor_destroy(FloxExecutorHandle executor)`
-- `void flox_executor_submit_order(FloxExecutorHandle executor, uint64_t id, uint8_t side, double price, double quantity, uint8_t order_type, uint32_t symbol)`
-- `void flox_executor_cancel_order(FloxExecutorHandle executor, uint64_t order_id)`
-- `void flox_executor_cancel_all(FloxExecutorHandle executor, uint32_t symbol)`
-- `void flox_executor_on_bar(FloxExecutorHandle executor, uint32_t symbol, double close_price)`
-- `void flox_executor_on_trade(FloxExecutorHandle executor, uint32_t symbol, double price, uint8_t is_buy)`
-- `void flox_executor_advance_clock(FloxExecutorHandle executor, int64_t timestamp_ns)`
-- `uint32_t flox_executor_fill_count(FloxExecutorHandle executor)`
+- `FloxSimulatedExecutorHandle flox_simulated_executor_create(void)`
+- `void flox_simulated_executor_destroy(FloxSimulatedExecutorHandle executor)`
+- `void flox_simulated_executor_submit_order(FloxSimulatedExecutorHandle executor, uint64_t id, uint8_t side, double price, double quantity, uint8_t order_type, uint32_t symbol)`
+- `void flox_simulated_executor_cancel_order(FloxSimulatedExecutorHandle executor, uint64_t order_id)`
+- `void flox_simulated_executor_cancel_all(FloxSimulatedExecutorHandle executor, uint32_t symbol)`
+- `void flox_simulated_executor_on_bar(FloxSimulatedExecutorHandle executor, uint32_t symbol, double close_price)`
+- `void flox_simulated_executor_on_trade(FloxSimulatedExecutorHandle executor, uint32_t symbol, double price, uint8_t is_buy)`
+- `void flox_simulated_executor_advance_clock(FloxSimulatedExecutorHandle executor, int64_t timestamp_ns)`
+- `uint32_t flox_simulated_executor_fill_count(FloxSimulatedExecutorHandle executor)`
 
 ### statistics
 


### PR DESCRIPTION
## Summary
Closes the last W1 gap. Two binding-side execution hooks plus a breaking rename of the legacy simulated-executor C API.

### ExecutionListener
Bindings observe order lifecycle events (submit / accept / partial fill / fill / cancel / reject / replace / trigger / trailing update). Wires into BacktestRunner's existing `addExecutionListener` channel.

### Executor
Full `IOrderExecutor` surface: `submit`, `cancel`, `cancel_all`, `replace`, `submit_oco`, `capabilities()`, plus `on_start` / `on_stop` lifecycle. Available for runner, live engine and backtest runner via `flox_*_set_executor`. When attached, signals route through the executor (in **addition** to user `on_signal` for the synchronous runner / live engine; **instead of** SimulatedExecutor for backtest).

Two ABI-stable structs: `FloxOrder` (mirror of `flox::Order`) and `FloxExchangeCapabilities`.

## Breaking change: rename of legacy SimulatedExecutor C API
The legacy `flox_executor_*` / `FloxExecutorHandle` were specifically wrapping `SimulatedExecutor` — had simulator-only methods (`on_bar`, `advance_clock`, `fill_count`, `set_queue_model`). The abstract namespace was being squatted by a concrete simulator. Renamed to `flox_simulated_executor_*` / `FloxSimulatedExecutorHandle` across **all** consumers in this PR:
- spec / header / cpp
- golden codegen artefacts
- codon, node, quickjs bindings
- tests
- docs (queue_simulation, slippage)
The abstract `flox_executor_*` namespace now belongs to the new binding-side hook, matching the rest of the C API naming pattern (`flox_risk_manager_*`, `flox_pnl_tracker_*`, `flox_replay_source_*`, etc.).

## Core flox refactor
Added `BacktestRunner::setExecutor(IOrderExecutor*)` + non-owning `_customExecutor` pointer. When set, `onSignal` routes through the custom executor; when null, existing `SimulatedExecutor` behaviour is preserved bit-for-bit. Default-construction unchanged, no migration needed for existing flox users.

## API surface (6 new exports, 322 → 328)
- `flox_executor_create` / `_destroy` / `_get_capabilities`
- `flox_runner_set_executor` / `flox_live_engine_set_executor` / `flox_backtest_runner_set_executor`
- ExecutionListener side (already from previous work in this branch): `flox_execution_listener_create` / `_destroy` / `flox_backtest_runner_add_execution_listener`

## Test plan
- [x] 4 ExecutionListener cases (create/destroy, BacktestRunner fill propagation, multiple listeners receive same events, NULL callbacks no-op)
- [x] 7 Executor cases (create/destroy/capabilities, capabilities NULL→zero, runner market-buy forwarding, runner cancel/cancel_all/replace forwarding, NULL detach mid-run, BacktestRunner forwarding, NULL callbacks no-op)
- [x] Local: full test suite (56/56 passing)
- [x] Codegen check clean (signatures + ABI snapshot in sync)
- [x] CI: 20 checks expected green

W1-T023

🤖 Generated with [Claude Code](https://claude.com/claude-code)