### PR TITLE
feat(errors): migrate top-20 throw sites to FloxError

### DIFF
--- a/docs/.snippet-allowlist.txt
+++ b/docs/.snippet-allowlist.txt
@@ -22,6 +22,13 @@ docs/bindings/python.md        # multi-API overview
 # Error code reference — fix recipes shown across language tabs; runnable
 # end-to-end equivalents live in docs/examples/.
 docs/errors/E_SYM_001.md       # cross-language fix-recipe tabs
+# Other error pages use `=== "Python"` admonition tabs with indented
+# fences, which the snippet-lint regex doesn't see as top-level
+# inline blocks — no allowlist entry needed.
+# Pages with non-indented fences for cross-language fix recipes:
+docs/errors/E_KEY_001.md       # has plain ```python fence
+docs/errors/E_RUN_002.md       # has plain ```python fence
+docs/errors/E_DATA_001.md      # has plain ```python fence
 
 # Reference: Python — narrative API docs with inline snippets that mirror
 # the curated examples. The full alphabetical surface is in _api_index.md

--- a/docs/errors/E_ADF_001.md
+++ b/docs/errors/E_ADF_001.md
@@ -1,0 +1,29 @@
+---
+code: E_ADF_001
+title: ADF — invalid regression mode
+severity: error
+since: 0.5.7
+---
+
+# E_ADF_001 — ADF: invalid regression mode
+
+The Augmented Dickey-Fuller test received a `regression` argument that
+isn't one of the three supported modes:
+
+| Mode  | Regressors |
+|-------|-----------|
+| `"n"` | No constant, no trend |
+| `"c"` | Constant (drift) — default |
+| `"ct"`| Constant + linear trend |
+
+## How to fix
+
+=== "Python"
+    ```python
+    result = flox.adf(prices, max_lag=8, regression="c")
+    ```
+
+## Common causes
+
+- Passing a long form like `"constant"` instead of `"c"`.
+- Capitalisation: FLOX expects lowercase letters.

--- a/docs/errors/E_ADF_002.md
+++ b/docs/errors/E_ADF_002.md
@@ -1,0 +1,41 @@
+---
+code: E_ADF_002
+title: ADF — input too short
+severity: error
+since: 0.5.7
+---
+
+# E_ADF_002 — ADF: input too short
+
+The Augmented Dickey-Fuller test needs at least 4 observations, and
+typically more depending on `max_lag` and the regression mode. The
+input series didn't provide enough.
+
+## How to fix
+
+Use a longer input series or reduce `max_lag`:
+
+=== "Python"
+    ```python
+    # OK: enough data for max_lag=4 with constant regression
+    flox.adf(prices_500, max_lag=4, regression="c")
+
+    # Avoid:
+    # flox.adf(prices_5, max_lag=10, regression="ct")
+    # → too short for max_lag=10 + 2 trend regressors
+    ```
+
+The minimum required length is approximately:
+
+```
+n_required = max_lag + n_regressors + 2
+n_regressors = 1 (the lagged-level term)
+             + (1 if regression in {"c", "ct"})
+             + (1 if regression == "ct")
+```
+
+## Common causes
+
+- Stationarity test on a per-day window of intraday returns where the
+  window is too small.
+- Forgetting that `max_lag` consumes observations from the front.

--- a/docs/errors/E_ADF_003.md
+++ b/docs/errors/E_ADF_003.md
@@ -1,0 +1,34 @@
+---
+code: E_ADF_003
+title: ADF — NaN in input
+severity: error
+since: 0.5.7
+---
+
+# E_ADF_003 — ADF: NaN in input
+
+The input series contains `NaN` values. ADF can't compute over missing
+data; the result would be undefined.
+
+## How to fix
+
+Drop or fill NaN values before testing:
+
+=== "Python"
+    ```python
+    import numpy as np
+
+    clean = prices[~np.isnan(prices)]
+    result = flox.adf(clean, max_lag=8, regression="c")
+
+    # Or, if you need same-length output (e.g. rolling test):
+    filled = np.where(np.isnan(prices), 0.0, prices)
+    ```
+
+## Common causes
+
+- Indicator outputs producing leading NaNs (e.g. SMA's first `period-1`
+  values).
+- Returns computed via `prices[1:] - prices[:-1]` followed by reattaching
+  to the original index, leaving NaN at position 0.
+- Joins / merges that left unmatched rows.

--- a/docs/errors/E_ADF_004.md
+++ b/docs/errors/E_ADF_004.md
@@ -1,0 +1,35 @@
+---
+code: E_ADF_004
+title: ADF — singular / degenerate regression
+severity: error
+since: 0.5.7
+---
+
+# E_ADF_004 — ADF: singular / degenerate regression
+
+The ADF regression matrix is numerically singular — one or more
+regressors are linearly dependent. This usually means the input series
+is constant, near-constant, or otherwise lacks variation.
+
+## How to fix
+
+Check the input variance and the lag specification:
+
+=== "Python"
+    ```python
+    import numpy as np
+
+    print(f"variance: {np.var(prices)}")
+    print(f"unique values: {len(np.unique(prices))}")
+
+    # Reduce lag count if the series is short relative to max_lag.
+    result = flox.adf(prices, max_lag=4, regression="c")
+    ```
+
+## Common causes
+
+- The series is constant (`var == 0`) or near-constant after rounding.
+- The series has < N unique values where N is the regressor count.
+- `max_lag` is too large for the available variation.
+- Floating-point underflow in the augmented regression — try the same
+  series scaled (e.g. multiply by 1000 and re-test).

--- a/docs/errors/E_BACKTEST_001.md
+++ b/docs/errors/E_BACKTEST_001.md
@@ -1,0 +1,36 @@
+---
+code: E_BACKTEST_001
+title: Bar type unsupported by writer
+severity: error
+since: 0.5.7
+---
+
+# E_BACKTEST_001 — Bar type unsupported by writer
+
+`MmapBarWriter` only supports time-based bars. A non-time bar event
+(tick / volume / range / Renko / Heikin-Ashi) was passed.
+
+## How to fix
+
+Pre-aggregate to a time bar before writing:
+
+=== "Python"
+    ```python
+    # ✗ Won't work — tick bars can't be mmapped (variable-duration).
+    # writer = flox.MmapBarWriter("out/BTCUSDT")
+    # writer.on_bar(tick_bar)
+
+    # ✓ Aggregate to time first, then write.
+    time_bars = flox.aggregate_time_bars(
+        timestamps=ts, prices=px, quantities=qty, is_buy=is_buy,
+        interval_seconds=60,
+    )
+    for bar in time_bars:
+        writer.on_bar(bar)
+    ```
+
+## Why
+
+The mmap format relies on a fixed bar duration to compute file offsets
+in O(1). Variable-duration bars (tick/volume/range/Renko) need a
+different storage layout — open an issue if you need that.

--- a/docs/errors/E_DATA_001.md
+++ b/docs/errors/E_DATA_001.md
@@ -1,0 +1,44 @@
+---
+code: E_DATA_001
+title: Bar data not found
+severity: error
+since: 0.5.7
+---
+
+# E_DATA_001 — Bar data not found
+
+`MmapBarStorage` couldn't find any `bars_*.bin` files in the symbol
+directory. Either the directory doesn't exist, or it exists but
+contains no recorded data.
+
+## How to fix
+
+Run a recorder over the dataset first:
+
+=== "Python"
+    ```python
+    import flox
+
+    rec = flox.MmapBarWriter("out/BTCUSDT")
+    rec.set_metadata({"exchange": "binance", "kind": "perpetual"})
+
+    for bar in your_data_source():
+        rec.on_bar(bar)
+    rec.flush()           # writes bars_60s.bin (or similar)
+    rec.write_metadata()
+    ```
+
+Then read it back:
+
+```python
+storage = flox.MmapBarStorage("out/BTCUSDT")
+```
+
+## Common causes
+
+- Pointing at the data root (`"out"`) instead of the per-symbol
+  subdirectory (`"out/BTCUSDT"`).
+- The recorder ran but `flush()` was never called — buffered bars never
+  hit disk.
+- The symbol directory was created (`MmapBarWriter` does this on init)
+  but no bars were ever written.

