### PR TITLE
docs(contributors): architecture + contributor guide

### DIFF
--- a/docs/.snippet-allowlist.txt
+++ b/docs/.snippet-allowlist.txt
@@ -68,3 +68,10 @@ docs/reference/quickjs/tools.md
 docs/tutorials/codon-strategy.md
 docs/tutorials/node-quickstart.md
 docs/tutorials/python-quickstart.md
+
+# Contributor docs — code blocks are pattern templates / pseudocode
+# (e.g. "your hook trampoline looks like X"), not runnable snippets.
+# Extracting them as runnable files would obscure the structural
+# point being illustrated.
+docs/contributors/adding-a-c-api-export.md
+docs/contributors/extension-hook-pattern.md

--- a/docs/contributors/adding-a-c-api-export.md
+++ b/docs/contributors/adding-a-c-api-export.md
@@ -1,0 +1,216 @@
+# Adding a C ABI Export
+
+Step-by-step for adding a new function to the FLOX public C ABI surface (anything in `flox_capi.h`).
+
+If you're adding an extension hook (PnLTracker, Executor, etc.), follow [extension-hook-pattern.md](extension-hook-pattern.md) instead — that's a specialized variant of this flow.
+
+## Mental model
+
+```
+include/flox/capi/flox_capi_spec.hpp     ← you edit this (the IDL)
+        │
+        │  bash tools/codegen/scripts/regenerate.sh
+        ▼
+include/flox/capi/flox_capi.h            ← regenerated
+.api/c-api.snapshot                       ← regenerated (ABI signature gate)
+mcp/flox_mcp/data/c-api.snapshot          ← regenerated (MCP context)
+tools/codegen/golden/flox_capi.{h,codon,md}  ← regenerated
+        │
+        │  you implement in src/capi/flox_capi.cpp
+        ▼
+libflox_capi.so                           ← compiled
+
+then bindings:
+  python/    pybind11 wrapper       (hand-written, calls flox_xxx_*)
+  node/      NAPI wrapper           (hand-written)
+  codon/     auto-imported via golden
+  quickjs/   hand-written wrapper
+
+then docs sync (eight scripts, see ci-pipeline.md):
+  scripts/gen_pyi_stubs.py     ← regenerates Python .pyi
+  scripts/gen_api_index.py     ← regenerates docs/reference/python/_api_index.md
+  scripts/gen_llms_txt.py      ← regenerates docs/llms*.txt
+  scripts/sync_mcp_data.py     ← regenerates mcp/flox_mcp/data/
+```
+
+## Step 1: edit the IDL
+
+In [`include/flox/capi/flox_capi_spec.hpp`](../../include/flox/capi/flox_capi_spec.hpp):
+
+```cpp
+FLOX_EXPORT(group = "your_group")
+void flox_your_function(FloxRunnerHandle runner,
+                        uint32_t symbol,
+                        double param);
+```
+
+The `group = "..."` string is required — every export belongs to a group, and the [parity gate](parity-gate.md) checks per-group coverage in pybind11 / NAPI / codon.
+
+If you're adding a new group, also add a stanza in [`tools/codegen/binding_parity.yaml`](../../tools/codegen/binding_parity.yaml). CI fails until you do.
+
+## Step 2: regenerate codegen artifacts
+
+```bash
+bash tools/codegen/scripts/regenerate.sh
+```
+
+This single command updates:
+- `include/flox/capi/flox_capi.h` (the live header)
+- `tools/codegen/golden/flox_capi.{h,codon,md}` (the golden reference)
+- `.api/c-api.snapshot` (signature snapshot for ABI gating)
+- `mcp/flox_mcp/data/*` (data the flox-mcp server bundles)
+
+Then verify nothing drifted:
+
+```bash
+bash tools/codegen/scripts/check.sh
+```
+
+## Step 3: implement in C++
+
+In [`src/capi/flox_capi.cpp`](../../src/capi/flox_capi.cpp):
+
+```cpp
+void flox_your_function(FloxRunnerHandle h, uint32_t symbol, double param) {
+  toRunner(h)->yourFunction(symbol, param);
+}
+```
+
+If the function calls into C++ engine code that doesn't yet exist, write that first. The C ABI wrapper is a thin translation layer; business logic lives in `src/` proper.
+
+## Step 4: build and test the C side
+
+```bash
+cmake --build build
+ctest --test-dir build
+```
+
+Add a GTest case under `tests/` if the function has non-trivial semantics (anything beyond a one-line delegation). Pattern: `tests/test_capi_*.cpp` — link against `flox_capi`, exercise the function via the C ABI directly.
+
+## Step 5: pybind11 wrapper
+
+Open [`python/strategy_bindings.h`](../../python/strategy_bindings.h) (or the appropriate `python/*_bindings.h` file matching your group). Add a method on the relevant `Py*` class that calls your C ABI function. Then register it in the `py::class_<...>` block.
+
+Example:
+
+```cpp
+class PyStrategyRunner {
+  // ...
+  void your_function(uint32_t symbol, double param) {
+    flox_your_function(_runner, symbol, param);
+  }
+};
+```
+
+```cpp
+py::class_<PyStrategyRunner>(m, "Runner")
+    // ...
+    .def("your_function", &PyStrategyRunner::your_function,
+         py::arg("symbol"), py::arg("param"));
+```
+
+Build the Python module:
+
+```bash
+cmake --build build --target _flox_py
+```
+
+Regenerate the `.pyi` stubs (running pybind11 module is the source of truth):
+
+```bash
+PYTHONPATH=build/python python3 scripts/gen_pyi_stubs.py
+```
+
+## Step 6: NAPI wrapper
+
+Open [`node/src/strategy.h`](../../node/src/strategy.h) (or the appropriate `node/src/*.h` file). Add an `InstanceMethod` entry to the class's `Init` and a corresponding method that calls the C ABI:
+
+```cpp
+Napi::Value yourFunction(const Napi::CallbackInfo& info) {
+  uint32_t sym = symId(info[0]);
+  double param = info[1].As<Napi::Number>().DoubleValue();
+  flox_your_function(_handle, sym, param);
+  return info.Env().Undefined();
+}
+```
+
+Add the TypeScript declaration in [`node/index.d.ts`](../../node/index.d.ts):
+
+```typescript
+yourFunction(symbol: Symbol | number, param: number): void;
+```
+
+Rebuild and verify:
+
+```bash
+cd node && npm run build && npm run typecheck
+node test/test_bindings.js
+```
+
+## Step 7: parity gate
+
+If your group is new (not yet in `binding_parity.yaml`), add it. If your group exists, your function should be covered already — check by running:
+
+```bash
+python3 scripts/check_binding_parity.py
+```
+
+The gate scans the IDL for `FLOX_EXPORT(group = "X")` declarations and verifies every group has the declared classes / functions in pybind11 (`.pyi`) and NAPI (`.d.ts`).
+
+For function-shaped groups (no class wrapping), list expected function names:
+
+```yaml
+your_group:
+  pybind11: { status: required, functions: [your_function] }
+  napi: { status: required, functions: [yourFunction] }
+  codon: { status: required }
+```
+
+## Step 8: docs sync chain
+
+Three scripts re-derive documentation from the bindings — run them in order:
+
+```bash
+python3 scripts/gen_pyi_stubs.py        # 1. .pyi from running pybind11
+python3 scripts/gen_api_index.py        # 2. docs/reference/python/_api_index.md from .pyi
+python3 scripts/gen_llms_txt.py         # 3. docs/llms*.txt (embeds api_index)
+```
+
+`sync_mcp_data.py` runs as part of `regenerate.sh`, so it's already up to date.
+
+Verify with `--check` flags before committing:
+
+```bash
+python3 scripts/gen_pyi_stubs.py --check
+python3 scripts/gen_api_index.py --check
+python3 scripts/gen_llms_txt.py --check
+```
+
+If any drifts, the generated form differs from what's in the repo — re-run the generator without `--check` and commit the diff.
+
+## Step 9: commit
+
+Stage the regenerated artifacts plus your new code:
+
+```bash
+git add include/flox/capi/flox_capi.h \
+        include/flox/capi/flox_capi_spec.hpp \
+        src/capi/flox_capi.cpp \
+        .api/c-api.snapshot \
+        mcp/flox_mcp/data/c-api.snapshot \
+        tools/codegen/golden/ \
+        python/flox_py/_flox_py/__init__.pyi \
+        docs/reference/python/_api_index.md \
+        docs/llms*.txt \
+        python/<your binding header> \
+        node/src/<your binding header> \
+        node/index.d.ts \
+        tools/codegen/binding_parity.yaml \
+        tests/<your test>.cpp
+```
+
+Don't `git add -A` — `analysis/` and `build*/` are gitignored but other untracked artifacts (screenshots, scratch notes) might be present and shouldn't go in the commit.
+
+## CI
+
+If everything above passes locally, CI will pass too — the same scripts run there. The fast-fail pipeline ([ci-pipeline.md](ci-pipeline.md)) runs `format-check` and `verify-docs-current` before the OS build matrix, so if you forgot to regenerate something the failure surfaces in ~30 seconds.

