### PR TITLE
feat(node): cross-binding FloxError surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,10 @@ jobs:
       run: |
         cd node && node test/test_hooks.js
 
+    - name: Verify Node.js FloxError surface
+      run: |
+        cd node && node test/test_flox_error.js
+
     - name: Cross-binding parity (Python ↔ Node, same C++ math)
       run: PYTHONPATH=build/python python3 scripts/cross_binding_parity.py
 

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -7,6 +7,32 @@
 //   - node/test/test_types.ts        (signature-level: tsc --noEmit)
 // Both run in CI (linux-gcc job).
 
+// ── Errors ────────────────────────────────────────────────────────────
+
+/**
+ * Structured FLOX error. Thrown by Engine / BacktestRunner / etc. when
+ * a stable error code is appropriate. Compatible with `instanceof Error`.
+ *
+ * The `code` follows the convention `E_<DOMAIN>_<NNN>` (e.g. `E_IO_001`,
+ * `E_RUN_002`). The `helpUrl` points to the canonical fix-recipe page on
+ * the FLOX docs site.
+ *
+ * Example:
+ *
+ * ```js
+ * try {
+ *   engine.loadCsv("missing.csv", "BTC");
+ * } catch (e) {
+ *   if (e.code === "E_IO_001") console.log(`see ${e.helpUrl}`);
+ *   throw e;
+ * }
+ * ```
+ */
+export interface FloxError extends Error {
+  readonly code: string;
+  readonly helpUrl: string;
+}
+
 // ── Common types ──────────────────────────────────────────────────────
 
 /** Side of an order or trade. */

--- a/node/src/engine.h
+++ b/node/src/engine.h
@@ -7,6 +7,9 @@
 #include "flox/backtest/simulated_clock.h"
 #include "flox/backtest/simulated_executor.h"
 #include "flox/common.h"
+#include "flox/error/flox_error.h"
+
+#include "error_translator.h"
 
 #include <algorithm>
 #include <cctype>
@@ -66,7 +69,10 @@ inline std::vector<OhlcvBar> parseCsv(const std::string& path)
   std::ifstream file(path);
   if (!file.is_open())
   {
-    throw std::runtime_error("cannot open: " + path);
+    throw flox::FloxError(
+        "E_IO_001",
+        "Cannot open file: '" + path +
+            "'. Check the path is correct and the file is readable.");
   }
 
   std::vector<OhlcvBar> bars;
@@ -360,46 +366,57 @@ class EngineWrap : public Napi::ObjectWrap<EngineWrap>
     return buf;
   }
 
-  void LoadCsv(const Napi::CallbackInfo& info)
+  Napi::Value LoadCsv(const Napi::CallbackInfo& info)
   {
-    std::string path = info[0].As<Napi::String>().Utf8Value();
-    std::string sym = (info.Length() > 1 && info[1].IsString()) ? info[1].As<Napi::String>().Utf8Value() : inferSymbol(path);
-    getOrCreate(sym).bars = parseCsv(path);
+    return tryFlox(info.Env(), [&]() -> Napi::Value
+                   {
+      std::string path = info[0].As<Napi::String>().Utf8Value();
+      std::string sym = (info.Length() > 1 && info[1].IsString()) ? info[1].As<Napi::String>().Utf8Value() : inferSymbol(path);
+      getOrCreate(sym).bars = parseCsv(path);
+      return info.Env().Undefined(); });
   }
 