--- a/docs/errors/E_GRAPH_001.md
+++ b/docs/errors/E_GRAPH_001.md
@@ -1,0 +1,34 @@
+---
+code: E_GRAPH_001
+title: Unknown indicator graph node
+severity: error
+since: 0.5.7
+---
+
+# E_GRAPH_001 — Unknown indicator graph node
+
+The indicator pipeline asked for a node by name, but no node with that
+name has been registered. The error message includes the missing
+node name.
+
+## How to fix
+
+Register every node before requiring it:
+
+=== "Python"
+    ```python
+    from flox import IndicatorGraph
+
+    g = IndicatorGraph()
+    g.add_node("close", deps=[], fn=...)
+    g.add_node("ema_fast", deps=["close"], fn=lambda x: ema(x, 12))
+    g.add_node("ema_slow", deps=["close"], fn=lambda x: ema(x, 26))
+    g.add_node("macd", deps=["ema_fast", "ema_slow"], fn=...)
+    # macd → ema_fast → close — all required nodes exist
+    ```
+
+## Common causes
+
+- Typo in a `deps=[...]` list — case-sensitive.
+- Forgetting to register a feature column that the strategy uses.
+- Renaming a node and missing one of its dependents.

--- a/docs/errors/E_GRAPH_002.md
+++ b/docs/errors/E_GRAPH_002.md
@@ -1,0 +1,37 @@
+---
+code: E_GRAPH_002
+title: Circular dependency in indicator graph
+severity: error
+since: 0.5.7
+---
+
+# E_GRAPH_002 — Circular dependency in indicator graph
+
+The indicator pipeline detected that a node transitively depends on
+itself. The error message names the node that closed the cycle.
+
+## How to fix
+
+Trace the `deps=[...]` chain back to the cycle and break it. The
+indicator graph is a DAG — values only flow forward.
+
+=== "Python"
+    ```python
+    # ✗ cycle: a → b → c → a
+    g.add_node("a", deps=["c"], fn=...)
+    g.add_node("b", deps=["a"], fn=...)
+    g.add_node("c", deps=["b"], fn=...)
+
+    # ✓ fix: introduce a stateful "previous a" feature instead of
+    # making `c` literally depend on `a`.
+    g.add_node("a_prev", deps=[], fn=...)   # delayed copy
+    g.add_node("a",      deps=["c"], fn=...)
+    g.add_node("b",      deps=["a"], fn=...)
+    g.add_node("c",      deps=["a_prev", "b"], fn=...)
+    ```
+
+## Common causes
+
+- A feature was refactored to depend on its consumer (e.g. an EMA-of-EMA
+  setup that accidentally references the wrong input).
+- Two parallel chains were merged but the merge introduced a back-edge.

--- a/docs/errors/E_INPUT_001.md
+++ b/docs/errors/E_INPUT_001.md
@@ -1,0 +1,31 @@
+---
+code: E_INPUT_001
+title: Unknown compression type
+severity: error
+since: 0.5.7
+---
+
+# E_INPUT_001 — Unknown compression type
+
+A compression name passed to a recorder / writer is not one FLOX
+supports. Accepted values:
+
+| Value          | Effect |
+|----------------|--------|
+| `"none"` / `""` | No compression (default) |
+| `"lz4"`        | LZ4 frame compression |
+
+## How to fix
+
+=== "Python"
+    ```python
+    cfg = flox.RecordingConfig(
+        output_dir="out",
+        compression="lz4",        # or "none"
+    )
+    ```
+
+## Common causes
+
+- Typo: `"lz4hc"` / `"zstd"` / `"gzip"` — only `lz4` is currently
+  built in. Adding more compressors is a separate task.

--- a/docs/errors/E_IO_001.md
+++ b/docs/errors/E_IO_001.md
@@ -1,0 +1,36 @@
+---
+code: E_IO_001
+title: Cannot open file (read)
+severity: error
+since: 0.5.7
+---
+
+# E_IO_001 — Cannot open file (read)
+
+A read attempt on a file failed — the file doesn't exist, the path is
+wrong, or permissions don't allow reading.
+
+The error message includes the offending path. Print it to confirm.
+
+## How to fix
+
+=== "Python"
+    ```python
+    import os, flox
+
+    path = "data/BTCUSDT-2024.csv"
+    if not os.path.exists(path):
+        # Either fix the path or download the data first.
+        raise SystemExit(f"missing: {path}")
+
+    eng.run_csv("BTCUSDT", path)
+    ```
+
+## Common causes
+
+- Path is relative to the wrong working directory (`os.getcwd()` may not
+  be where you think it is — IDE / Jupyter / launcher all differ).
+- File doesn't exist yet (forgot to download, mount, or sync).
+- Read permission denied (file owned by another user / group).
+- Path uses backslashes on Windows that didn't escape in a Python literal
+  (`"C:\Users\..."` becomes `\U` escape — use `r"..."` or `/`).

--- a/docs/errors/E_IO_002.md
+++ b/docs/errors/E_IO_002.md
@@ -1,0 +1,34 @@
+---
+code: E_IO_002
+title: Cannot open file (write)
+severity: error
+since: 0.5.7
+---
+
+# E_IO_002 — Cannot open file (write)
+
+A write attempt on a file failed — the directory doesn't exist, the
+filesystem is read-only, the disk is full, or write permission is
+denied.
+
+## How to fix
+
+Check the destination directory:
+
+=== "Python"
+    ```python
+    import os
+    out_dir = "out/recordings"
+    os.makedirs(out_dir, exist_ok=True)        # create if missing
+
+    rec = flox.MmapBarWriter(out_dir + "/BTCUSDT")
+    ```
+
+## Common causes
+
+- Output directory missing — `MmapBarWriter` creates the symbol
+  directory but not its parent.
+- Disk full — `df -h` on the target volume.
+- Write permission denied (e.g. trying to write under `/usr` or
+  read-only mount).
+- Concurrent writer holding the file with an exclusive lock.

--- a/docs/errors/E_KEY_001.md
+++ b/docs/errors/E_KEY_001.md
@@ -1,0 +1,46 @@
+---
+code: E_KEY_001
+title: Required key missing
+severity: error
+since: 0.5.7
+---
+
+# E_KEY_001 — Required key missing
+
+A dict / object passed to a FLOX API was missing a required key. The
+error message names the missing key.
+
+## Where it fires
+
+- `Engine.load_ohlcv(d)` — expects `ts` (or `timestamp`), `open`,
+  `high`, `low`, `close`, `volume`.
+
+## How to fix
+
+=== "Python"
+    ```python
+    eng.load_ohlcv({
+        "ts":     ts_array,        # int64 ns timestamps
+        "open":   opens,
+        "high":   highs,
+        "low":    lows,
+        "close":  closes,
+        "volume": volumes,
+    }, symbol="BTCUSDT")
+    ```
+
+If your DataFrame uses different column names, rename them:
+
+```python
+df = df.rename(columns={"timestamp": "ts", "vol": "volume"})
+eng.load_ohlcv({k: df[k].to_numpy() for k in
+                ["ts", "open", "high", "low", "close", "volume"]},
+               symbol="BTCUSDT")
+```
+
+## Common causes
+
+- Source data uses `timestamp_ns` / `time` / `t` instead of `ts` —
+  rename before passing.
+- Volume series stored as `vol` — same fix.
+- Trying to load a tick stream into the OHLCV path.

--- a/docs/errors/E_LEN_001.md
+++ b/docs/errors/E_LEN_001.md
@@ -1,0 +1,49 @@
+---
+code: E_LEN_001
+title: Array length mismatch
+severity: error
+since: 0.5.7
+---
+
+# E_LEN_001 — Array length mismatch
+
+Two or more input arrays have different lengths but were expected to be
+parallel (i.e. each index represents the same time / row across all
+arrays). Common offenders: OHLCV bars where `high` / `low` / `close` /
+`volume` don't match `open`, or trade arrays where `prices` /
+`quantities` / `is_buy` don't match.
+
+## How to fix
+
+Pad / trim the arrays so they all share the same length, then re-pass
+to the API:
+
+=== "Python"
+    ```python
+    import numpy as np
+
+    # Make sure every array has the same length before passing.
+    n = min(len(opens), len(highs), len(lows), len(closes))
+    eng.load_ohlcv({
+        "ts": ts[:n],
+        "open": opens[:n],
+        "high": highs[:n],
+        "low": lows[:n],
+        "close": closes[:n],
+        "volume": volumes[:n],
+    }, symbol="BTCUSDT")
+    ```
+
+=== "Node.js"
+    ```js
+    const n = Math.min(opens.length, highs.length, lows.length, closes.length);
+    runner.runOhlcv(ts.slice(0, n), closes.slice(0, n), "BTC");
+    ```
+
+## Common causes
+
+- Forgetting that pandas `dropna()` operates per-column — re-run on the
+  full DataFrame, not on each Series individually.
+- Indicator computations producing shorter outputs than inputs (rolling
+  windows) — align with the input length before passing.
+- Concatenating data from sources that disagree on the calendar.