--- a/docs/contributors/architecture-overview.md
+++ b/docs/contributors/architecture-overview.md
@@ -1,0 +1,82 @@
+# Binding Architecture Overview
+
+How FLOX exposes a single C++ engine to Python, Node.js, Codon, and QuickJS — and why each path is shaped the way it is.
+
+## Layers
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  C++ engine (src/, include/flox/) — the authoritative implementation │
+└─────────────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ thin C ABI wrapper (src/capi/flox_capi.cpp)
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  C ABI surface (include/flox/capi/flox_capi.h)                       │
+│  • declared in IDL spec (flox_capi_spec.hpp)                         │
+│  • frozen via .api/c-api.snapshot                                    │
+│  • 328+ functions, opaque handles, raw fixed-point integers          │
+└─────────────────────────────────────────────────────────────────────┘
+              │             │             │             │
+              ▼             ▼             ▼             ▼
+        ┌─────────┐   ┌─────────┐   ┌─────────┐   ┌─────────┐
+        │ pybind11│   │  NAPI   │   │  Codon  │   │ QuickJS │
+        │ python/ │   │  node/  │   │ codon/  │   │ quickjs/│
+        └─────────┘   └─────────┘   └─────────┘   └─────────┘
+        idiomatic     idiomatic     auto-gen      auto-gen
+        Python        Node.js       Codon FFI     JS bindings
+```
+
+## Why this layout (not "C ABI all the way")
+
+A reasonable question: "why not generate every binding from the C ABI? Single source of truth, bindings come for free."
+
+Two reasons it isn't done:
+
+**Performance.** Python's [pybind11](https://pybind11.readthedocs.io/) gives numpy zero-copy via the [buffer protocol](https://docs.python.org/3/c-api/buffer.html) — bar arrays, indicator outputs, position equity curves cross C++↔Python without copying. A pure C ABI binding via cffi/ctypes requires either a copy or hand-rolled `ctypes.c_double * N` machinery, costing 20–40% on hot paths (large backtests, tick data ingestion). FLOX is a high-frequency trading framework; we don't trade that.
+
+Same logic applies to NAPI: native async / `Promise` / `Worker` patterns are ergonomic in Node and slow to fake from `node-ffi` / `koffi`.
+
+**Idiom.** Python users expect context managers, native exception hierarchies, type hints in their editor. Node users expect TypedArrays, `class extends`, Promise-based APIs. Auto-generating those from a C-shaped IR produces "C with a Python accent" — works, but every line of user code has to bend around the C ABI's choices instead of the language's.
+
+**Decision:** every binding is shaped to its language. The C ABI exists so Codon / QuickJS / future-Rust / future-Go can be wired up with codegen, while pybind11 / NAPI stay hand-written with idiom freedom.
+
+## Per-binding paths
+
+### pybind11 (`python/`)
+
+- Wraps **C ABI handles**, not C++ classes directly. `python/strategy_bindings.h` calls `flox_runner_create`, `flox_runner_add_strategy`, etc. — same surface Codon and QuickJS see.
+- One exception: `PyBacktestRunner` wraps `flox::BacktestRunner` (C++) directly. It predates the C ABI on that surface; the hook setters work around it via `cxx_adapters` in `python/hook_bindings.h` that implement `flox::IOrderExecutor` / `IOrderExecutionListener` rather than going through C ABI handles. Subject to migration once the C ABI replay-source path covers OHLCV / CSV.
+- `.pyi` stubs auto-generated from the live module by `scripts/gen_pyi_stubs.py`. Type checkers and AI agents see the full typed surface.
+
+### NAPI (`node/`)
+
+- All wrappers go through C ABI handles (`FloxRunnerHandle`, `FloxBacktestRunnerHandle`, etc.) — `node/src/strategy.h`, `backtest.h`, `engine.h`.
+- TypeScript declarations hand-written in `node/index.d.ts`. CI verifies declared exports match the C++ binding (`scripts/check_dts_exports.py`) and that `tsc --noEmit` passes (`node/test/test_types.ts`).
+
+### Codon (`codon/`, `tools/codegen/golden/flox_capi.codon`)
+
+- 100% generated from the IDL spec by `tools/codegen/flox_codegen/emit_codon.py`. Each `FLOX_EXPORT(...)` becomes a `from C import ...` declaration.
+- Strategy / backtest examples in `codon/flox/` consume the golden file via re-export.
+
+### QuickJS (`src/quickjs/`)
+
+- Hand-written bindings in `js_bindings.cpp` / `js_strategy.cpp`, all going through C ABI. Used for the embedded JS runner; not the same module as NAPI.
+
+## Build / packaging
+
+| Binding   | Build mechanism                         | Distributed as                    |
+|-----------|-----------------------------------------|-----------------------------------|
+| pybind11  | CMake target `_flox_py` via pybind11    | Wheel on PyPI (`flox-py`)         |
+| NAPI      | `cmake-js` via `node/CMakeLists.txt`    | npm package (`@flox-foundation/flox`) |
+| Codon    | Codon compiler emits native binaries     | Linked against `libflox_capi.so`  |
+| QuickJS   | CMake target `flox_js_runner`           | In-tree binary                    |
+
+The C++ engine and C ABI compile into `libflox_capi.so` (Linux) / `.dylib` (macOS) / `.dll` (Windows). All binding modules link against it.
+
+## Where to look next
+
+- **Adding a new C ABI export** end-to-end: see [adding-a-c-api-export.md](adding-a-c-api-export.md).
+- **Adding an extension hook** (PnLTracker / Executor / etc.): see [extension-hook-pattern.md](extension-hook-pattern.md).
+- **Cross-binding coverage gate** (catches "I forgot to wire pybind11 / NAPI"): see [parity-gate.md](parity-gate.md).
+- **CI pipeline** (fast-fail, docs sync chain): see [ci-pipeline.md](ci-pipeline.md).

--- a/docs/contributors/binding-architecture-rfc.md
+++ b/docs/contributors/binding-architecture-rfc.md
@@ -1,0 +1,161 @@
+# RFC: Binding Architecture (Public Version)
+
+The "why" behind the C ABI / pybind11 / NAPI / Codon split. Adapted from the internal RFC; this is the public summary. If you're trying to land a change that conflicts with one of these decisions, please open an issue first.
+
+## Goal
+
+A single source of truth for the FLOX public API surface so that:
+
+- `flox_capi.h` is generated, not hand-edited.
+- Codon bindings are generated.
+- ABI snapshot diffing is mechanical.
+- Stub artifacts (`.pyi`, `.d.ts`, `llms.txt`, MCP context) stay in sync with the shipped surface.
+
+## Non-goals
+
+- Replacing the C++ engine with an IDL-defined API. **C++ is the authoritative implementation.** IDL describes only the **export surface**.
+- Auto-generating pybind11 / NAPI bindings (decision below — see "What is *not* generated").
+- Migrating LiveEngine consumers (CCXT, custom transports) under the IDL. Connectors and transports stay binding-owned.
+- Generating an RPC protocol. FLOX is in-process FFI, not network IPC. This rules out gRPC/protobuf-shaped IDLs.
+
+## Constraints (from the surface audit)
+
+The IDL must encode the conventions already present in the hand-written `flox_capi.h`:
+
+1. **Opaque handles** with explicit lifetime (`Flox<X>Handle` typedef + paired `_create` / `_destroy`).
+2. **Raw fixed-point convention** (`int64_t price_raw`, `int64_t qty_raw`, scaled by 1e8).
+3. **Out-parameters** in two flavours: single value (`uint8_t flox_book_best_bid(handle, double* out)`) and composite struct (`void flox_get_symbol_context(handle, uint32_t sym, FloxSymbolContext* out)`).
+4. **Pointer-out wrappers** (`*_p` variants) for runtimes that cannot consume structs by value (Codon / QuickJS).
+5. **Parallel arrays** for L2 books (`bid_prices[], bid_qtys[], n_bids, ...`) and similar shapes.
+6. **Sliced flat arrays** with header indices (book updates: `level_offset / bid_count / ask_count` slicing a single levels array).
+7. **`\0`-separated string lists** (`flox_segment_merge_full(input_paths, num_paths, ...)`).
+8. **Extension-hook callback bundles** — struct-of-fn-pointers + `user_data` (RiskManager, Executor, etc.) See [extension-hook-pattern.md](extension-hook-pattern.md).
+
+## Options considered
+
+### A — Hand-authored YAML / JSON IDL + custom codegen
+
+Write a separate schema file describing every export. Codegen consumes the schema, emits `flox_capi.h` and bindings.
+
+- **Pro:** language-neutral, expressive type system, no preprocessor gymnastics.
+- **Con:** schema drifts from C++ engine signatures because they're disconnected. Adding a new C++ method means updating *two* sources. High risk of stale schema.
+
+### B — libclang extraction from C++ headers
+
+Parse the C++ engine headers directly with libclang, treat declarations annotated `[[clang::annotate("flox_export")]]` as the export set.
+
+- **Pro:** zero schema duplication. Every export is defined exactly once, in C++.
+- **Con:** libclang version drift between developers. Needs a stable annotation convention. Templates and explicit instantiations are ambiguous.
+
+### C — Hybrid: annotated C++ headers + libclang extraction (chosen)
+
+Same as B, but the annotations live on a dedicated **spec header** (`include/flox/capi/flox_capi_spec.hpp`) — not on the C++ engine declarations. The spec header is the IDL; the engine header is implementation.
+
+- **Pro:** spec stays close to C, libclang parses it cheaply, conventions (handles, fixed-point, out-params) are encoded as macros (`FLOX_EXPORT(group = "...")`). No version drift between IDL and bindings — both come from the same parse.
+- **Pro:** the spec is C, so it's grep-able, IDE-friendly, and bindings authors can read it directly.
+- **Con:** still need to keep the spec aligned with the C++ engine surface. We accept this — it's the same friction as keeping a public API in sync with internal code.
+
+**Decision: Option C.** The spec header is `include/flox/capi/flox_capi_spec.hpp`. Tooling lives in `tools/codegen/`.
+
+## What *is* generated
+
+Out of the spec header, the codegen pipeline emits:
+
+- `include/flox/capi/flox_capi.h` (the live header bindings consume)
+- `tools/codegen/golden/flox_capi.{h,codon,md}` (golden reference + Codon FFI + Markdown)
+- `.api/c-api.snapshot` (signature snapshot for ABI gating)
+- `mcp/flox_mcp/data/c-api.snapshot` (data the flox-mcp server bundles)
+
+Run `bash tools/codegen/scripts/regenerate.sh` to rebuild all of those atomically. CI verifies they're in sync.
+
+## What is *not* generated (and why)
+
+**The pybind11 binding (`python/`) is hand-written.** It does **not** consume `flox_capi.h` directly. The pybind11 surface exposes Pythonic APIs (numpy arrays, context managers, kwargs, exception mapping) that intentionally don't mirror the C ABI 1:1. Auto-generating those from a C-API IR would mean either:
+
+1. Producing a parallel **second** Python module that wraps the C ABI, parallel to the existing pybind11 one — confusing duplication for users.
+2. Re-architecting the existing pybind11 binding to be C-API based — a massive refactor that would lose pybind11's idiomatic strengths (numpy buffer protocol for zero-copy, RAII, native exception hierarchy).
+
+Same logic for the NAPI binding (`node/`) — it wraps C++ classes / C ABI handles directly to surface idiomatic Node features (TypedArrays, async, JS object shapes).
+
+Neither path is worth the cost. **Performance specifically:** numpy zero-copy via the buffer protocol crosses C++↔Python without copies for bar arrays, indicator outputs, equity curves. A pure C-ABI binding via cffi/ctypes would cost 20–40% on hot paths — disqualifying for a high-frequency trading framework.
+
+`.pyi` stubs continue to be **derived** from the built pybind11 module via `scripts/gen_pyi_stubs.py` (in CI as a sync gate). That covers the AI-DX angle without forcing auto-generation of binding code.
+
+`.d.ts` is hand-written in `node/index.d.ts`. CI checks every NAPI export has a matching declaration via `scripts/check_dts_exports.py`. Same trade-off as `.pyi`.
+
+If a future use case appears for "C ABI from Python via ctypes" (e.g. for a binding-free dependency), an `emit_pyi_capi.py` emitter could produce a thin ctypes wrapper distinct from the pybind11 module. This is a future possibility, not in-flight work.
+
+## How the layers fit
+
+The diagram in [architecture-overview.md](architecture-overview.md) shows the runtime layout. From an IDL-spec-edit perspective:
+
+1. You edit `flox_capi_spec.hpp`.
+2. `regenerate.sh` derives `flox_capi.h`, the Codon golden file, the markdown reference, and the snapshots.
+3. You implement the C++ side in `src/capi/flox_capi.cpp`.
+4. You **hand-write** the pybind11 wrapper in `python/` and the NAPI wrapper in `node/src/`.
+5. The [parity gate](parity-gate.md) catches it if you forget steps 4.
+
+## Coverage instead of generation
+
+For pybind11 and NAPI, instead of generating, we use a manifest-based gate ([parity-gate.md](parity-gate.md)) that asserts every IDL group has the expected classes / functions in each binding. This is mechanical (catches "you forgot to wire pybind11") but doesn't constrain how the binding is written (you keep your numpy buffer protocol, your TypedArrays, your idiomatic exception types).
+
+It's a coarser check than auto-generation, but it's the right trade for a framework where binding ergonomics matter as much as the C++ engine itself.
+
+## Annotation convention
+
+Everywhere in the spec header:
+
+```cpp
+#if defined(__clang__) && __has_cpp_attribute(clang::annotate)
+#  define FLOX_EXPORT(...) [[clang::annotate("flox_export:" __VA_ARGS__)]]
+#else
+#  define FLOX_EXPORT(...)
+#endif
+```
+
+Usage:
+
+```cpp
+FLOX_EXPORT(group = "metrics")
+FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks cb);
+```
+
+Group strings are mandatory; they're how the parity gate knows which classes / functions belong together across bindings.
+
+## Generation pipeline
+
+```
+                   spec header (flox_capi_spec.hpp)
+                            │
+                            ▼
+                       libclang AST
+                            │   (Python bindings: clang.cindex)
+                            ▼
+              ┌─── extractor.py ────┐
+              │ - walk translation unit
+              │ - collect FLOX_EXPORT decls
+              │ - normalize types
+              │ - resolve handles
+              └────────┬────────────┘
+                       ▼
+                       IR (Python dataclass tree)
+                       │
+        ┌──────────────┼──────────────┬──────────────┬───────────────┐
+        ▼              ▼              ▼              ▼               ▼
+  emit_capi.py    emit_codon.py   emit_md.py    emit_snapshot.py   emit_mcp.py
+        │              │              │              │               │
+        ▼              ▼              ▼              ▼               ▼
+   flox_capi.h    flox_capi.codon flox_capi.md  c-api.snapshot   mcp/data/
+```
+
+Each emitter is independent and operates on the same IR. Adding a new auto-generated binding is one new emitter file, no schema edits.
+
+## Risks
+
+1. **libclang version drift.** The codegen locks to a specific libclang release (the one CI uses for clang-format / clang-tidy). Contributors running a wildly different version locally may produce slightly different output. Mitigation: regenerate-and-diff in CI rather than trust the developer's local toolchain — that's `codegen-check`.
+
+2. **Templates and explicit instantiation.** Annotating a template primary declaration is ambiguous. Convention: annotate the explicit instantiation that will be exported, or a thin non-template wrapper function.
+
+3. **Schema↔engine drift.** Since the IDL is a separate header (not the engine itself), it's possible to add a C++ method without exporting it. This is intentional — most engine internals aren't user-facing. The opposite drift (export listed in IDL but engine method removed) surfaces as a link error in `src/capi/flox_capi.cpp` at compile time.
+
+4. **Adding a binding-side hook without IDL.** Not possible: the [parity gate](parity-gate.md) requires every binding-exposed group to be declared in the IDL first.

--- a/docs/contributors/ci-pipeline.md
+++ b/docs/contributors/ci-pipeline.md
@@ -1,0 +1,122 @@
+# CI Pipeline
+
+Mental model for the CI workflow under [`.github/workflows/`](../../.github/workflows/) — what runs in what order, what fails fast, and what to regenerate locally before pushing.
+
+## Workflow shape
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  Quick gates (parallel, ~30s each)                                  │
+│                                                                     │
+│  ┌──────────────┐   ┌─────────────────────┐   ┌─────────────────┐  │
+│  │ format-check │   │ verify-docs-current │   │  codegen-check  │  │
+│  └──────────────┘   └─────────────────────┘   └─────────────────┘  │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                  needs: [format-check, verify-docs-current]
+                              │
+                              ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  OS build matrix (parallel, ~5–10 min each)                         │
+│                                                                     │
+│  ┌──────────┐ ┌───────────┐ ┌───────┐ ┌─────────────┐ ┌──────────┐ │
+│  │linux-gcc │ │linux-clang│ │ macos │ │windows-msvc │ │win-clang │ │
+│  └──────────┘ └───────────┘ └───────┘ └─────────────┘ └──────────┘ │
+│  ┌────────────────────┐ ┌────────────────────────┐                 │
+│  │sanitizers (address)│ │sanitizers (undefined)  │                 │
+│  └────────────────────┘ └────────────────────────┘                 │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+`codegen-check` runs in a separate workflow ([`codegen.yml`](../../.github/workflows/codegen.yml)) — it's not in the dependency chain because it's already fast (~30s) and runs in parallel.
+
+## Fast-fail wiring
+
+Two mechanisms keep the pipeline cheap on bad pushes:
+
+1. **`needs:` dependency.** Every OS build job in [`ci.yml`](../../.github/workflows/ci.yml) declares `needs: [format-check, verify-docs-current]`. If either quick gate fails, the multi-OS matrix is skipped — saving ~50 compute minutes (10 min × 5 jobs).
+2. **`concurrency.cancel-in-progress`.** A new push to the same branch / PR cancels the in-flight workflow run for that ref. No more "two builds racing on stale code".
+
+Both are at the workflow top:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-gcc:
+    needs: [format-check, verify-docs-current]
+    ...
+```
+
+## What runs in each gate
+
+### `format-check`
+
+Just `./scripts/check-format.sh` — runs `clang-format --dry-run -Werror` on every C/C++/header file. Ten seconds. Failures show the exact lines that differ from the configured style; fix is `clang-format -i <file>`.
+
+### `verify-docs-current`
+
+Runs eight checks in sequence (each takes <5s):
+
+| Step | What it does | If it fails |
+|------|--------------|-------------|
+| `gen_indicator_docs.py` | Indicator reference matches `registry.def` | Run `python3 scripts/gen_indicator_docs.py` |
+| `gen_llms_txt.py --check` | `docs/llms.txt` + `llms-full.txt` match `docs/` | Run `python3 scripts/gen_llms_txt.py` |
+| `check_dts_exports.py` | `node/index.d.ts` matches NAPI exports | Edit `.d.ts` to add/remove the listed names |
+| `check_binding_parity.py` | pybind11/NAPI/Codon coverage matches IDL | See [parity-gate.md](parity-gate.md) |
+| `check_error_codes.py` | Every error code has a doc page; pages aren't stale | Add the doc page or remove the unused code |
+| `gen_api_index.py --check` | `docs/reference/python/_api_index.md` matches `.pyi` | Run `python3 scripts/gen_api_index.py` |
+| `check_doc_snippets.py` | Doc snippets follow `--8<--` include pattern | Refactor inline snippets into includes |
+| `sync_mcp_data.py --check` | `mcp/flox_mcp/data/` matches source | Run `python3 scripts/sync_mcp_data.py` |
+| flox-mcp pytest | MCP server unit tests | Fix the broken test |
+
+### `codegen-check` (separate workflow)
+
+Re-runs the IDL→header/codon/markdown emitters and verifies the output matches what's committed. If you edited `flox_capi_spec.hpp` and forgot to re-run `regenerate.sh`, this fails.
+
+### OS build matrix
+
+Builds the full project (engine + C ABI + tests + benchmarks + Python + Node + Codon + QuickJS), runs `ctest`, runs all the integration tests, runs cross-binding parity tests (Python ↔ Node, same C++ math), and exercises example programs.
+
+## The docs sync chain (eight scripts, in order)
+
+The "verify-docs" gates each check that a generated artifact matches what's committed. Several of those artifacts depend on each other — regenerating one re-derives the next:
+
+```
+1. tools/codegen/scripts/regenerate.sh  → flox_capi.h, golden/, .api/, mcp data
+2. cmake --build build                  → libflox_capi + Python module
+3. scripts/gen_pyi_stubs.py             → .pyi from running pybind11
+4. scripts/gen_api_index.py             → docs/reference/python/_api_index.md from .pyi
+5. scripts/gen_llms_txt.py              → docs/llms.txt + llms-full.txt (embeds api_index)
+6. scripts/sync_mcp_data.py             → mcp/flox_mcp/data/ (handled by regenerate.sh, but run manually if you skipped step 1)
+7. scripts/gen_indicator_docs.py        → docs/reference/codon/indicators.md (only if you touched registry.def)
+8. python3 scripts/check_binding_parity.py  → manifests vs bindings
+```
+
+**Skipping any one of those usually means a CI failure that takes ~30s to detect**, but the order matters — `gen_llms_txt.py` reads `_api_index.md`, so regenerating `_api_index.md` after generating `llms-full.txt` leaves them out of sync.
+
+If you've touched the IDL spec or any pybind11/NAPI code, run them all in order before committing. If you've only touched a C++ engine internal that doesn't change the public surface, you don't need to.
+
+## What fails first (debugging guide)
+
+When CI is red, look at the topmost failed step:
+
+- **format-check fails** → run `clang-format -i` on the listed files
+- **codegen-check fails** → run `bash tools/codegen/scripts/regenerate.sh`
+- **verify-docs-current fails** → look at the specific step name; run the script it names
+- **OS build fails** → reproduce locally with the matching toolchain (most issues are platform-specific compile errors visible in the log)
+- **OS build but only on sanitizers** → the bug exists, sanitizers caught what regular tests missed; address it, don't disable the sanitizer
+
+The fast-fail wiring means if quick gates fail, build matrix is `SKIPPED` (gray, not red) — which is the design. If you see all build jobs gray and only one quick gate red, fix that gate; everything else will run on the next push.
+
+## Adding a new gate
+
+To add a new check that should block builds:
+
+1. Add a step under `verify-docs-current` (if it's a docs/sync check) or `format-check` (if it's a static check on source).
+2. Make sure the script exits non-zero on failure with a clear `::error::` annotation.
+3. Verify the build jobs already `needs: [format-check, verify-docs-current]` — they do — so failures will short-circuit the matrix automatically.
+
+If a check needs to run on every OS (e.g. exercising the platform-specific `.dylib` / `.dll`), put it in each OS build job instead. The fast-fail logic still applies — it won't even start if quick gates failed.

