### PR TITLE
docs(nav): collapse Errors and Contributing into existing sections

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,19 +140,14 @@ nav:
       - Memory Model: explanation/memory-model.md
       - Integration Flow: explanation/integration-flow.md
       - Indicators: explanation/indicators.md
-
-  - Contributing:
-      - contributors/index.md
-      - Binding architecture: contributors/architecture-overview.md
-      - Adding a C ABI export: contributors/adding-a-c-api-export.md
-      - Extension hook pattern: contributors/extension-hook-pattern.md
-      - Cross-binding parity gate: contributors/parity-gate.md
-      - CI pipeline: contributors/ci-pipeline.md
-      - Binding architecture RFC: contributors/binding-architecture-rfc.md
-
-  - Errors:
-      - errors/index.md
-      - E_SYM_001 - Symbol is not registered: errors/E_SYM_001.md
+      - Contributing:
+          - contributors/index.md
+          - Binding architecture: contributors/architecture-overview.md
+          - Adding a C ABI export: contributors/adding-a-c-api-export.md
+          - Extension hook pattern: contributors/extension-hook-pattern.md
+          - Cross-binding parity gate: contributors/parity-gate.md
+          - CI pipeline: contributors/ci-pipeline.md
+          - Binding architecture RFC: contributors/binding-architecture-rfc.md
 
   - Reference:
       - reference/README.md
@@ -195,6 +190,9 @@ nav:
           - Tools: reference/quickjs/tools.md
           - Backtest & runtime: reference/quickjs/backtest.md
       - C API: reference/api/capi/flox_capi.md
+      - Errors:
+          - errors/index.md
+          - E_SYM_001 - Symbol is not registered: errors/E_SYM_001.md
       - Core (C++ internals):
           - reference/api/README.md
           - Common: reference/api/common.md


### PR DESCRIPTION
Top-level nav was getting wide (8 items). Moved:

- **Errors** → Reference > Errors (reference material; lives next to C API and binding references)
- **Contributing** → Explanation > Contributing (it's "why and how things work")

Top-level now: Home / Tutorials / Bindings / How-To / Explanation / Reference. Same content, fewer headings to scan.