--- a/docs/errors/E_LEN_002.md
+++ b/docs/errors/E_LEN_002.md
@@ -1,0 +1,31 @@
+---
+code: E_LEN_002
+title: Empty input array
+severity: error
+since: 0.5.7
+---
+
+# E_LEN_002 — Empty input array
+
+A function received an empty array but needs at least one element.
+Statistics, bootstrap sampling, and indicator computations can't
+produce a value over zero observations.
+
+## How to fix
+
+Check the array length before calling, or filter out empty cases:
+
+=== "Python"
+    ```python
+    if len(returns) > 0:
+        ci = flox.bootstrap_ci(returns, confidence=0.95)
+    else:
+        ci = (float("nan"), float("nan"), float("nan"))
+    ```
+
+## Common causes
+
+- An aggregator pipeline produced no bars (e.g. trades all on the same
+  timestamp with sub-millisecond resolution lost to int64 conversion).
+- `dropna()` removed every row.
+- A symbol filter excluded all symbols.

--- a/docs/errors/E_RUN_001.md
+++ b/docs/errors/E_RUN_001.md
@@ -1,0 +1,35 @@
+---
+code: E_RUN_001
+title: Backtest run before set_strategy()
+severity: error
+since: 0.5.7
+---
+
+# E_RUN_001 — Backtest run before `set_strategy()`
+
+`BacktestRunner.run_*()` was called without first attaching a strategy
+via `set_strategy()`. The runner needs a strategy to know what to do
+with each bar.
+
+## How to fix
+
+=== "Python"
+    ```python
+    import flox
+
+    runner = flox.BacktestRunner(reg, fee_rate=0.001, initial_capital=10_000)
+    runner.set_strategy(MyStrategy())          # ← required first
+    runner.run_csv("data.csv")
+    ```
+
+=== "Node.js"
+    ```js
+    const runner = new flox.BacktestRunner(reg, 0.001, 10000);
+    runner.setStrategy({ /* ... */ });          // ← required first
+    runner.runCsv("data.csv", "BTC");
+    ```
+
+## Common causes
+
+- The strategy class was instantiated but never passed to `set_strategy()`.
+- Code was refactored and the `set_strategy()` call accidentally removed.

--- a/docs/errors/E_RUN_002.md
+++ b/docs/errors/E_RUN_002.md
@@ -1,0 +1,40 @@
+---
+code: E_RUN_002
+title: No data loaded
+severity: error
+since: 0.5.7
+---
+
+# E_RUN_002 — No data loaded
+
+`Engine.run()` was called but no market data has been loaded. Load
+OHLCV bars or trades before running.
+
+## How to fix
+
+=== "Python"
+    ```python
+    eng = flox.Engine()
+    eng.add_symbol("BTCUSDT")
+    eng.load_csv("BTCUSDT", "btc.csv")        # ← load first
+    eng.run(MyStrategy())
+    ```
+
+For OHLCV-from-arrays:
+
+```python
+eng.load_ohlcv({
+    "ts": ts_array,
+    "open": open_array,
+    "high": high_array,
+    "low": low_array,
+    "close": close_array,
+    "volume": volume_array,
+}, symbol="BTCUSDT")
+```
+
+## Common causes
+
+- The data-loading call was skipped (e.g. only the symbol was registered).
+- A typo in the symbol name caused `add_symbol("BTC")` and
+  `load_csv("BTCUSDT", ...)` to refer to different symbols.

--- a/docs/errors/E_TIME_001.md
+++ b/docs/errors/E_TIME_001.md
@@ -1,0 +1,36 @@
+---
+code: E_TIME_001
+title: Unknown interval unit
+severity: error
+since: 0.5.7
+---
+
+# E_TIME_001 — Unknown interval unit
+
+An interval string like `"5x"` was passed where the unit suffix is not
+recognised. FLOX accepts:
+
+| Unit | Meaning |
+|------|---------|
+| `s`  | seconds |
+| `m`  | minutes |
+| `h`  | hours   |
+| `d`  | days    |
+
+## How to fix
+
+=== "Python"
+    ```python
+    eng.resample("5m")          # 5 minutes — OK
+    eng.resample("1h")          # 1 hour — OK
+    eng.resample("15s")         # 15 seconds — OK
+    eng.resample("1d")          # 1 day — OK
+    # Not OK: "5min", "5 min", "1H", "five-minute"
+    ```
+
+## Common causes
+
+- Pandas-style suffixes (`"5min"`, `"1H"`) — FLOX uses single-character
+  units to avoid the `M` (month) / `m` (minute) ambiguity.
+- Whitespace in the string.
+- Empty unit (`"5"`) — always provide a unit.

--- a/include/flox/indicator/adf.h
+++ b/include/flox/indicator/adf.h
@@ -9,6 +9,8 @@
 #include <string>
 #include <vector>
 
+#include "flox/error/flox_error.h"
+
 namespace flox::indicator
 {
 
@@ -55,7 +57,9 @@ inline AdfRegression parseAdfRegression(const std::string& s)
   {
     return AdfRegression::ConstantTrend;
   }
-  throw std::invalid_argument("adf: regression must be one of: \"n\", \"c\", \"ct\"");
+  throw flox::FloxError(
+      "E_ADF_001",
+      "adf: regression must be one of \"n\", \"c\", or \"ct\".");
 }
 
 struct AdfResult