--- a/docs/contributors/extension-hook-pattern.md
+++ b/docs/contributors/extension-hook-pattern.md
@@ -1,0 +1,308 @@
+# Extension Hook Pattern
+
+How to add a binding-supplied callback hook to FLOX (PnLTracker, RiskManager, Executor, etc.) and wire it through every language binding.
+
+If you're consuming a hook (writing user code in Python or Node), see the binding API docs instead. This guide is for adding the *hook itself*.
+
+## What a hook is
+
+A hook is a struct of C function pointers that the engine invokes at a specific point. The binding-side code wraps a user-supplied class / object behind those pointers. As of today FLOX has nine hooks:
+
+| Hook                      | What it does                                                  | Group       |
+|---------------------------|----------------------------------------------------------------|-------------|
+| `PnLTracker`              | Observes every emitted signal, computes PnL                   | metrics     |
+| `StorageSink`             | Persists every emitted signal                                 | storage     |
+| `RiskManager`             | Pre-trade gate; can drop a signal                             | risk        |
+| `KillSwitch`              | Halts trading globally                                        | risk        |
+| `OrderValidator`          | Per-order validation                                          | risk        |
+| `MarketDataRecorderHook`  | Receives every trade/book update fed in                       | recorder    |
+| `ReplaySource`            | Custom event source for `BacktestRunner`                      | replay      |
+| `Executor`                | Replaces SimulatedExecutor with a real broker / paper-trading | execution   |
+| `ExecutionListener`       | Observes order lifecycle (fills / rejects / etc.)             | execution   |
+
+Plus `set_log_callback` (single function, not a class).
+
+## The four layers
+
+For each hook, four things exist in lock-step:
+
+```
+1. C ABI declaration (IDL → flox_capi.h)
+2. C++ implementation (src/capi/flox_capi.cpp)
+3. pybind11 wrapper (python/hook_bindings.h)
+4. NAPI wrapper (node/src/hooks.h)
+```
+
+If any one of those four is missing or out of sync, the [parity gate](parity-gate.md) catches it in CI.
+
+## Layer 1: IDL declaration
+
+In [`include/flox/capi/flox_capi_spec.hpp`](../../include/flox/capi/flox_capi_spec.hpp):
+
+```cpp
+typedef void (*FloxXxxOnEventFn)(void* user_data, const FloxSignal* sig);
+
+typedef struct {
+  FloxXxxOnEventFn on_event;
+  void* user_data;
+} FloxXxxCallbacks;
+
+typedef void* FloxXxxHandle;
+
+FLOX_EXPORT(group = "your_group_name")
+FloxXxxHandle flox_xxx_create(FloxXxxCallbacks cb);
+FLOX_EXPORT(group = "your_group_name")
+void flox_xxx_destroy(FloxXxxHandle xxx);
+```
+
+Plus a setter on `Runner` / `LiveEngine` / `BacktestRunner`:
+
+```cpp
+FLOX_EXPORT(group = "your_group_name")
+void flox_runner_set_xxx(FloxRunnerHandle runner, FloxXxxHandle xxx);
+```
+
+After editing the spec, run:
+
+```bash
+bash tools/codegen/scripts/regenerate.sh
+```
+
+This regenerates `flox_capi.h`, the Codon golden file, the Markdown reference, and the ABI snapshot.
+
+## Layer 2: C++ implementation
+
+In [`src/capi/flox_capi.cpp`](../../src/capi/flox_capi.cpp):
+
+```cpp
+struct FloxXxxImpl {
+  FloxXxxCallbacks cb;
+};
+
+FloxXxxHandle flox_xxx_create(FloxXxxCallbacks cb) {
+  return new FloxXxxImpl{cb};
+}
+void flox_xxx_destroy(FloxXxxHandle h) {
+  delete static_cast<FloxXxxImpl*>(h);
+}
+```
+
+Then **wire the hook into the place that fires it.** For a post-emission observer like PnLTracker, that means storing an atomic pointer on the signal handler and calling its `on_event` after the user callback. For a pre-trade gate like RiskManager, that means evaluating it inside `RunnerSignalHandler::onSignal` *before* the user callback. For an executor, that means routing emitted signals to it instead of `SimulatedExecutor`.
+
+The pattern for hot-swap atomic ownership:
+
+```cpp
+// On the consumer (RunnerSignalHandler / LiveEngineImpl):
+std::atomic<FloxXxxImpl*> _xxx{nullptr};
+
+void setXxx(FloxXxxImpl* x) noexcept {
+  _xxx.store(x, std::memory_order_release);
+}
+
+void onSomething(...) {
+  if (auto* x = _xxx.load(std::memory_order_acquire);
+      x != nullptr && x->cb.on_event != nullptr) {
+    x->cb.on_event(x->cb.user_data, &payload);
+  }
+}
+```
+
+Lifecycle (`on_start` / `on_stop`) follows the same hot-swap pattern, balanced against engine `start()` / `stop()` so attaching mid-run fires `on_start` immediately.
+
+## Layer 3: pybind11 wrapper
+
+In [`python/hook_bindings.h`](../../python/hook_bindings.h):
+
+```cpp
+class PyXxx {
+ public:
+  virtual ~PyXxx() = default;
+  virtual void on_event(const PySignal& /*sig*/) {}
+};
+
+class PyXxxTrampoline : public PyXxx {
+ public:
+  using PyXxx::PyXxx;
+  void on_event(const PySignal& sig) override {
+    PYBIND11_OVERRIDE(void, PyXxx, on_event, sig);
+  }
+};
+
+// C-ABI bridge: acquires GIL, swallows Python exceptions.
+inline void xxxOnEventBridge(void* ud, const FloxSignal* sig) {
+  auto* py = static_cast<PyXxx*>(ud);
+  invokeUnderGil([&] { py->on_event(pySignalFromC(sig)); });
+}
+
+// RAII over the C ABI handle.
+class PyXxxOwner {
+  std::shared_ptr<PyXxx> _delegate;
+  FloxXxxHandle _handle{nullptr};
+ public:
+  PyXxxOwner(std::shared_ptr<PyXxx> d) : _delegate(std::move(d)) {
+    FloxXxxCallbacks cb{};
+    cb.on_event = xxxOnEventBridge;
+    cb.user_data = _delegate.get();
+    _handle = flox_xxx_create(cb);
+  }
+  ~PyXxxOwner() { if (_handle) flox_xxx_destroy(_handle); }
+  FloxXxxHandle handle() const noexcept { return _handle; }
+};
+```
+
+Then add a `set_xxx` method to `PyStrategyRunner`, `PyLiveEngine`, `PyBacktestRunner` that owns the `PyXxxOwner` and calls the C-ABI setter.
+
+Register the class in `flox_py.cpp` (or in the registration block at the bottom of `strategy_bindings.h`):
+
+```cpp
+py::class_<PyXxx, PyXxxTrampoline, std::shared_ptr<PyXxx>>(m, "Xxx")
+    .def(py::init<>())
+    .def("on_event", &PyXxx::on_event, py::arg("signal"));
+```
+
+User code:
+
+```python
+class MyXxx(flox.Xxx):
+    def on_event(self, sig):
+        ...
+
+runner.set_xxx(MyXxx())
+```
+
+### Important rules
+
+1. **Acquire the GIL.** Use the `invokeUnderGil` helper. Live engine callbacks fire from C++ consumer threads where the GIL is *not* held.
+2. **Never propagate Python exceptions across the C ABI boundary.** The helper catches `py::error_already_set` and prints the traceback. Letting an exception unwind through C is undefined behaviour.
+3. **Hold a `shared_ptr` to the user object.** The Owner holds a non-owning C ABI handle; the user's Python class must outlive that handle. `std::shared_ptr<PyXxx>` propagates to pybind11's class registration.
+
+## Layer 4: NAPI wrapper
+
+In [`node/src/hooks.h`](../../node/src/hooks.h):
+
+```cpp
+struct XxxHost {
+  Napi::FunctionReference on_event_fn;
+  Napi::ThreadSafeFunction tsfn;
+  HookMode mode;
+  Napi::Env env;
+  FloxXxxHandle handle{nullptr};
+
+  XxxHost(Napi::Env env_, Napi::Object obj, HookMode m = HookMode::Sync)
+      : on_event_fn(takeFn(obj, "onEvent")), mode(m), env(env_) {
+    if (mode == HookMode::Threaded) {
+      auto noop = Napi::Function::New(env, [](const Napi::CallbackInfo&) {});
+      tsfn = Napi::ThreadSafeFunction::New(env, noop, "flox_xxx_cb", 0, 1);
+    }
+    FloxXxxCallbacks cb{};
+    cb.on_event = &XxxHost::onEventBridge;
+    cb.user_data = this;
+    handle = flox_xxx_create(cb);
+  }
+  ~XxxHost() {
+    if (handle) flox_xxx_destroy(handle);
+    if (mode == HookMode::Threaded) tsfn.Release();
+  }
+
+  static void onEventBridge(void* ud, const FloxSignal* sig) {
+    auto* self = static_cast<XxxHost*>(ud);
+    if (self->on_event_fn.IsEmpty()) return;
+    if (self->mode == HookMode::Sync) {
+      // We're already on the JS thread — direct call. The result is
+      // observable immediately on return from runner.onTrade etc.
+      self->on_event_fn.Call({signalToJs(self->env, sig)});
+      return;
+    }
+    // We're on a C++ consumer thread (LiveEngine). Queue via TSFN so
+    // the JS handler runs at the next Node event loop tick.
+    auto* copy = new FloxSignal(*sig);
+    self->tsfn.NonBlockingCall(copy, [self](Napi::Env env, Napi::Function, FloxSignal* s) {
+      self->on_event_fn.Call({signalToJs(env, s)});
+      delete s;
+    });
+  }
+};
+```
+
+Then add a `setXxx` method to `RunnerNode` / `BacktestRunnerNode` (`node/src/strategy.h`):
+
+```cpp
+Napi::Value setXxx(const Napi::CallbackInfo& info) {
+  auto env = info.Env();
+  if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined()) {
+    _xxx_host.reset();
+    flox_runner_set_xxx(_runner, nullptr);
+    return env.Undefined();
+  }
+  _xxx_host = std::make_unique<flox_node::XxxHost>(env, info[0].As<Napi::Object>());
+  flox_runner_set_xxx(_runner, _xxx_host->handle);
+  return env.Undefined();
+}
+```
+
+User code:
+
+```javascript
+runner.setXxx({
+  onEvent(sig) { ... }
+});
+```
+
+### Why two modes (Sync / Threaded)
+
+The synchronous Runner / BacktestRunner fires hooks from the JS thread (the same thread `runner.onTrade(...)` was called from). Going through `Napi::ThreadSafeFunction::NonBlockingCall` from there would queue the JS handler for *the next event loop tick* — meaning a test that does `runner.onTrade(...)` and then immediately checks `seen.length === 1` would see `0`, because the callback hasn't run yet.
+
+Direct `FunctionReference::Call` from the JS thread is what users actually want: the hook fires synchronously, and `await runner.something()` semantics are preserved.
+
+For LiveEngine (`threaded: true`), callbacks fire from a C++ Disruptor consumer thread. Touching V8 from there would crash. `ThreadSafeFunction` is mandatory.
+
+The `HookMode` flag picks the right path. Pre-trade gates (`RiskManager.allow`, `KillSwitch.check`, `OrderValidator.validate`) and `Executor.capabilities` are **Sync-only** — the engine reads the return value inline.
+
+## Layer 5: TypeScript declaration
+
+In [`node/index.d.ts`](../../node/index.d.ts), add an `interface` (not a `class`) for the user-supplied object:
+
+```typescript
+export interface Xxx {
+  onEvent?(signal: Signal): void;
+}
+```
+
+The parity gate accepts `interface` declarations as fulfilling the same role as a class.
+
+## Tests
+
+Mirror the existing patterns:
+
+- pybind11: [`python/tests/test_hooks.py`](../../python/tests/test_hooks.py)
+- NAPI: [`node/test/test_hooks.js`](../../node/test/test_hooks.js)
+
+A test should: subclass / instantiate the hook → attach to runner → fire a scenario → assert the callback ran the expected number of times with the expected payload.
+
+## Coverage gate
+
+Open [`tools/codegen/binding_parity.yaml`](../../tools/codegen/binding_parity.yaml) and add the new group with `required` status:
+
+```yaml
+your_group_name:
+  pybind11: { status: required, classes: [Xxx] }
+  napi: { status: required, classes: [Xxx] }  # interface name
+  codon: { status: required }
+```
+
+Run `python3 scripts/check_binding_parity.py` to verify.
+
+## Checklist
+
+- [ ] IDL spec updated, `regenerate.sh` ran clean
+- [ ] C++ impl wired into the right firing point
+- [ ] pybind11 trampoline + Owner + class registration + setter on Runner/Engine/BacktestRunner
+- [ ] NAPI Host (with Sync/Threaded modes) + setter on RunnerNode/BacktestRunnerNode
+- [ ] `node/index.d.ts` interface added
+- [ ] Tests on both pybind11 and NAPI sides
+- [ ] `binding_parity.yaml` updated to `required`
+- [ ] `scripts/check_binding_parity.py` passes
+- [ ] `scripts/check_dts_exports.py` passes
+- [ ] `scripts/gen_pyi_stubs.py --check` passes (regenerated `.pyi`)
+
+If all of the above pass locally, CI will be green.