-  void LoadOhlcv(const Napi::CallbackInfo& info)
+  Napi::Value LoadOhlcv(const Napi::CallbackInfo& info)
   {
-    auto obj = info[0].As<Napi::Object>();
-    std::string sym = (info.Length() > 1 && info[1].IsString()) ? info[1].As<Napi::String>().Utf8Value() : "default";
-    auto ts = obj.Get("ts").As<Napi::Float64Array>();
-    auto op = obj.Get("open").As<Napi::Float64Array>();
-    auto hi = obj.Get("high").As<Napi::Float64Array>();
-    auto lo = obj.Get("low").As<Napi::Float64Array>();
-    auto cl = obj.Get("close").As<Napi::Float64Array>();
-    auto vo = obj.Get("volume").As<Napi::Float64Array>();
-    size_t n = ts.ElementLength();
-    auto& sd = getOrCreate(sym);
-    sd.bars.resize(n);
-    for (size_t i = 0; i < n; ++i)
-    {
-      sd.bars[i] = {normalizeTs(static_cast<int64_t>(ts[i])),
-                    Price::fromDouble(op[i]).raw(), Price::fromDouble(hi[i]).raw(),
-                    Price::fromDouble(lo[i]).raw(), Price::fromDouble(cl[i]).raw(),
-                    Volume::fromDouble(vo[i]).raw()};
-    }
+    return tryFlox(info.Env(), [&]() -> Napi::Value
+                   {
+      auto obj = info[0].As<Napi::Object>();
+      std::string sym = (info.Length() > 1 && info[1].IsString()) ? info[1].As<Napi::String>().Utf8Value() : "default";
+      auto ts = obj.Get("ts").As<Napi::Float64Array>();
+      auto op = obj.Get("open").As<Napi::Float64Array>();
+      auto hi = obj.Get("high").As<Napi::Float64Array>();
+      auto lo = obj.Get("low").As<Napi::Float64Array>();
+      auto cl = obj.Get("close").As<Napi::Float64Array>();
+      auto vo = obj.Get("volume").As<Napi::Float64Array>();
+      size_t n = ts.ElementLength();
+      auto& sd = getOrCreate(sym);
+      sd.bars.resize(n);
+      for (size_t i = 0; i < n; ++i)
+      {
+        sd.bars[i] = {normalizeTs(static_cast<int64_t>(ts[i])),
+                      Price::fromDouble(op[i]).raw(), Price::fromDouble(hi[i]).raw(),
+                      Price::fromDouble(lo[i]).raw(), Price::fromDouble(cl[i]).raw(),
+                      Volume::fromDouble(vo[i]).raw()};
+      }
+      return info.Env().Undefined(); });
   }
 
-  void Resample(const Napi::CallbackInfo& info)
+  Napi::Value Resample(const Napi::CallbackInfo& info)
   {
-    std::string src = info[0].As<Napi::String>().Utf8Value();
-    std::string dst = info[1].As<Napi::String>().Utf8Value();
-    std::string interval = info[2].As<Napi::String>().Utf8Value();
-    auto it = _syms.find(src);
-    if (it == _syms.end())
-    {
-      throw std::invalid_argument("unknown symbol: " + src);
-    }
-    getOrCreate(dst).bars = resampleBars(it->second.bars, parseInterval(interval));
+    return tryFlox(info.Env(), [&]() -> Napi::Value
+                   {
+      std::string src = info[0].As<Napi::String>().Utf8Value();
+      std::string dst = info[1].As<Napi::String>().Utf8Value();
+      std::string interval = info[2].As<Napi::String>().Utf8Value();
+      auto it = _syms.find(src);
+      if (it == _syms.end())
+      {
+        throw flox::FloxError(
+            "E_SYM_001",
+            "Symbol '" + src + "' is not loaded. Call loadCsv / loadOhlcv first.");
+      }
+      getOrCreate(dst).bars = resampleBars(it->second.bars, parseInterval(interval));
+      return info.Env().Undefined(); });
   }
 
   Napi::Value Run(const Napi::CallbackInfo& info)