@@ -128,7 +132,9 @@ inline OlsFit olsFit(const std::vector<double>& X, size_t n, size_t k,
     }
     if (best < 1e-14)
     {
-      throw std::runtime_error("adf: singular regression matrix");
+      throw flox::FloxError(
+          "E_ADF_004",
+          "adf: singular regression matrix; input may be constant or degenerate.");
     }
     if (pivot != col)
     {
@@ -326,13 +332,17 @@ inline AdfResult adf(std::span<const double> x, size_t max_lag,
 {
   if (x.size() < 4)
   {
-    throw std::invalid_argument("adf: input too short (need at least 4 observations)");
+    throw flox::FloxError(
+        "E_ADF_002",
+        "adf: input too short; need at least 4 observations.");
   }
   for (double v : x)
   {
     if (std::isnan(v))
     {
-      throw std::invalid_argument("adf: input contains NaN");
+      throw flox::FloxError(
+          "E_ADF_003",
+          "adf: input array contains NaN values; clean the series before testing.");
     }
   }
 
@@ -370,7 +380,9 @@ inline AdfResult adf(std::span<const double> x, size_t max_lag,
 
   if (!found)
   {
-    throw std::invalid_argument("adf: input too short for the requested max_lag and regression");
+    throw flox::FloxError(
+        "E_ADF_002",
+        "adf: input too short for the requested max_lag and regression.");
   }
 
   // t-statistic for the y[t-1] coefficient.
@@ -378,7 +390,9 @@ inline AdfResult adf(std::span<const double> x, size_t max_lag,
   double sigma2 = bestFit.rss / static_cast<double>(bestFit.n - bestFit.k);
   if (sigma2 <= 0.0 || bestFit.covDiag[bestBetaIdx] <= 0.0)
   {
-    throw std::runtime_error("adf: degenerate regression");
+    throw flox::FloxError(
+        "E_ADF_004",
+        "adf: degenerate regression — input may be constant or numerically unstable.");
   }
   double se = std::sqrt(sigma2 * bestFit.covDiag[bestBetaIdx]);
   double tau = beta / se;

--- a/include/flox/indicator/indicator_pipeline.h
+++ b/include/flox/indicator/indicator_pipeline.h
@@ -12,6 +12,7 @@
 
 #include "flox/aggregator/bar.h"
 #include "flox/common.h"
+#include "flox/error/flox_error.h"
 
 namespace flox::indicator
 {
@@ -94,13 +95,19 @@ class IndicatorGraph
     auto nodeIt = _nodes.find(name);
     if (nodeIt == _nodes.end())
     {
-      throw std::logic_error("unknown node: " + name);
+      throw flox::FloxError(
+          "E_GRAPH_001",
+          "Indicator graph: unknown node '" + name +
+              "'. Make sure every dependency is added with add_node() before use.");
     }
 
     auto cycleKey = CacheKey{symbol, name};
     if (_computing.count(cycleKey))
     {
-      throw std::logic_error("circular dependency: " + name);
+      throw flox::FloxError(
+          "E_GRAPH_002",
+          "Indicator graph: circular dependency at '" + name +
+              "'. A node depends on itself transitively; break the cycle.");
     }
     _computing.insert(cycleKey);
 

--- a/mcp/flox_mcp/data/errors/E_ADF_001.md
+++ b/mcp/flox_mcp/data/errors/E_ADF_001.md
@@ -1,0 +1,29 @@
+---
+code: E_ADF_001
+title: ADF — invalid regression mode
+severity: error
+since: 0.5.7
+---
+
+# E_ADF_001 — ADF: invalid regression mode
+
+The Augmented Dickey-Fuller test received a `regression` argument that
+isn't one of the three supported modes:
+
+| Mode  | Regressors |
+|-------|-----------|
+| `"n"` | No constant, no trend |
+| `"c"` | Constant (drift) — default |
+| `"ct"`| Constant + linear trend |
+
+## How to fix
+
+=== "Python"
+    ```python
+    result = flox.adf(prices, max_lag=8, regression="c")
+    ```
+
+## Common causes
+
+- Passing a long form like `"constant"` instead of `"c"`.
+- Capitalisation: FLOX expects lowercase letters.

--- a/mcp/flox_mcp/data/errors/E_ADF_002.md
+++ b/mcp/flox_mcp/data/errors/E_ADF_002.md
@@ -1,0 +1,41 @@
+---
+code: E_ADF_002
+title: ADF — input too short
+severity: error
+since: 0.5.7
+---
+
+# E_ADF_002 — ADF: input too short
+
+The Augmented Dickey-Fuller test needs at least 4 observations, and
+typically more depending on `max_lag` and the regression mode. The
+input series didn't provide enough.
+
+## How to fix
+
+Use a longer input series or reduce `max_lag`:
+
+=== "Python"
+    ```python
+    # OK: enough data for max_lag=4 with constant regression
+    flox.adf(prices_500, max_lag=4, regression="c")
+
+    # Avoid:
+    # flox.adf(prices_5, max_lag=10, regression="ct")
+    # → too short for max_lag=10 + 2 trend regressors
+    ```
+
+The minimum required length is approximately:
+
+```
+n_required = max_lag + n_regressors + 2
+n_regressors = 1 (the lagged-level term)
+             + (1 if regression in {"c", "ct"})
+             + (1 if regression == "ct")
+```
+
+## Common causes
+
+- Stationarity test on a per-day window of intraday returns where the
+  window is too small.
+- Forgetting that `max_lag` consumes observations from the front.

--- a/mcp/flox_mcp/data/errors/E_ADF_003.md
+++ b/mcp/flox_mcp/data/errors/E_ADF_003.md
@@ -1,0 +1,34 @@
+---
+code: E_ADF_003
+title: ADF — NaN in input
+severity: error
+since: 0.5.7
+---
+
+# E_ADF_003 — ADF: NaN in input
+
+The input series contains `NaN` values. ADF can't compute over missing
+data; the result would be undefined.
+
+## How to fix
+
+Drop or fill NaN values before testing:
+
+=== "Python"
+    ```python
+    import numpy as np
+
+    clean = prices[~np.isnan(prices)]
+    result = flox.adf(clean, max_lag=8, regression="c")
+
+    # Or, if you need same-length output (e.g. rolling test):
+    filled = np.where(np.isnan(prices), 0.0, prices)
+    ```
+
+## Common causes
+
+- Indicator outputs producing leading NaNs (e.g. SMA's first `period-1`
+  values).
+- Returns computed via `prices[1:] - prices[:-1]` followed by reattaching
+  to the original index, leaving NaN at position 0.
+- Joins / merges that left unmatched rows.

--- a/mcp/flox_mcp/data/errors/E_ADF_004.md
+++ b/mcp/flox_mcp/data/errors/E_ADF_004.md
@@ -1,0 +1,35 @@
+---
+code: E_ADF_004
+title: ADF — singular / degenerate regression
+severity: error
+since: 0.5.7
+---
+
+# E_ADF_004 — ADF: singular / degenerate regression
+
+The ADF regression matrix is numerically singular — one or more
+regressors are linearly dependent. This usually means the input series
+is constant, near-constant, or otherwise lacks variation.
+
+## How to fix
+
+Check the input variance and the lag specification:
+
+=== "Python"
+    ```python
+    import numpy as np
+
+    print(f"variance: {np.var(prices)}")
+    print(f"unique values: {len(np.unique(prices))}")
+
+    # Reduce lag count if the series is short relative to max_lag.
+    result = flox.adf(prices, max_lag=4, regression="c")
+    ```
+
+## Common causes
+
+- The series is constant (`var == 0`) or near-constant after rounding.
+- The series has < N unique values where N is the regressor count.
+- `max_lag` is too large for the available variation.
+- Floating-point underflow in the augmented regression — try the same
+  series scaled (e.g. multiply by 1000 and re-test).

--- a/mcp/flox_mcp/data/errors/E_BACKTEST_001.md
+++ b/mcp/flox_mcp/data/errors/E_BACKTEST_001.md
@@ -1,0 +1,36 @@
+---
+code: E_BACKTEST_001
+title: Bar type unsupported by writer
+severity: error
+since: 0.5.7
+---
+
+# E_BACKTEST_001 — Bar type unsupported by writer
+
+`MmapBarWriter` only supports time-based bars. A non-time bar event
+(tick / volume / range / Renko / Heikin-Ashi) was passed.
+
+## How to fix
+
+Pre-aggregate to a time bar before writing:
+
+=== "Python"
+    ```python
+    # ✗ Won't work — tick bars can't be mmapped (variable-duration).
+    # writer = flox.MmapBarWriter("out/BTCUSDT")
+    # writer.on_bar(tick_bar)
+
+    # ✓ Aggregate to time first, then write.
+    time_bars = flox.aggregate_time_bars(
+        timestamps=ts, prices=px, quantities=qty, is_buy=is_buy,
+        interval_seconds=60,
+    )
+    for bar in time_bars:
+        writer.on_bar(bar)
+    ```
+
+## Why
+
+The mmap format relies on a fixed bar duration to compute file offsets
+in O(1). Variable-duration bars (tick/volume/range/Renko) need a
+different storage layout — open an issue if you need that.

--- a/mcp/flox_mcp/data/errors/E_DATA_001.md
+++ b/mcp/flox_mcp/data/errors/E_DATA_001.md
@@ -1,0 +1,44 @@
+---
+code: E_DATA_001
+title: Bar data not found
+severity: error
+since: 0.5.7
+---
+
+# E_DATA_001 — Bar data not found
+
+`MmapBarStorage` couldn't find any `bars_*.bin` files in the symbol
+directory. Either the directory doesn't exist, or it exists but
+contains no recorded data.
+
+## How to fix
+
+Run a recorder over the dataset first:
+
+=== "Python"
+    ```python
+    import flox
+
+    rec = flox.MmapBarWriter("out/BTCUSDT")
+    rec.set_metadata({"exchange": "binance", "kind": "perpetual"})
+
+    for bar in your_data_source():
+        rec.on_bar(bar)
+    rec.flush()           # writes bars_60s.bin (or similar)
+    rec.write_metadata()
+    ```
+
+Then read it back:
+
+```python
+storage = flox.MmapBarStorage("out/BTCUSDT")
+```
+
+## Common causes
+
+- Pointing at the data root (`"out"`) instead of the per-symbol
+  subdirectory (`"out/BTCUSDT"`).
+- The recorder ran but `flush()` was never called — buffered bars never
+  hit disk.
+- The symbol directory was created (`MmapBarWriter` does this on init)
+  but no bars were ever written.

--- a/mcp/flox_mcp/data/errors/E_GRAPH_001.md
+++ b/mcp/flox_mcp/data/errors/E_GRAPH_001.md
@@ -1,0 +1,34 @@
+---
+code: E_GRAPH_001
+title: Unknown indicator graph node
+severity: error
+since: 0.5.7
+---
+
+# E_GRAPH_001 — Unknown indicator graph node
+
+The indicator pipeline asked for a node by name, but no node with that
+name has been registered. The error message includes the missing
+node name.
+
+## How to fix
+
+Register every node before requiring it:
+
+=== "Python"
+    ```python
+    from flox import IndicatorGraph
+
+    g = IndicatorGraph()
+    g.add_node("close", deps=[], fn=...)
+    g.add_node("ema_fast", deps=["close"], fn=lambda x: ema(x, 12))
+    g.add_node("ema_slow", deps=["close"], fn=lambda x: ema(x, 26))
+    g.add_node("macd", deps=["ema_fast", "ema_slow"], fn=...)
+    # macd → ema_fast → close — all required nodes exist
+    ```
+
+## Common causes
+
+- Typo in a `deps=[...]` list — case-sensitive.
+- Forgetting to register a feature column that the strategy uses.
+- Renaming a node and missing one of its dependents.

--- a/mcp/flox_mcp/data/errors/E_GRAPH_002.md
+++ b/mcp/flox_mcp/data/errors/E_GRAPH_002.md
@@ -1,0 +1,37 @@
+---
+code: E_GRAPH_002
+title: Circular dependency in indicator graph
+severity: error
+since: 0.5.7
+---
+
+# E_GRAPH_002 — Circular dependency in indicator graph
+
+The indicator pipeline detected that a node transitively depends on
+itself. The error message names the node that closed the cycle.
+
+## How to fix
+
+Trace the `deps=[...]` chain back to the cycle and break it. The
+indicator graph is a DAG — values only flow forward.
+
+=== "Python"
+    ```python
+    # ✗ cycle: a → b → c → a
+    g.add_node("a", deps=["c"], fn=...)
+    g.add_node("b", deps=["a"], fn=...)
+    g.add_node("c", deps=["b"], fn=...)
+
+    # ✓ fix: introduce a stateful "previous a" feature instead of
+    # making `c` literally depend on `a`.
+    g.add_node("a_prev", deps=[], fn=...)   # delayed copy
+    g.add_node("a",      deps=["c"], fn=...)
+    g.add_node("b",      deps=["a"], fn=...)
+    g.add_node("c",      deps=["a_prev", "b"], fn=...)
+    ```
+
+## Common causes
+
+- A feature was refactored to depend on its consumer (e.g. an EMA-of-EMA
+  setup that accidentally references the wrong input).
+- Two parallel chains were merged but the merge introduced a back-edge.

--- a/mcp/flox_mcp/data/errors/E_INPUT_001.md
+++ b/mcp/flox_mcp/data/errors/E_INPUT_001.md
@@ -1,0 +1,31 @@
+---
+code: E_INPUT_001
+title: Unknown compression type
+severity: error
+since: 0.5.7
+---
+
+# E_INPUT_001 — Unknown compression type
+
+A compression name passed to a recorder / writer is not one FLOX
+supports. Accepted values:
+
+| Value          | Effect |
+|----------------|--------|
+| `"none"` / `""` | No compression (default) |
+| `"lz4"`        | LZ4 frame compression |
+
+## How to fix
+
+=== "Python"
+    ```python
+    cfg = flox.RecordingConfig(
+        output_dir="out",
+        compression="lz4",        # or "none"
+    )
+    ```
+
+## Common causes
+
+- Typo: `"lz4hc"` / `"zstd"` / `"gzip"` — only `lz4` is currently
+  built in. Adding more compressors is a separate task.

--- a/mcp/flox_mcp/data/errors/E_IO_001.md
+++ b/mcp/flox_mcp/data/errors/E_IO_001.md
@@ -1,0 +1,36 @@
+---
+code: E_IO_001
+title: Cannot open file (read)
+severity: error
+since: 0.5.7
+---
+
+# E_IO_001 — Cannot open file (read)
+
+A read attempt on a file failed — the file doesn't exist, the path is
+wrong, or permissions don't allow reading.
+
+The error message includes the offending path. Print it to confirm.
+
+## How to fix
+
+=== "Python"
+    ```python
+    import os, flox
+
+    path = "data/BTCUSDT-2024.csv"
+    if not os.path.exists(path):
+        # Either fix the path or download the data first.
+        raise SystemExit(f"missing: {path}")
+
+    eng.run_csv("BTCUSDT", path)
+    ```
+
+## Common causes
+
+- Path is relative to the wrong working directory (`os.getcwd()` may not
+  be where you think it is — IDE / Jupyter / launcher all differ).
+- File doesn't exist yet (forgot to download, mount, or sync).
+- Read permission denied (file owned by another user / group).
+- Path uses backslashes on Windows that didn't escape in a Python literal
+  (`"C:\Users\..."` becomes `\U` escape — use `r"..."` or `/`).

--- a/mcp/flox_mcp/data/errors/E_IO_002.md
+++ b/mcp/flox_mcp/data/errors/E_IO_002.md
@@ -1,0 +1,34 @@
+---
+code: E_IO_002
+title: Cannot open file (write)
+severity: error
+since: 0.5.7
+---
+
+# E_IO_002 — Cannot open file (write)
+
+A write attempt on a file failed — the directory doesn't exist, the
+filesystem is read-only, the disk is full, or write permission is
+denied.
+
+## How to fix
+
+Check the destination directory:
+
+=== "Python"
+    ```python
+    import os
+    out_dir = "out/recordings"
+    os.makedirs(out_dir, exist_ok=True)        # create if missing
+
+    rec = flox.MmapBarWriter(out_dir + "/BTCUSDT")
+    ```
+
+## Common causes
+
+- Output directory missing — `MmapBarWriter` creates the symbol
+  directory but not its parent.
+- Disk full — `df -h` on the target volume.
+- Write permission denied (e.g. trying to write under `/usr` or
+  read-only mount).
+- Concurrent writer holding the file with an exclusive lock.

--- a/mcp/flox_mcp/data/errors/E_KEY_001.md
+++ b/mcp/flox_mcp/data/errors/E_KEY_001.md
@@ -1,0 +1,46 @@
+---
+code: E_KEY_001
+title: Required key missing
+severity: error
+since: 0.5.7
+---
+
+# E_KEY_001 — Required key missing
+
+A dict / object passed to a FLOX API was missing a required key. The
+error message names the missing key.
+
+## Where it fires
+
+- `Engine.load_ohlcv(d)` — expects `ts` (or `timestamp`), `open`,
+  `high`, `low`, `close`, `volume`.
+
+## How to fix
+
+=== "Python"
+    ```python
+    eng.load_ohlcv({
+        "ts":     ts_array,        # int64 ns timestamps
+        "open":   opens,
+        "high":   highs,
+        "low":    lows,
+        "close":  closes,
+        "volume": volumes,
+    }, symbol="BTCUSDT")
+    ```
+
+If your DataFrame uses different column names, rename them:
+
+```python
+df = df.rename(columns={"timestamp": "ts", "vol": "volume"})
+eng.load_ohlcv({k: df[k].to_numpy() for k in
+                ["ts", "open", "high", "low", "close", "volume"]},
+               symbol="BTCUSDT")
+```
+
+## Common causes
+
+- Source data uses `timestamp_ns` / `time` / `t` instead of `ts` —
+  rename before passing.
+- Volume series stored as `vol` — same fix.
+- Trying to load a tick stream into the OHLCV path.

--- a/mcp/flox_mcp/data/errors/E_LEN_001.md
+++ b/mcp/flox_mcp/data/errors/E_LEN_001.md
@@ -1,0 +1,49 @@
+---
+code: E_LEN_001
+title: Array length mismatch
+severity: error
+since: 0.5.7
+---
+
+# E_LEN_001 — Array length mismatch
+
+Two or more input arrays have different lengths but were expected to be
+parallel (i.e. each index represents the same time / row across all
+arrays). Common offenders: OHLCV bars where `high` / `low` / `close` /
+`volume` don't match `open`, or trade arrays where `prices` /
+`quantities` / `is_buy` don't match.
+
+## How to fix
+
+Pad / trim the arrays so they all share the same length, then re-pass
+to the API:
+
+=== "Python"
+    ```python
+    import numpy as np
+
+    # Make sure every array has the same length before passing.
+    n = min(len(opens), len(highs), len(lows), len(closes))
+    eng.load_ohlcv({
+        "ts": ts[:n],
+        "open": opens[:n],
+        "high": highs[:n],
+        "low": lows[:n],
+        "close": closes[:n],
+        "volume": volumes[:n],
+    }, symbol="BTCUSDT")
+    ```
+
+=== "Node.js"
+    ```js
+    const n = Math.min(opens.length, highs.length, lows.length, closes.length);
+    runner.runOhlcv(ts.slice(0, n), closes.slice(0, n), "BTC");
+    ```
+
+## Common causes
+
+- Forgetting that pandas `dropna()` operates per-column — re-run on the
+  full DataFrame, not on each Series individually.
+- Indicator computations producing shorter outputs than inputs (rolling
+  windows) — align with the input length before passing.
+- Concatenating data from sources that disagree on the calendar.

--- a/mcp/flox_mcp/data/errors/E_LEN_002.md
+++ b/mcp/flox_mcp/data/errors/E_LEN_002.md
@@ -1,0 +1,31 @@
+---
+code: E_LEN_002
+title: Empty input array
+severity: error
+since: 0.5.7
+---
+
+# E_LEN_002 — Empty input array
+
+A function received an empty array but needs at least one element.
+Statistics, bootstrap sampling, and indicator computations can't
+produce a value over zero observations.
+
+## How to fix
+
+Check the array length before calling, or filter out empty cases:
+
+=== "Python"
+    ```python
+    if len(returns) > 0:
+        ci = flox.bootstrap_ci(returns, confidence=0.95)
+    else:
+        ci = (float("nan"), float("nan"), float("nan"))
+    ```
+
+## Common causes
+
+- An aggregator pipeline produced no bars (e.g. trades all on the same
+  timestamp with sub-millisecond resolution lost to int64 conversion).
+- `dropna()` removed every row.
+- A symbol filter excluded all symbols.

--- a/mcp/flox_mcp/data/errors/E_RUN_001.md
+++ b/mcp/flox_mcp/data/errors/E_RUN_001.md
@@ -1,0 +1,35 @@
+---
+code: E_RUN_001
+title: Backtest run before set_strategy()
+severity: error
+since: 0.5.7
+---
+
+# E_RUN_001 — Backtest run before `set_strategy()`
+
+`BacktestRunner.run_*()` was called without first attaching a strategy
+via `set_strategy()`. The runner needs a strategy to know what to do
+with each bar.
+
+## How to fix
+
+=== "Python"
+    ```python
+    import flox
+
+    runner = flox.BacktestRunner(reg, fee_rate=0.001, initial_capital=10_000)
+    runner.set_strategy(MyStrategy())          # ← required first
+    runner.run_csv("data.csv")
+    ```
+
+=== "Node.js"
+    ```js
+    const runner = new flox.BacktestRunner(reg, 0.001, 10000);
+    runner.setStrategy({ /* ... */ });          // ← required first
+    runner.runCsv("data.csv", "BTC");
+    ```
+
+## Common causes
+
+- The strategy class was instantiated but never passed to `set_strategy()`.
+- Code was refactored and the `set_strategy()` call accidentally removed.

--- a/mcp/flox_mcp/data/errors/E_RUN_002.md
+++ b/mcp/flox_mcp/data/errors/E_RUN_002.md
@@ -1,0 +1,40 @@
+---
+code: E_RUN_002
+title: No data loaded
+severity: error
+since: 0.5.7
+---
+
+# E_RUN_002 — No data loaded
+
+`Engine.run()` was called but no market data has been loaded. Load
+OHLCV bars or trades before running.
+
+## How to fix
+
+=== "Python"
+    ```python
+    eng = flox.Engine()
+    eng.add_symbol("BTCUSDT")
+    eng.load_csv("BTCUSDT", "btc.csv")        # ← load first
+    eng.run(MyStrategy())
+    ```
+
+For OHLCV-from-arrays:
+
+```python
+eng.load_ohlcv({
+    "ts": ts_array,
+    "open": open_array,
+    "high": high_array,
+    "low": low_array,
+    "close": close_array,
+    "volume": volume_array,
+}, symbol="BTCUSDT")
+```
+
+## Common causes
+
+- The data-loading call was skipped (e.g. only the symbol was registered).
+- A typo in the symbol name caused `add_symbol("BTC")` and
+  `load_csv("BTCUSDT", ...)` to refer to different symbols.

--- a/mcp/flox_mcp/data/errors/E_TIME_001.md
+++ b/mcp/flox_mcp/data/errors/E_TIME_001.md
@@ -1,0 +1,36 @@
+---
+code: E_TIME_001
+title: Unknown interval unit
+severity: error
+since: 0.5.7
+---
+
+# E_TIME_001 — Unknown interval unit
+
+An interval string like `"5x"` was passed where the unit suffix is not
+recognised. FLOX accepts:
+
+| Unit | Meaning |
+|------|---------|
+| `s`  | seconds |
+| `m`  | minutes |
+| `h`  | hours   |
+| `d`  | days    |
+
+## How to fix
+
+=== "Python"
+    ```python
+    eng.resample("5m")          # 5 minutes — OK
+    eng.resample("1h")          # 1 hour — OK
+    eng.resample("15s")         # 15 seconds — OK
+    eng.resample("1d")          # 1 day — OK
+    # Not OK: "5min", "5 min", "1H", "five-minute"
+    ```
+
+## Common causes
+
+- Pandas-style suffixes (`"5min"`, `"1H"`) — FLOX uses single-character
+  units to avoid the `M` (month) / `m` (minute) ambiguity.
+- Whitespace in the string.
+- Empty unit (`"5"`) — always provide a unit.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -192,7 +192,24 @@ nav:
       - C API: reference/api/capi/flox_capi.md
       - Errors:
           - errors/index.md
-          - E_SYM_001 - Symbol is not registered: errors/E_SYM_001.md
+          - "E_SYM_001 — Symbol is not registered": errors/E_SYM_001.md
+          - "E_RUN_001 — Backtest run before set_strategy()": errors/E_RUN_001.md
+          - "E_RUN_002 — No data loaded": errors/E_RUN_002.md
+          - "E_LEN_001 — Array length mismatch": errors/E_LEN_001.md
+          - "E_LEN_002 — Empty input array": errors/E_LEN_002.md
+          - "E_IO_001 — Cannot open file (read)": errors/E_IO_001.md
+          - "E_IO_002 — Cannot open file (write)": errors/E_IO_002.md
+          - "E_KEY_001 — Required key missing": errors/E_KEY_001.md
+          - "E_TIME_001 — Unknown interval unit": errors/E_TIME_001.md
+          - "E_INPUT_001 — Unknown compression type": errors/E_INPUT_001.md
+          - "E_GRAPH_001 — Unknown indicator graph node": errors/E_GRAPH_001.md
+          - "E_GRAPH_002 — Circular dependency in indicator graph": errors/E_GRAPH_002.md
+          - "E_ADF_001 — ADF: invalid regression mode": errors/E_ADF_001.md
+          - "E_ADF_002 — ADF: input too short": errors/E_ADF_002.md
+          - "E_ADF_003 — ADF: NaN in input": errors/E_ADF_003.md
+          - "E_ADF_004 — ADF: singular regression": errors/E_ADF_004.md
+          - "E_BACKTEST_001 — Bar type unsupported by writer": errors/E_BACKTEST_001.md
+          - "E_DATA_001 — Bar data not found": errors/E_DATA_001.md
       - Core (C++ internals):
           - reference/api/README.md
           - Common: reference/api/common.md

--- a/python/flox_py.cpp
+++ b/python/flox_py.cpp
@@ -71,7 +71,10 @@ static std::vector<OhlcvBar> parseCsv(const std::string& path)
   std::ifstream file(path);
   if (!file.is_open())
   {
-    throw std::runtime_error("cannot open: " + path);
+    throw flox::FloxError(
+        "E_IO_001",
+        "Cannot open file: '" + path +
+            "'. Check the path is correct and the file is readable.");
   }
 
   std::vector<OhlcvBar> bars;
@@ -337,7 +340,11 @@ class Engine
     {
       if (!d.contains(key))
       {
-        throw std::invalid_argument(std::string("missing key: ") + key);
+        throw flox::FloxError(
+            "E_KEY_001",
+            std::string("Required key '") + key +
+                "' is missing from the OHLCV dict. Expected keys: "
+                "'ts' (or 'timestamp'), 'open', 'high', 'low', 'close', 'volume'.");
       }
       return d[key].cast<contiguous_f64>();
     };
@@ -353,7 +360,10 @@ class Engine
     }
     if (timestamps.size() == 0)
     {
-      throw std::invalid_argument("missing key: ts or timestamp");
+      throw flox::FloxError(
+          "E_KEY_001",
+          "OHLCV dict is missing both 'ts' and 'timestamp' keys. "
+          "Provide one of them as an int64 array of nanosecond timestamps.");
     }
 
     std::string sym = symbol.empty() ? "default" : symbol;
@@ -555,7 +565,10 @@ class Engine
     {
       if (_insertOrder.empty())
       {
-        throw std::runtime_error("no data loaded");
+        throw flox::FloxError(
+            "E_RUN_002",
+            "No market data has been loaded into the engine. Call "
+            "Engine.load_csv(...) or load_ohlcv(...) before run().");
       }
       return _symbols.at(_insertOrder.front());
     }
@@ -631,7 +644,11 @@ class Engine
     {
       return val * 86'400'000'000'000LL;
     }
-    throw std::invalid_argument("unknown interval unit: " + unit);
+    throw flox::FloxError(
+        "E_TIME_001",
+        "Unknown interval unit '" + unit +
+            "'. Expected one of: 's', 'm', 'h', 'd' "
+            "(seconds, minutes, hours, days).");
   }
 
   BacktestConfig _config;

--- a/python/graph_bindings.h
+++ b/python/graph_bindings.h
@@ -2,7 +2,9 @@
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
+
 #include <pybind11/stl.h>
+#include "flox/error/flox_error.h"
 
 #include <cstring>
 #include <optional>
@@ -48,7 +50,9 @@ class PyIndicatorGraph
       auto b = high->request();
       if (static_cast<size_t>(b.shape[0]) != n)
       {
-        throw std::invalid_argument("set_bars: high must match close length");
+        throw flox::FloxError(
+            "E_LEN_001",
+            "set_bars: 'high' array must have the same length as 'close'.");
       }
       h = static_cast<const double*>(b.ptr);
     }
@@ -57,7 +61,9 @@ class PyIndicatorGraph
       auto b = low->request();
       if (static_cast<size_t>(b.shape[0]) != n)
       {
-        throw std::invalid_argument("set_bars: low must match close length");
+        throw flox::FloxError(
+            "E_LEN_001",
+            "set_bars: 'low' array must have the same length as 'close'.");
       }
       l = static_cast<const double*>(b.ptr);
     }
@@ -66,7 +72,9 @@ class PyIndicatorGraph
       auto b = volume->request();
       if (static_cast<size_t>(b.shape[0]) != n)
       {
-        throw std::invalid_argument("set_bars: volume must match close length");
+        throw flox::FloxError(
+            "E_LEN_001",
+            "set_bars: 'volume' array must have the same length as 'close'.");
       }
       v = static_cast<const double*>(b.ptr);
     }

--- a/python/indicator_bindings.h
+++ b/python/indicator_bindings.h
@@ -2,7 +2,9 @@
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
+
 #include <pybind11/stl.h>
+#include "flox/error/flox_error.h"
 
 #include <algorithm>
 #include <cmath>
@@ -45,7 +47,7 @@ inline void checkSameSize(size_t a, size_t b, const char* msg)
 {
   if (a != b)
   {
-    throw std::invalid_argument(msg);
+    throw flox::FloxError("E_LEN_001", msg);
   }
 }
 

--- a/python/optimizer_bindings.h
+++ b/python/optimizer_bindings.h
@@ -5,6 +5,8 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
+#include "flox/error/flox_error.h"
+
 #include <algorithm>
 #include <cmath>
 #include <numeric>
@@ -153,7 +155,9 @@ inline void bindOptimizer(py::module_& m)
       {
         if (x.size() != y.size())
         {
-          throw std::invalid_argument("x and y must have the same length");
+          throw flox::FloxError(
+              "E_LEN_001",
+              "x and y arrays must have the same length.");
         }
         auto* xp = x.data();
         auto* yp = y.data();
@@ -177,7 +181,9 @@ inline void bindOptimizer(py::module_& m)
         size_t n = data.size();
         if (n == 0)
         {
-          throw std::invalid_argument("data must not be empty");
+          throw flox::FloxError(
+              "E_LEN_002",
+              "Input array must not be empty.");
         }
 
         std::tuple<double, double, double> result;

--- a/python/profile_bindings.h
+++ b/python/profile_bindings.h
@@ -4,7 +4,9 @@
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
+
 #include <pybind11/stl.h>
+#include "flox/error/flox_error.h"
 
 #include <chrono>
 
@@ -49,7 +51,9 @@ class PyFootprintBar
     if (quantities.size() != static_cast<py::ssize_t>(n) ||
         isBuy.size() != static_cast<py::ssize_t>(n))
     {
-      throw std::invalid_argument("prices, quantities, and is_buy must have the same length");
+      throw flox::FloxError(
+          "E_LEN_001",
+          "prices, quantities, and is_buy arrays must have the same length.");
     }
 
     const auto* px = prices.data();
@@ -135,7 +139,9 @@ class PyVolumeProfile
     if (quantities.size() != static_cast<py::ssize_t>(n) ||
         isBuy.size() != static_cast<py::ssize_t>(n))
     {
-      throw std::invalid_argument("prices, quantities, and is_buy must have the same length");
+      throw flox::FloxError(
+          "E_LEN_001",
+          "prices, quantities, and is_buy arrays must have the same length.");
     }
 
     const auto* px = prices.data();
@@ -219,8 +225,9 @@ class PyMarketProfile
         quantities.size() != static_cast<py::ssize_t>(n) ||
         isBuy.size() != static_cast<py::ssize_t>(n))
     {
-      throw std::invalid_argument(
-          "timestamps, prices, quantities, and is_buy must have the same length");
+      throw flox::FloxError(
+          "E_LEN_001",
+          "timestamps, prices, quantities, and is_buy arrays must have the same length.");
     }
 
     const auto* ts = timestampsNs.data();

--- a/python/replay_bindings.h
+++ b/python/replay_bindings.h
@@ -4,7 +4,9 @@
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
+
 #include <pybind11/stl.h>
+#include "flox/error/flox_error.h"
 
 #include "flox/common.h"
 #include "flox/replay/binary_format_v1.h"
@@ -138,8 +140,10 @@ inline WriterConfig makeWriterConfig(const std::string& outputDir, uint64_t maxS
   }
   else
   {
-    throw std::invalid_argument("Unknown compression type: '" + compression +
-                                "' (expected 'none' or 'lz4')");
+    throw flox::FloxError(
+        "E_INPUT_001",
+        "Unknown compression type: '" + compression +
+            "'. Expected 'none' or 'lz4'.");
   }
 
   return cfg;
@@ -499,7 +503,9 @@ class PyDataWriter
         symbolIds.size() != static_cast<py::ssize_t>(n) ||
         sides.size() != static_cast<py::ssize_t>(n))
     {
-      throw std::invalid_argument("All arrays must have the same length");
+      throw flox::FloxError(
+          "E_LEN_001",
+          "All input arrays must have the same length.");
     }
 
     const auto* ets = exchangeTsNs.data();