--- a/docs/contributors/index.md
+++ b/docs/contributors/index.md
@@ -1,0 +1,27 @@
+# Contributor Guide
+
+Internal architecture and workflow documentation for people *changing* FLOX (not consuming it). User-facing API docs live elsewhere — start at the top of [docs/](../index.md).
+
+## Start here
+
+| If you want to... | Read |
+|---|---|
+| Understand how the bindings fit together | [architecture-overview.md](architecture-overview.md) |
+| Add a function to `flox_capi.h` | [adding-a-c-api-export.md](adding-a-c-api-export.md) |
+| Add a callback hook (PnLTracker / Executor / etc.) | [extension-hook-pattern.md](extension-hook-pattern.md) |
+| Understand the cross-binding coverage gate | [parity-gate.md](parity-gate.md) |
+| Debug CI / understand which scripts regenerate what | [ci-pipeline.md](ci-pipeline.md) |
+| Know *why* the architecture is what it is | [binding-architecture-rfc.md](binding-architecture-rfc.md) |
+
+## Mental model in one paragraph
+
+FLOX is a C++ engine wrapped by a stable C ABI. The C ABI is generated from an IDL spec (`flox_capi_spec.hpp`). Codon and QuickJS bindings are auto-generated from the same spec. Python (pybind11) and Node (NAPI) bindings are **hand-written** so they can use language-idiomatic features (numpy zero-copy, async/await, native exception types) that auto-generation would lose. A coverage gate (`scripts/check_binding_parity.py`) catches "I added a C ABI export but forgot the pybind11/NAPI wrapper" at PR review time. CI is structured fast-fail: cheap checks (format, docs sync, parity) run first; the multi-OS build matrix only starts if those pass.
+
+## When to update these docs
+
+- **Adding a new binding** (Rust, Go, Swift): update `architecture-overview.md` to describe the new layer; add per-binding rules to `parity-gate.md`.
+- **Changing the codegen pipeline**: update `binding-architecture-rfc.md` with the new emitter / IR change.
+- **Adding a doc-sync script**: add it to the docs sync chain in `ci-pipeline.md` and `adding-a-c-api-export.md`.
+- **Adding a new gate to CI**: document it under `ci-pipeline.md`'s "What runs in each gate" table.
+
+This is a small set of docs by design — we don't need formal ADRs for every implementation choice. If a decision is non-obvious enough to warrant explanation, it goes inline in the relevant guide above.