--- a/node/src/error_translator.h
+++ b/node/src/error_translator.h
@@ -1,0 +1,61 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+// Translate flox::FloxError thrown from C++ engine code into a JavaScript
+// Error with `.code` / `.helpUrl` extra properties set on the instance.
+//
+// Usage at the boundary of a NAPI method that calls into FLOX:
+//
+//     Napi::Value myMethod(const Napi::CallbackInfo& info) {
+//       return node_flox::tryFlox(info.Env(), [&] {
+//         // ... call FLOX C++ that may throw FloxError ...
+//         return info.Env().Undefined();
+//       });
+//     }
+//
+// On FloxError: a JS Error is thrown with `.code` and `.helpUrl` set,
+// and the lambda's nominal return value is replaced with `env.Undefined()`.
+// On std::exception: a generic JS Error is thrown with the .what() text.
+// On success: the lambda's return value is returned unchanged.
+
+#pragma once
+
+#include <napi.h>
+
+#include "flox/error/flox_error.h"
+
+#include <exception>
+
+namespace node_flox
+{
+
+template <typename Fn>
+inline Napi::Value tryFlox(Napi::Env env, Fn fn)
+{
+  try
+  {
+    return fn();
+  }
+  catch (const flox::FloxError& e)
+  {
+    auto err = Napi::Error::New(env, e.message());
+    err.Value().Set("code", Napi::String::New(env, e.code()));
+    err.Value().Set("helpUrl", Napi::String::New(env, e.helpUrl()));
+    err.Value().Set("name", Napi::String::New(env, "FloxError"));
+    err.ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  catch (const std::exception& e)
+  {
+    Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+}
+
+}  // namespace node_flox

--- a/node/src/strategy.h
+++ b/node/src/strategy.h
@@ -4,6 +4,7 @@
 
 #include <napi.h>
 
+#include "error_translator.h"
 #include "flox/capi/bridge_strategy.h"
 #include "flox/capi/flox_capi.h"
 #include "flox/engine/symbol_registry.h"
@@ -874,34 +875,38 @@ class BacktestRunnerNode : public Napi::ObjectWrap<BacktestRunnerNode>
   // runner.runCsv(path, symbol) → stats object
   Napi::Value runCsv(const Napi::CallbackInfo& info)
   {
-    std::string path = info[0].As<Napi::String>().Utf8Value();
-    std::string symbol = info[1].As<Napi::String>().Utf8Value();
-    FloxBacktestStats s{};
-    int ok = flox_backtest_runner_run_csv(_handle, path.c_str(), symbol.c_str(), &s);
-    if (!ok)
-    {
-      return info.Env().Null();
-    }
-    return statsToJs(info.Env(), s);
+    return tryFlox(info.Env(), [&]() -> Napi::Value
+                   {
+      std::string path = info[0].As<Napi::String>().Utf8Value();
+      std::string symbol = info[1].As<Napi::String>().Utf8Value();
+      FloxBacktestStats s{};
+      int ok = flox_backtest_runner_run_csv(_handle, path.c_str(), symbol.c_str(), &s);
+      if (!ok)
+      {
+        return info.Env().Null();
+      }
+      return statsToJs(info.Env(), s); });
   }
 
   // runner.runOhlcv(tsArray, closeArray, symbol) → stats object
   Napi::Value runOhlcv(const Napi::CallbackInfo& info)
   {
-    auto tsArr = info[0].As<Napi::BigInt64Array>();
-    auto closeArr = info[1].As<Napi::Float64Array>();
-    std::string symbol = info[2].As<Napi::String>().Utf8Value();
-    uint32_t n = static_cast<uint32_t>(tsArr.ElementLength());
-    FloxBacktestStats s{};
-    int ok = flox_backtest_runner_run_ohlcv(_handle,
-                                            reinterpret_cast<const int64_t*>(tsArr.Data()),
-                                            closeArr.Data(),
-                                            n, symbol.c_str(), &s);
-    if (!ok)
-    {
-      return info.Env().Null();
-    }
-    return statsToJs(info.Env(), s);
+    return tryFlox(info.Env(), [&]() -> Napi::Value
+                   {
+      auto tsArr = info[0].As<Napi::BigInt64Array>();
+      auto closeArr = info[1].As<Napi::Float64Array>();
+      std::string symbol = info[2].As<Napi::String>().Utf8Value();
+      uint32_t n = static_cast<uint32_t>(tsArr.ElementLength());
+      FloxBacktestStats s{};
+      int ok = flox_backtest_runner_run_ohlcv(_handle,
+                                              reinterpret_cast<const int64_t*>(tsArr.Data()),
+                                              closeArr.Data(),
+                                              n, symbol.c_str(), &s);
+      if (!ok)
+      {
+        return info.Env().Null();
+      }
+      return statsToJs(info.Env(), s); });
   }
 
   // runner.runBars(startNs, endNs, open, high, low, close, volume,
@@ -909,31 +914,33 @@ class BacktestRunnerNode : public Napi::ObjectWrap<BacktestRunnerNode>
   // All arrays are typed (BigInt64Array for ts, Float64Array for OHLCV).
   Napi::Value runBars(const Napi::CallbackInfo& info)
   {
-    auto startNs = info[0].As<Napi::BigInt64Array>();
-    auto endNs = info[1].As<Napi::BigInt64Array>();
-    auto openA = info[2].As<Napi::Float64Array>();
-    auto highA = info[3].As<Napi::Float64Array>();
-    auto lowA = info[4].As<Napi::Float64Array>();
-    auto closeA = info[5].As<Napi::Float64Array>();
-    auto volA = info[6].As<Napi::Float64Array>();
-    std::string symbol = info[7].As<Napi::String>().Utf8Value();
-    uint8_t barType = info.Length() > 8 ? static_cast<uint8_t>(info[8].As<Napi::Number>().Uint32Value()) : 0;
-    uint64_t barTypeParam = info.Length() > 9
-                                ? static_cast<uint64_t>(info[9].As<Napi::Number>().Int64Value())
-                                : 0;
-    uint32_t n = static_cast<uint32_t>(startNs.ElementLength());
-    FloxBacktestStats s{};
-    int ok = flox_backtest_runner_run_bars(
-        _handle,
-        reinterpret_cast<const int64_t*>(startNs.Data()),
-        reinterpret_cast<const int64_t*>(endNs.Data()),
-        openA.Data(), highA.Data(), lowA.Data(), closeA.Data(), volA.Data(),
-        n, symbol.c_str(), barType, barTypeParam, &s);
-    if (!ok)
-    {
-      return info.Env().Null();
-    }
-    return statsToJs(info.Env(), s);
+    return tryFlox(info.Env(), [&]() -> Napi::Value
+                   {
+      auto startNs = info[0].As<Napi::BigInt64Array>();
+      auto endNs = info[1].As<Napi::BigInt64Array>();
+      auto openA = info[2].As<Napi::Float64Array>();
+      auto highA = info[3].As<Napi::Float64Array>();
+      auto lowA = info[4].As<Napi::Float64Array>();
+      auto closeA = info[5].As<Napi::Float64Array>();
+      auto volA = info[6].As<Napi::Float64Array>();
+      std::string symbol = info[7].As<Napi::String>().Utf8Value();
+      uint8_t barType = info.Length() > 8 ? static_cast<uint8_t>(info[8].As<Napi::Number>().Uint32Value()) : 0;
+      uint64_t barTypeParam = info.Length() > 9
+                                  ? static_cast<uint64_t>(info[9].As<Napi::Number>().Int64Value())
+                                  : 0;
+      uint32_t n = static_cast<uint32_t>(startNs.ElementLength());
+      FloxBacktestStats s{};
+      int ok = flox_backtest_runner_run_bars(
+          _handle,
+          reinterpret_cast<const int64_t*>(startNs.Data()),
+          reinterpret_cast<const int64_t*>(endNs.Data()),
+          openA.Data(), highA.Data(), lowA.Data(), closeA.Data(), volA.Data(),
+          n, symbol.c_str(), barType, barTypeParam, &s);
+      if (!ok)
+      {
+        return info.Env().Null();
+      }
+      return statsToJs(info.Env(), s); });
   }
 
   static Napi::Object statsToJs(Napi::Env env, const FloxBacktestStats& s)

--- a/node/test/test_flox_error.js
+++ b/node/test/test_flox_error.js
@@ -1,0 +1,67 @@
+'use strict';
+/**
+ * node/test/test_flox_error.js — verify that FloxError thrown from C++
+ * surfaces in Node.js with .code / .helpUrl set, and is `instanceof Error`.
+ *
+ * Run from repo root:
+ *   cd node && node test/test_flox_error.js
+ */
+
+const path = require('path');
+const flox = require(path.join(__dirname, '..'));
+
+let passed = 0;
+let failed = 0;
+function check(condition, msg) {
+  if (condition) {
+    console.log(`  ok  ${msg}`);
+    passed++;
+  } else {
+    console.error(`  FAIL  ${msg}`);
+    failed++;
+  }
+}
+
+// ── E_IO_001: file not found ────────────────────────────────────────
+
+function testIoNotFound() {
+  console.log('testIoNotFound');
+  const eng = new flox.Engine(10000, 0.001);
+  try {
+    eng.loadCsv('/this/path/does/not/exist.csv', 'BTC');
+    check(false, 'expected loadCsv to throw');
+  } catch (e) {
+    check(e instanceof Error, 'error is instanceof Error');
+    check(e.code === 'E_IO_001', `error.code === 'E_IO_001' (got ${e.code})`);
+    check(typeof e.helpUrl === 'string' && e.helpUrl.length > 0,
+          `error.helpUrl is non-empty string`);
+    check(e.helpUrl.includes('E_IO_001'),
+          `error.helpUrl mentions code (got ${e.helpUrl})`);
+    check(e.message.includes('does/not/exist.csv'),
+          `error.message names the offending path`);
+  }
+}
+
+// ── E_SYM_001: resample with unknown source symbol ────────────────────
+
+function testResampleUnknownSymbol() {
+  console.log('testResampleUnknownSymbol');
+  const eng = new flox.Engine(10000, 0.001);
+  try {
+    eng.resample('NEVER_LOADED', 'TARGET', '1m');
+    check(false, 'expected resample to throw for unloaded source');
+  } catch (e) {
+    check(e instanceof Error, 'error is instanceof Error');
+    check(e.code === 'E_SYM_001', `error.code === 'E_SYM_001' (got ${e.code})`);
+    check(typeof e.helpUrl === 'string' && e.helpUrl.includes('E_SYM_001'),
+          `error.helpUrl mentions code`);
+  }
+}
+
+// ── Run ─────────────────────────────────────────────────────────────
+
+testIoNotFound();
+testResampleUnknownSymbol();
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
Adds NAPI translation of `flox::FloxError` thrown from C++ engine code into a JavaScript Error with `.code` / `.helpUrl` / `.name = 'FloxError'` extra properties. Compatible with `instanceof Error`.

User-facing example:

```js
try {
  engine.loadCsv('missing.csv', 'BTC');
} catch (e) {
  if (e.code === 'E_IO_001') console.log(`see ${e.helpUrl}`);
  throw e;
}
```

## Architecture

- **`node/src/error_translator.h`** — `tryFlox(env, fn)` helper wraps a lambda calling into the engine, catches `flox::FloxError`, rethrows as Napi::Error with structured fields attached.
- **Wrapped methods** that can throw FloxError: `EngineWrap::LoadCsv` / `LoadOhlcv` / `Resample`; `BacktestRunnerNode::runCsv` / `runOhlcv` / `runBars`. Plus `parseCsv` and `Resample` themselves throw structured codes (`E_IO_001`, `E_SYM_001`).
- **`node/index.d.ts`** — new `export interface FloxError extends Error` with readonly `code` / `helpUrl`.
- **`node/test/test_flox_error.js`** — 8 assertions on `instanceof Error`, `.code` values, `.helpUrl` format, message content.

## Scope

Codon and QuickJS are deferred. Codon FFI doesn't propagate C++ exceptions cleanly (would crash on throw); surfacing FloxError there needs a C ABI return-code path separate from this PR. QuickJS scripts run sandboxed and don't directly trigger engine throws today.

## Test plan
- [x] 8/8 node/test/test_flox_error.js passing locally
- [x] node/test/test_bindings.js (70/70) and test_hooks.js (18/18) still pass
- [x] tsc --noEmit passes (FloxError interface declared)
- [x] check_dts_exports.py clean
- [ ] CI: 11 checks expected green

W2-T010