--- a/python/strategy_bindings.h
+++ b/python/strategy_bindings.h
@@ -1418,14 +1418,20 @@ class PyBacktestRunner
   {
     if (!_host)
     {
-      throw std::runtime_error("call set_strategy() before run");
+      throw flox::FloxError(
+          "E_RUN_001",
+          "BacktestRunner.run_bars() called before set_strategy(). "
+          "Attach a strategy with set_strategy(MyStrategy()) first.");
     }
     std::string sym = symbol.empty() ? "default" : symbol;
     auto id = resolveSymbol(sym);
     const auto n = start_ns.size();
     if (end_ns.size() != n || open.size() != n || high.size() != n || low.size() != n || close.size() != n || volume.size() != n)
     {
-      throw std::invalid_argument("run_bars: all arrays must have the same length");
+      throw flox::FloxError(
+          "E_LEN_001",
+          "run_bars: all arrays (start_time_ns, end_time_ns, open, high, "
+          "low, close, volume) must have the same length.");
     }
     auto ps = start_ns.unchecked<1>();
     auto pe = end_ns.unchecked<1>();
@@ -1500,7 +1506,12 @@ class PyBacktestRunner
           return info.id;
         }
       }
-      throw std::invalid_argument("Symbol not registered: " + sym);
+      throw flox::FloxError(
+          "E_SYM_001",
+          "Symbol '" + sym +
+              "' is not registered. Register it via "
+              "BacktestRunner.set_strategy(...) or by calling "
+              "Engine.add_symbol() before running.");
     }
     return *opt;
   }