--- a/docs/contributors/parity-gate.md
+++ b/docs/contributors/parity-gate.md
@@ -1,0 +1,128 @@
+# Cross-Binding Parity Gate
+
+How `scripts/check_binding_parity.py` makes "I added a function to the C ABI but forgot the pybind11/NAPI wrapper" a CI failure instead of a silent gap that surfaces months later when a user complains.
+
+## The problem it solves
+
+The C ABI surface (`flox_capi.h`) grows whenever someone adds a `FLOX_EXPORT` to the IDL. Each binding (pybind11, NAPI, Codon) is supposed to expose that addition. Codon is auto-generated, so it's automatic. **pybind11 and NAPI are hand-written**, so they drift.
+
+Before this gate existed, the only way to notice a gap was for a Python or Node user to say "where's the `Executor` class?" — usually months after the C ABI shipped it. The gate catches it on the PR that introduces the drift.
+
+## How it works
+
+The script:
+
+1. **Parses the IDL** ([`include/flox/capi/flox_capi_spec.hpp`](../../include/flox/capi/flox_capi_spec.hpp)). Every `FLOX_EXPORT(group = "X")` declaration belongs to a named group.
+2. **Reads the manifest** ([`tools/codegen/binding_parity.yaml`](../../tools/codegen/binding_parity.yaml)). Each group has up to four entries: `pybind11`, `napi`, `codon`, `quickjs`.
+3. **Scans the bindings** for the symbols each entry promises.
+   - pybind11: parses `python/flox_py/_flox_py/__init__.pyi` for `class X:` and `def x(...):`
+   - NAPI: parses `node/index.d.ts` for `export class X` / `export interface X` / `export function x`
+   - Codon: checks the auto-generated `tools/codegen/golden/flox_capi.codon` for the group section
+4. **Fails loudly** if anything is missing.
+
+Run locally:
+
+```bash
+python3 scripts/check_binding_parity.py            # exit 1 on drift
+python3 scripts/check_binding_parity.py --verbose  # show every group, not just failures
+```
+
+Wired into CI as the "Verify cross-binding parity" step inside the `verify-docs-current` job.
+
+## Status values
+
+Each per-binding entry has one of three statuses:
+
+### `required`
+
+The binding **must** expose the listed symbols. List them under `classes` or `functions`:
+
+```yaml
+metrics:
+  pybind11: { status: required, classes: [PnLTracker] }
+  napi: { status: required, classes: [PnLTracker] }
+  codon: { status: required }
+```
+
+This is the default for every user-facing surface. If the listed class or function disappears, CI fails.
+
+### `not_applicable`
+
+This group is internal helpers and **never** intended for this binding. No symbol list:
+
+```yaml
+fixed_point:
+  pybind11: { status: not_applicable }   # exposed via Price.toDouble() on classes
+  napi: { status: not_applicable }
+  codon: { status: required }
+```
+
+Used for things like `pointer_out` (output-pointer helpers) or `validation` (input validation primitives) that wouldn't make sense as a Python class.
+
+### `allowlist`
+
+A **known gap**, with a `reason` string. The reason is mandatory — CI fails if it's empty or missing:
+
+```yaml
+your_group:
+  napi:
+    status: allowlist
+    reason: "stats functions exposed via Stats class methods; function-style not declared. Cosmetic gap; tracked under <issue>."
+```
+
+Use sparingly. The point of the gate is to surface gaps; allowlisting them just kicks the can. If a gap is intentional and stable, it should be `not_applicable` instead. If it's "we'll do this next sprint", that's `allowlist` — but link the tracker so it doesn't get forgotten.
+
+## Adding a new IDL group
+
+If you add `FLOX_EXPORT(group = "new_thing")` and don't update the YAML, CI says:
+
+```
+FAIL  new_thing  config  missing_yaml: add an entry to binding_parity.yaml
+```
+
+Add a stanza for the new group:
+
+```yaml
+new_thing:
+  pybind11: { status: required, classes: [NewThing] }
+  napi: { status: required, classes: [NewThing] }
+  codon: { status: required }
+```
+
+Then make sure the listed classes / functions actually exist on each side.
+
+## Removing a group
+
+If you delete the last `FLOX_EXPORT(group = "old_thing")` declaration, the gate notices the YAML still mentions it:
+
+```
+FAIL  old_thing  config  missing_in_binding: group `old_thing` not found in IDL spec; remove from yaml
+```
+
+Remove the YAML stanza in the same PR.
+
+## Why this is just a manifest, not auto-generation
+
+Reasonable question: "if you know which classes belong to which group, why not generate the bindings from that?"
+
+Two reasons:
+
+1. **The manifest knows the *names*, not the *shape*.** It can say "`Executor` should exist", but it can't generate the `submit / cancel / replace / submit_oco / capabilities` method signatures — those are codegen's job (and codegen is unsafe to run for pybind11/NAPI for [perf reasons](architecture-overview.md#why-this-layout-not-c-abi-all-the-way)).
+2. **Coverage ≠ correctness.** Even if `Executor` is named in `.pyi`, that doesn't mean the binding actually wires `flox_executor_*` correctly. Tests check correctness; the gate checks "did you remember to write the wrapper at all".
+
+So the gate is a coarse mechanical check: "does the symbol exist?". Tests cover the semantics. Together they catch most of what auto-generation would catch, without giving up idiomatic bindings.
+
+## Scope of the gate (what it doesn't catch)
+
+- Argument signature drift (pybind11 method takes `int` but C ABI takes `int64_t`). That's pybind11's responsibility at runtime.
+- Submodule-style exposure (`flox.targets.linear_slope` rather than top-level `flox.LinearSlope`). The gate only inspects top-level declarations. The `targets` group is `allowlist`'ed for this reason.
+- Behavioral parity (Python and Node returning different values for the same input). Cross-binding parity *tests* (`scripts/cross_binding_parity.py`) cover that.
+
+## Extending the gate
+
+The script is small (~280 lines, [scripts/check_binding_parity.py](../../scripts/check_binding_parity.py)). If you need a new check, add it there. Examples:
+
+- **QuickJS coverage.** Currently QuickJS is unchecked because its bindings live in `.cpp` and aren't easily introspectable. Could be added by parsing `JS_NewCFunction` calls in `src/quickjs/js_bindings.cpp`.
+- **Method-level checks.** Currently we check class presence; we could check that a class has specific methods (e.g. `Executor` must have `submit`, `cancel`, `replace`).
+
+Both would tighten the gate. Keep changes minimal — every false-positive case wastes contributor time.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,15 @@ nav:
       - Integration Flow: explanation/integration-flow.md
       - Indicators: explanation/indicators.md
 
+  - Contributing:
+      - contributors/index.md
+      - Binding architecture: contributors/architecture-overview.md
+      - Adding a C ABI export: contributors/adding-a-c-api-export.md
+      - Extension hook pattern: contributors/extension-hook-pattern.md
+      - Cross-binding parity gate: contributors/parity-gate.md
+      - CI pipeline: contributors/ci-pipeline.md
+      - Binding architecture RFC: contributors/binding-architecture-rfc.md
+
   - Errors:
       - errors/index.md
       - E_SYM_001 - Symbol is not registered: errors/E_SYM_001.md


### PR DESCRIPTION
## Summary

New `docs/contributors/` section: internal architecture docs for people *changing* FLOX. Covers the binding layout, the C ABI extension flow, the extension-hook pattern, the parity gate, and the CI pipeline. ~1050 lines across 7 pages.

Sample table of contents:

| Page | What it covers |
|---|---|
| index.md | Landing + quick nav |
| architecture-overview.md | Layered diagram (C++ / C ABI / pybind11 / NAPI / Codon / QuickJS); why each path is shaped the way it is |
| adding-a-c-api-export.md | Step-by-step: IDL → regenerate.sh → C++ impl → pybind11 → NAPI → docs sync → commit |
| extension-hook-pattern.md | How to add a callback hook end-to-end (4 layers + tests + parity flip) |
| parity-gate.md | binding_parity.yaml structure; when to use required / not_applicable / allowlist |
| ci-pipeline.md | Fast-fail wiring, concurrency cancel, the 8 docs sync scripts in order |
| binding-architecture-rfc.md | Public version of the codegen RFC: why pybind11/NAPI aren't auto-generated (numpy zero-copy, native async) |

## Why now

The hook system, parity gate, and fast-fail CI were built up rapidly across recent PRs. The patterns are non-obvious (Sync/Threaded NAPI hosts, pybind11 trampoline + GIL acquire, hot-swap atomic ownership, the docs sync chain) and are about to be forgotten — including by future Claude Code / Cursor sessions that need to extend them. This documents the load-bearing decisions while context is still fresh, rather than waiting for someone to reverse-engineer them six months from now.

The pages avoid formal ADRs / decision-log overhead — when a "why" is non-obvious, it lives inline in the relevant guide.

## Wiring

mkdocs.yml registers a new top-level "Contributing" section in the nav. docs/llms.txt and llms-full.txt regenerated to pick up the new pages.

## Test plan
- [x] All seven new pages render via mkdocs serve locally
- [x] scripts/check_doc_snippets.py passes (no inline-snippet violations)
- [x] scripts/check_binding_parity.py passes
- [x] scripts/gen_llms_txt.py --check passes
- [x] CI: 11 checks expected green