@@ -1509,7 +1520,10 @@ class PyBacktestRunner
   {
     if (!_host)
     {
-      throw std::runtime_error("call set_strategy() before run");
+      throw flox::FloxError(
+          "E_RUN_001",
+          "BacktestRunner.run_*() called before set_strategy(). "
+          "Attach a strategy with set_strategy(MyStrategy()) first.");
     }
     OhlcvBacktestReader reader(std::move(bars));
     BacktestResult result = _runner->run(reader);
@@ -1541,7 +1555,10 @@ class PyBacktestRunner
     std::ifstream f(path);
     if (!f.is_open())
     {
-      throw std::runtime_error("cannot open: " + path);
+      throw flox::FloxError(
+          "E_IO_001",
+          "Cannot open file: '" + path +
+              "'. Check the path is correct and the file is readable.");
     }
     std::vector<OhlcvBacktestReader::Bar> bars;
     std::string line;

--- a/src/backtest/mmap_bar_storage.cpp
+++ b/src/backtest/mmap_bar_storage.cpp
@@ -9,6 +9,8 @@
 
 #include "flox/backtest/mmap_bar_storage.h"
 
+#include "flox/error/flox_error.h"
+
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -29,7 +31,10 @@ MmapBarStorage::MmapBarStorage(const std::filesystem::path& symbolDir) : _symbol
 {
   if (!std::filesystem::exists(symbolDir))
   {
-    throw std::runtime_error("Symbol directory not found: " + symbolDir.string());
+    throw flox::FloxError(
+        "E_DATA_001",
+        "Symbol bar data directory not found: '" + symbolDir.string() +
+            "'. Run a recorder over the dataset first or check the data root.");
   }
 
   for (const auto& entry : std::filesystem::directory_iterator(symbolDir))
@@ -67,7 +72,10 @@ MmapBarStorage::MmapBarStorage(const std::filesystem::path& symbolDir) : _symbol
 
   if (_files.empty())
   {
-    throw std::runtime_error("No bars_*.bin files found in: " + symbolDir.string());
+    throw flox::FloxError(
+        "E_DATA_001",
+        "No bar files (bars_*.bin) found in: '" + symbolDir.string() +
+            "'. The directory exists but contains no time-based bar data.");
   }
 }
 

--- a/src/backtest/mmap_bar_writer.cpp
+++ b/src/backtest/mmap_bar_writer.cpp
@@ -9,6 +9,8 @@
 
 #include "flox/backtest/mmap_bar_writer.h"
 
+#include "flox/error/flox_error.h"
+
 #include <stdexcept>
 
 namespace flox
@@ -80,7 +82,10 @@ void MmapBarWriter::flush()
     std::ofstream outFile(filename, std::ios::binary | std::ios::trunc);
     if (!outFile)
     {
-      throw std::runtime_error("Failed to open file for writing: " + filename.string());
+      throw flox::FloxError(
+          "E_IO_002",
+          "Cannot open file for writing: '" + filename.string() +
+              "'. Check the directory exists and is writable.");
     }
 
     uint64_t count = existingBars.size();
@@ -127,7 +132,10 @@ void MmapBarWriter::writeBars(TimeframeId tf, std::span<const Bar> bars)
   std::ofstream outFile(filename, std::ios::binary | std::ios::trunc);
   if (!outFile)
   {
-    throw std::runtime_error("Failed to open file for writing: " + filename.string());
+    throw flox::FloxError(
+        "E_IO_002",
+        "Cannot open file for writing: '" + filename.string() +
+            "'. Check the directory exists and is writable.");
   }
 
   uint64_t count = bars.size();
@@ -139,7 +147,10 @@ std::filesystem::path MmapBarWriter::makeFilename(TimeframeId tf) const
 {
   if (tf.type != BarType::Time)
   {
-    throw std::runtime_error("MmapBarWriter currently only supports time-based bars");
+    throw flox::FloxError(
+        "E_BACKTEST_001",
+        "MmapBarWriter currently only supports time-based bars. "
+        "Aggregate to a fixed time interval before writing.");
   }
 
   auto seconds = tf.param / 1'000'000'000ULL;
@@ -175,7 +186,9 @@ void MmapBarWriter::writeMetadata()
 
   if (!file)
   {
-    throw std::runtime_error("Failed to open metadata file: " + metadataPath.string());
+    throw flox::FloxError(
+        "E_IO_002",
+        "Cannot open metadata file for writing: '" + metadataPath.string() + "'.");
   }
 
   for (const auto& [key, value] : _metadata)

--- a/tests/test_adf.cpp
+++ b/tests/test_adf.cpp
@@ -4,6 +4,7 @@
 #include <random>
 #include <vector>
 
+#include "flox/error/flox_error.h"
 #include "flox/indicator/adf.h"
 
 using namespace flox::indicator;
@@ -72,19 +73,19 @@ TEST(ADF, RegressionStringParse)
 TEST(ADF, InvalidRegressionThrows)
 {
   std::vector<double> y(20, 1.0);
-  EXPECT_THROW(adf(y, 1, std::string("xx")), std::invalid_argument);
+  EXPECT_THROW(adf(y, 1, std::string("xx")), flox::FloxError);
 }
 
 TEST(ADF, NaNInputThrows)
 {
   std::vector<double> y = {1.0, 2.0, std::nan(""), 4.0, 5.0};
-  EXPECT_THROW(adf(y, 1), std::invalid_argument);
+  EXPECT_THROW(adf(y, 1), flox::FloxError);
 }
 
 TEST(ADF, TooShortInputThrows)
 {
   std::vector<double> y = {1.0, 2.0, 3.0};
-  EXPECT_THROW(adf(y, 0), std::invalid_argument);
+  EXPECT_THROW(adf(y, 0), flox::FloxError);
 }
 
 TEST(ADF, ZeroLagWorks)

--- a/tests/test_indicators.cpp
+++ b/tests/test_indicators.cpp
@@ -25,6 +25,8 @@
 #include "flox/indicator/stochastic.h"
 #include "flox/indicator/vwap.h"
 
+#include "flox/error/flox_error.h"
+
 #include <gtest/gtest.h>
 #include <cmath>
 #include <vector>
@@ -727,7 +729,7 @@ TEST(IndicatorGraph, CircularDependencyThrows)
             { return std::vector<double>{}; });
   g.addNode("b", {"a"}, [](IndicatorGraph&, SymbolId)
             { return std::vector<double>{}; });
-  EXPECT_THROW(g.require(0, "a"), std::logic_error);
+  EXPECT_THROW(g.require(0, "a"), flox::FloxError);
 }
 
 TEST(IndicatorGraph, CacheInvalidation)


### PR DESCRIPTION
Adds 17 new structured error codes alongside the existing E_SYM_001, covering the most user-visible failure paths. Each code carries a stable identifier, a message naming the offending value, and a help URL pointing to a new errors page with cross-language fix recipes.

## Codes added

| Code | What |
|---|---|
| E_RUN_001 | Backtest run before set_strategy() |
| E_RUN_002 | No data loaded |
| E_LEN_001 | Array length mismatch |
| E_LEN_002 | Empty input array |
| E_IO_001  | Cannot open file (read) |
| E_IO_002  | Cannot open file (write) |
| E_KEY_001 | Required key missing |
| E_TIME_001 | Unknown interval unit |
| E_INPUT_001 | Unknown compression type |
| E_GRAPH_001 | Unknown indicator graph node |
| E_GRAPH_002 | Circular dependency in indicator graph |
| E_ADF_001 — E_ADF_004 | ADF input / regression errors |
| E_BACKTEST_001 | Bar type unsupported by writer |
| E_DATA_001 | Bar data not found |

## Migration sites

- pybind11: `flox_py.cpp`, `strategy_bindings.h`, `optimizer_bindings.h`, `profile_bindings.h`, `graph_bindings.h`, `replay_bindings.h`, `indicator_bindings.h`
- C++ engine: `indicator_pipeline.h`, `adf.h`, `mmap_bar_writer.cpp`, `mmap_bar_storage.cpp`

Internal mmap diagnostics (file-too-small, mmap failed) intentionally stay `std::runtime_error` — they're rare debugging output, not user-actionable.

## Tests

`tests/test_adf.cpp` + `tests/test_indicators.cpp` previously expected `std::invalid_argument` / `std::logic_error` and now expect `flox::FloxError`. The existing pybind11 exception translator surfaces these as `flox.FloxError` with `.code` / `.message` / `.help_url` to Python users.

## CI gate

`scripts/check_error_codes.py` verifies every code is referenced from source AND has a doc page (both directions). 18 codes documented, all referenced.

## Test plan
- [x] 56/56 ctests passing locally
- [x] check_error_codes: 18 codes, all referenced
- [x] check_doc_snippets: clean
- [x] check_binding_parity: clean
- [x] gen_pyi_stubs / gen_api_index / gen_llms_txt regenerated
- [ ] CI: 11 checks expected green

W2-T009