### PR TITLE
feat(python): CcxtBroker — live broker adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,9 @@ jobs:
     - name: Verify flox new CLI scaffolder
       run: PYTHONPATH=build/python python3 python/tests/test_flox_new_cli.py
 
+    - name: Verify Python CCXT adapter (mock-based)
+      run: PYTHONPATH=build/python python3 python/tests/test_ccxt_adapter.py
+
     - name: Verify .pyi stubs are in sync with the binding
       run: python3 scripts/gen_pyi_stubs.py --check
 

--- a/docs/.snippet-allowlist.txt
+++ b/docs/.snippet-allowlist.txt
@@ -82,3 +82,7 @@ docs/tutorials/python-quickstart.md
 # point being illustrated.
 docs/contributors/adding-a-c-api-export.md
 docs/contributors/extension-hook-pattern.md
+
+# How-to: CCXT adapter — quickstart contains illustrative snippets;
+# the runnable end-to-end example lives in docs/examples/python_ccxt_live.py.
+docs/how-to/ccxt-adapter.md

--- a/docs/examples/python_ccxt_live.py
+++ b/docs/examples/python_ccxt_live.py
@@ -1,111 +1,93 @@
-"""
-Live SMA crossover strategy fed from Binance via ccxt.pro WebSocket.
+"""Live SMA crossover on Binance public WebSocket via CcxtBroker.
 
-Connects to Binance public WebSocket, streams BTC/USDT trades in real time,
-runs SMA(10/30) crossover strategy, prints signals.
+The broker owns the SymbolRegistry, the Runner, and the ccxt.pro
+exchange. ``self.market_buy(...)`` inside the strategy is what
+actually submits the order to the exchange — there is no separate
+signal handler the user has to wire up.
 
-No API key needed — uses public trade stream.
+No API key is needed for the public trade / book streams. Order
+placement requires keys; uncomment the ``api_key`` / ``secret`` /
+``sandbox=True`` lines and supply your testnet credentials before
+removing the dry-run guard.
 
-Usage:
+Usage::
+
     cd /path/to/flox
-    PYTHONPATH=build/python python3 examples/python_ccxt_live.py
+    PYTHONPATH=build/python python3 docs/examples/python_ccxt_live.py
 
 Stop with Ctrl+C.
 """
+from __future__ import annotations
 
 import asyncio
-import ccxt.pro as ccxt
+import os
+
 import flox_py as flox
+from flox_py.ccxt import CcxtBroker
 
-# ── Symbols ────────────────────────────────────────────────────────────
 
-registry = flox.SymbolRegistry()
-btc = registry.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+DRY_RUN = os.environ.get("FLOX_LIVE", "0") != "1"
 
-# Map ccxt symbol name → flox Symbol.
-# Add more symbols here to trade multiple pairs.
-SYMBOL_MAP = {
-    "BTC/USDT": btc,
-}
-
-# ── Strategy ───────────────────────────────────────────────────────────
 
 class SMAStrategy(flox.Strategy):
     def __init__(self, symbols):
         super().__init__(symbols)
         self.fast = flox.SMA(10)
         self.slow = flox.SMA(30)
+        self.tick_count = 0
 
     def on_start(self):
-        print(f"strategy started — watching {btc}")
+        print(f"strategy started (dry_run={DRY_RUN})")
 
     def on_stop(self):
-        print("strategy stopped")
+        print(f"strategy stopped (saw {self.tick_count} trades)")
 
     def on_trade(self, ctx, trade):
-        # trade.symbol is the symbol id — only symbols passed to __init__ arrive here.
-        # For a multi-symbol strategy use: if trade.symbol == btc.id: ...
-        fv = self.fast.update(trade.price)
-        sv = self.slow.update(trade.price)
-        if fv is None or sv is None or not self.slow.ready:
+        self.tick_count += 1
+        if self.tick_count % 50 == 0:
+            print(f"  {self.tick_count} trades processed  last={trade.price}")
+        f = self.fast.update(trade.price)
+        s = self.slow.update(trade.price)
+        if f is None or s is None or not self.slow.ready:
             return
-        if fv > sv and ctx.is_flat():
-            self.market_buy(0.01)
-        elif fv < sv and ctx.is_flat():
-            self.market_sell(0.01)
+        if DRY_RUN:
+            # Don't actually submit anything in dry-run — just log the
+            # crossover state so the example is safe to run on a
+            # public account.
+            if f > s and ctx.is_flat():
+                print(f"  [dry] would buy 0.001 @ ~{trade.price}")
+            elif f < s and ctx.is_long():
+                print(f"  [dry] would sell 0.001 @ ~{trade.price}")
+            return
+        if f > s and ctx.is_flat():
+            self.market_buy(0.001)
+        elif f < s and ctx.is_long():
+            self.market_sell(0.001)
 
-# ── Signal handler ─────────────────────────────────────────────────────
+    def on_order_update(self, sym, status, filled, avg):
+        print(f"  order {sym} status={status} filled={filled} avg={avg}")
 
-def on_signal(sig):
-    print(f"  signal  {sig.side:4s}  qty={sig.quantity:.4f}  [{sig.order_type}]")
-    # In production: submit to exchange via ccxt or gateway:
-    #   exchange.create_market_buy_order("BTC/USDT:USDT", sig.quantity)
+    def on_initial_position(self, sym, qty, avg):
+        print(f"  starting position on {sym}: qty={qty} avg={avg}")
 
-# ── Runner ─────────────────────────────────────────────────────────────
-
-runner = flox.Runner(registry, on_signal)
-runner.add_strategy(SMAStrategy([btc]))
-runner.start()
-
-# ── CCXT WebSocket feed ────────────────────────────────────────────────
-
-exchange = ccxt.binance({"newUpdates": True})
-
-async def feed():
-    print("connecting to Binance WebSocket...")
-    tick_count = 0
-    try:
-        while True:
-            trades = await exchange.watch_trades("BTC/USDT")
-            for t in trades:
-                sym = SYMBOL_MAP.get(t["symbol"])
-                if sym is None:
-                    continue
-                runner.on_trade(
-                    sym,
-                    float(t["price"]),
-                    float(t["amount"]),
-                    t["side"] == "buy",
-                    int(t["timestamp"]) * 1_000_000,  # ms → ns
-                )
-                tick_count += 1
-                if tick_count % 50 == 0:
-                    print(f"  {tick_count} trades processed  last={t['price']}")
-    except asyncio.CancelledError:
-        pass
-    finally:
-        await exchange.close()
 
 async def main():
-    feed_task = asyncio.create_task(feed())
-    try:
-        await asyncio.Event().wait()  # run until Ctrl+C
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
-    finally:
-        feed_task.cancel()
-        await asyncio.gather(feed_task, return_exceptions=True)
-        runner.stop()
-        print("done")
+    # For real order placement, set the env var FLOX_LIVE=1 and pass
+    # api_key / secret / sandbox=True. Keep DRY_RUN otherwise.
+    broker = CcxtBroker(
+        "binance",
+        api_key=os.environ.get("BINANCE_API_KEY"),
+        secret=os.environ.get("BINANCE_SECRET"),
+        sandbox=not DRY_RUN,
+    )
+    async with broker:
+        btc = await broker.add_symbol("BTC/USDT")
+        broker.add_strategy(SMAStrategy([btc]))
+        try:
+            await broker.run(streams=("trades", "orders") if not DRY_RUN else ("trades",))
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
 
-asyncio.run(main())
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/how-to/ccxt-adapter.md
+++ b/docs/how-to/ccxt-adapter.md
@@ -1,0 +1,100 @@
+# Connect FLOX to a CCXT exchange
+
+`flox_py.ccxt.CcxtFeed` bridges any [ccxt.pro](https://github.com/ccxt/ccxt/wiki/ccxt.pro) WebSocket exchange (100+ supported) into a `flox.Runner` — trades and L2 book updates flow into your strategy without you writing the WebSocket plumbing.
+
+## Install
+
+```bash
+pip install flox-py "ccxt[pro]"
+```
+
+## Quick start
+
+```python
+import asyncio
+import ccxt.pro as ccxtpro
+import flox_py as flox
+from flox_py.ccxt import CcxtFeed
+
+# 1. Register symbols.
+registry = flox.SymbolRegistry()
+btc = registry.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+eth = registry.add_symbol("binance", "ETHUSDT", tick_size=0.01)
+
+# 2. Define a strategy and runner.
+class MyStrategy(flox.Strategy):
+    def on_trade(self, ctx, trade):
+        # Your logic
+        pass
+
+def on_signal(sig):
+    print(f"signal: {sig}")
+    # In production: route to exchange via ccxt or your gateway.
+
+runner = flox.Runner(registry, on_signal)
+runner.add_strategy(MyStrategy([btc, eth]))
+runner.start()
+
+# 3. Wire CCXT into the runner.
+exchange = ccxtpro.binance()  # public market data — no API key needed
+feed = CcxtFeed(
+    exchange=exchange,
+    runner=runner,
+    symbols={"BTC/USDT": btc, "ETH/USDT": eth},
+    streams=("trades", "book"),  # subscribe to both, or one
+    book_depth=20,
+)
+
+try:
+    asyncio.run(feed.run())
+except KeyboardInterrupt:
+    pass
+finally:
+    runner.stop()
+    asyncio.run(exchange.close())
+```
+
+## Order routing
+
+`CcxtFeed` only handles **inbound** market data. Order placement is up to your signal handler — split keeps inbound (FLOX-controlled) and outbound (broker-controlled) paths clean:
+
+```python
+def on_signal(sig):
+    if sig.side == "buy":
+        asyncio.create_task(
+            exchange.create_market_buy_order("BTC/USDT", sig.quantity)
+        )
+    elif sig.side == "sell":
+        asyncio.create_task(
+            exchange.create_market_sell_order("BTC/USDT", sig.quantity)
+        )
+```
+
+For multi-exchange routing, instantiate a separate `CcxtFeed` per exchange.
+
+## API reference
+
+### `CcxtFeed(exchange, runner, symbols, *, streams=("trades","book"), book_depth=20, on_error=None)`
+
+| Argument     | Type                          | Meaning |
+|--------------|-------------------------------|---------|
+| `exchange`   | ccxt.pro exchange instance    | Pre-configured (API keys if you'll trade) |
+| `runner`     | `flox_py.Runner`              | Started before `feed.run()` |
+| `symbols`    | `Mapping[str, Symbol]`        | `{ccxt_symbol: flox_symbol}`. CCXT format like `"BTC/USDT"` or `"BTC/USDT:USDT"` |
+| `streams`    | `Iterable[str]`               | Subset of `{"trades", "book"}` |
+| `book_depth` | `int`                         | L2 depth (number of bid/ask levels). Default 20 |
+| `on_error`   | `Callable[[str, BaseException], None]` | Per-stream error handler. Default: log via `logging`. Pass `None` to silence |
+
+### `await feed.run()`
+
+Runs all configured streams concurrently. Returns when every stream task is cancelled. Typically called via `asyncio.run(feed.run())`; clean shutdown comes from `KeyboardInterrupt` or external cancellation.
+
+### `await feed.stop()`
+
+Cancels all in-flight stream tasks. Idempotent.
+
+## Reconnection / errors
+
+`watch_trades` and `watch_order_book` are wrapped in retry loops with a 1-second backoff. On exception, `on_error(symbol, exc)` fires (logged by default) and the loop reconnects. There's no max retry — disconnects are treated as transient.
+
+For production strategies, monitor disconnects via your `on_error` callback and decide on a stop policy (e.g. flatten positions if disconnected for > 30 seconds).

--- a/docs/how-to/ccxt-adapter.md
+++ b/docs/how-to/ccxt-adapter.md
@@ -1,6 +1,6 @@
 # Connect FLOX to a CCXT exchange
 
-`flox_py.ccxt.CcxtBroker` wraps a [ccxt.pro](https://github.com/ccxt/ccxt/wiki/ccxt.pro) exchange and gives a strategy a single entry point for both market data (trades, L2 books, order updates) and order routing. The strategy's `self.market_buy(...)` / `self.limit_sell(...)` / `self.stop_market(...)` calls translate into real `create_*_order` calls on the underlying exchange.
+`flox_py.ccxt.CcxtBroker` wraps a [ccxt.pro](https://github.com/ccxt/ccxt/wiki/ccxt.pro) exchange. Market data flows in (trades, L2 books, order updates) and orders flow out (`self.market_buy(...)`, `self.limit_sell(...)`, `self.stop_market(...)` from inside the strategy translate into `create_*_order` calls on the exchange).
 
 ## Install
 
@@ -54,7 +54,7 @@ async def main():
 asyncio.run(main())
 ```
 
-`add_symbol` calls `exchange.load_markets()` once and reads tick size from the market metadata, so the strategy never hard-codes one. `add_strategy` attaches to the broker's internal `Runner`. The runner's signal callback is wired through to `_place_order` — calling `self.market_buy(...)` from inside the strategy results in a real ccxt order placement.
+`add_symbol` calls `exchange.load_markets()` once and reads tick size from `markets[sym]["precision"]["price"]`. `add_strategy` attaches to the broker's internal `Runner`. The runner's signal callback is wired to `_handle_signal`, which dispatches to a per-order-type method (`_place_market`, `_place_limit`, `_place_stop_market`, ...). Calling `self.market_buy(...)` inside the strategy ends up calling `exchange.create_market_buy_order(...)`.
 
 ## Lifecycle
 
@@ -93,15 +93,15 @@ When a strategy emits a signal (via `self.market_buy(...)` etc.), the broker's s
 | `CANCEL_ALL`                | `cancel_order` for every tracked id on the symbol                                 |
 | `MODIFY`                    | `edit_order(ccxt_id, sym, "limit", side, new_qty, new_price)`                     |
 
-Stop / take-profit / trailing parameters vary across exchanges. The broker uses ccxt's unified-API defaults; if a particular exchange needs a different params shape (e.g. Binance futures `stopPrice` vs. `triggerPrice`), subclass and override `_place_stop_market` / `_place_trailing` / etc.
+Stop, take-profit, and trailing parameter shapes differ across exchanges. The broker uses ccxt's unified-API defaults. If your exchange wants a different params dict (Binance futures uses `triggerPrice` instead of `stopPrice`, OKX uses `triggerPx`), subclass and override `_place_stop_market`, `_place_trailing`, etc.
 
-Anything not in the table above goes through `on_error` as `UnsupportedOrderType` — the order is dropped, not silently routed somewhere unexpected.
+Order types outside the table dispatch to `on_error(sym, UnsupportedOrderType(...))`. The exchange call is skipped.
 
 ## Position reconciliation
 
-Before streams start, `run(reconcile=True)` (the default) calls `fetch_balance()` and `fetch_positions()`. For each non-zero position whose symbol is registered in the broker, the strategy's `on_initial_position(ccxt_sym, qty, avg_price)` callback is invoked. Strategies that don't define the method are skipped.
+`run(reconcile=True)` (default) calls `fetch_balance()` and `fetch_positions()` before streams start. For each non-zero position on a registered symbol the broker calls `strategy.on_initial_position(ccxt_sym, qty, avg_price)`. If the strategy has no such method the position is just logged.
 
-`fetch_positions` is a derivatives concept — for spot exchanges ccxt raises `NotSupported`, which the broker treats as "no positions" rather than fail.
+`fetch_positions` is a derivatives concept. Spot exchanges raise `NotSupported`; the broker swallows it and proceeds with an empty position list.
 
 ## Backoff
 
@@ -133,8 +133,8 @@ class BybitBroker(CcxtBroker):
 
 ## Multi-exchange
 
-Instantiate one broker per exchange. Strategies attached to one broker only see that exchange's market data — there is no cross-broker symbol id sharing.
+Instantiate one broker per exchange. A strategy attached to one broker only sees that exchange's market data; symbol ids are scoped to the broker that registered them.
 
 ## Runnable example
 
-A complete script lives at [`docs/examples/python_ccxt_live.py`](../examples/python-ccxt-live.md): SMA(10/30) on `BTC/USDT` connected to Binance public WebSocket, no API key needed.
+A complete script lives at [`docs/examples/python_ccxt_live.py`](../examples/python-ccxt-live.md): SMA(10/30) on `BTC/USDT` against Binance's public WebSocket. Runs in dry-run mode by default; set `FLOX_LIVE=1` plus `BINANCE_API_KEY` / `BINANCE_SECRET` to actually place sandbox orders.

--- a/docs/how-to/ccxt-adapter.md
+++ b/docs/how-to/ccxt-adapter.md
@@ -1,6 +1,6 @@
 # Connect FLOX to a CCXT exchange
 
-`flox_py.ccxt.CcxtFeed` bridges any [ccxt.pro](https://github.com/ccxt/ccxt/wiki/ccxt.pro) WebSocket exchange (100+ supported) into a `flox.Runner` — trades and L2 book updates flow into your strategy without you writing the WebSocket plumbing.
+`flox_py.ccxt.CcxtBroker` wraps a [ccxt.pro](https://github.com/ccxt/ccxt/wiki/ccxt.pro) exchange and gives a strategy a single entry point for both market data (trades, L2 books, order updates) and order routing. The strategy's `self.market_buy(...)` / `self.limit_sell(...)` / `self.stop_market(...)` calls translate into real `create_*_order` calls on the underlying exchange.
 
 ## Install
 
@@ -12,89 +12,129 @@ pip install flox-py "ccxt[pro]"
 
 ```python
 import asyncio
-import ccxt.pro as ccxtpro
 import flox_py as flox
-from flox_py.ccxt import CcxtFeed
+from flox_py.ccxt import CcxtBroker
 
-# 1. Register symbols.
-registry = flox.SymbolRegistry()
-btc = registry.add_symbol("binance", "BTCUSDT", tick_size=0.01)
-eth = registry.add_symbol("binance", "ETHUSDT", tick_size=0.01)
 
-# 2. Define a strategy and runner.
-class MyStrategy(flox.Strategy):
+class SMA(flox.Strategy):
+    def __init__(self, symbols):
+        super().__init__(symbols)
+        self.fast = flox.SMA(10)
+        self.slow = flox.SMA(30)
+
     def on_trade(self, ctx, trade):
-        # Your logic
-        pass
+        f = self.fast.update(trade.price)
+        s = self.slow.update(trade.price)
+        if f is None or s is None:
+            return
+        if f > s and ctx.is_flat():
+            self.market_buy(0.001)
+        elif f < s and ctx.is_long():
+            self.market_sell(0.001)
 
-def on_signal(sig):
-    print(f"signal: {sig}")
-    # In production: route to exchange via ccxt or your gateway.
+    def on_order_update(self, sym, status, filled, avg):
+        print(f"  {sym} {status} filled={filled} avg={avg}")
 
-runner = flox.Runner(registry, on_signal)
-runner.add_strategy(MyStrategy([btc, eth]))
-runner.start()
+    def on_initial_position(self, sym, qty, avg):
+        print(f"  starting position on {sym}: qty={qty} avg={avg}")
 
-# 3. Wire CCXT into the runner.
-exchange = ccxtpro.binance()  # public market data — no API key needed
-feed = CcxtFeed(
-    exchange=exchange,
-    runner=runner,
-    symbols={"BTC/USDT": btc, "ETH/USDT": eth},
-    streams=("trades", "book"),  # subscribe to both, or one
-    book_depth=20,
-)
 
-try:
-    asyncio.run(feed.run())
-except KeyboardInterrupt:
-    pass
-finally:
-    runner.stop()
-    asyncio.run(exchange.close())
+async def main():
+    async with CcxtBroker(
+        "binance",
+        api_key="...",       # leave None for public market data only
+        secret="...",
+        sandbox=True,
+    ) as broker:
+        btc = await broker.add_symbol("BTC/USDT")
+        broker.add_strategy(SMA([btc]))
+        await broker.run(streams=("trades", "book", "orders"))
+
+
+asyncio.run(main())
 ```
+
+`add_symbol` calls `exchange.load_markets()` once and reads tick size from the market metadata, so the strategy never hard-codes one. `add_strategy` attaches to the broker's internal `Runner`. The runner's signal callback is wired through to `_place_order` — calling `self.market_buy(...)` from inside the strategy results in a real ccxt order placement.
+
+## Lifecycle
+
+`async with CcxtBroker(...)` constructs the exchange. `await broker.run(...)` starts the runner, dispatches initial-position callbacks, spawns one asyncio task per (symbol × stream), and awaits until cancelled. On `__aexit__` the broker cancels stream tasks, stops the runner, and closes the exchange.
+
+`broker.run(...)` blocks until cancelled (e.g. via `Ctrl+C` or an outer task cancel). To run alongside other coroutines, schedule it as a task and cancel it on shutdown.
+
+## Streams
+
+Pass any subset of `("trades", "book", "orders")` to `run(streams=...)`:
+
+| Stream    | ccxt method               | FLOX target                                                    |
+|-----------|---------------------------|----------------------------------------------------------------|
+| `trades`  | `watch_trades(sym)`       | `runner.on_trade(sym_id, price, qty, is_buy, ts_ns)`           |
+| `book`    | `watch_order_book(sym)`   | `runner.on_book_snapshot(sym_id, bids/asks)`                   |
+| `orders`  | `watch_orders()`          | strategy's `on_order_update(ccxt_sym, status, filled, avg)`    |
+
+Each yields a snapshot per call. The book stream forwards `book_depth` levels (default 20).
 
 ## Order routing
 
-`CcxtFeed` only handles **inbound** market data. Order placement is up to your signal handler — split keeps inbound (FLOX-controlled) and outbound (broker-controlled) paths clean:
+When a strategy emits a signal (via `self.market_buy(...)` etc.), the broker's signal callback maps it to ccxt:
+
+| `Signal.order_type`         | ccxt call                                                                         |
+|-----------------------------|-----------------------------------------------------------------------------------|
+| `MARKET`                    | `create_market_<side>_order(sym, qty)`                                            |
+| `LIMIT`                     | `create_limit_<side>_order(sym, qty, price)`                                      |
+| `STOP_MARKET`               | `create_order(sym, "stop_market", side, qty, None, {"stopPrice": trigger})`       |
+| `STOP_LIMIT`                | `create_order(sym, "stop_limit", side, qty, limit, {"stopPrice": trigger})`       |
+| `TAKE_PROFIT_MARKET`        | `create_order(sym, "take_profit_market", side, qty, None, {"stopPrice": ...})`    |
+| `TAKE_PROFIT_LIMIT`         | `create_order(sym, "take_profit_limit", side, qty, limit, {"stopPrice": ...})`    |
+| `TRAILING_STOP`             | `create_order(sym, "trailing_stop_market", side, qty, None, {"trailingDelta": offset})` |
+| `TRAILING_STOP_PERCENT`     | `create_order(sym, "trailing_stop_market", side, qty, None, {"callbackRate": bps/100})` |
+| `CLOSE_POSITION`            | `create_order(sym, "market", side, qty, None, {"reduceOnly": True})`              |
+| `CANCEL`                    | `cancel_order(ccxt_id, ccxt_sym)` using the tracked id from the original signal   |
+| `CANCEL_ALL`                | `cancel_order` for every tracked id on the symbol                                 |
+| `MODIFY`                    | `edit_order(ccxt_id, sym, "limit", side, new_qty, new_price)`                     |
+
+Stop / take-profit / trailing parameters vary across exchanges. The broker uses ccxt's unified-API defaults; if a particular exchange needs a different params shape (e.g. Binance futures `stopPrice` vs. `triggerPrice`), subclass and override `_place_stop_market` / `_place_trailing` / etc.
+
+Anything not in the table above goes through `on_error` as `UnsupportedOrderType` — the order is dropped, not silently routed somewhere unexpected.
+
+## Position reconciliation
+
+Before streams start, `run(reconcile=True)` (the default) calls `fetch_balance()` and `fetch_positions()`. For each non-zero position whose symbol is registered in the broker, the strategy's `on_initial_position(ccxt_sym, qty, avg_price)` callback is invoked. Strategies that don't define the method are skipped.
+
+`fetch_positions` is a derivatives concept — for spot exchanges ccxt raises `NotSupported`, which the broker treats as "no positions" rather than fail.
+
+## Backoff
+
+Stream errors (network drops, exchange 5xx, etc.) are caught and retried with exponential backoff:
 
 ```python
-def on_signal(sig):
-    if sig.side == "buy":
-        asyncio.create_task(
-            exchange.create_market_buy_order("BTC/USDT", sig.quantity)
-        )
-    elif sig.side == "sell":
-        asyncio.create_task(
-            exchange.create_market_sell_order("BTC/USDT", sig.quantity)
+broker = CcxtBroker(
+    "binance",
+    retry_initial_delay=1.0,    # first sleep after a failure
+    retry_max_delay=60.0,       # cap
+    retry_multiplier=2.0,       # delay *= multiplier on each consecutive fail
+)
+```
+
+Delay starts at `retry_initial_delay`, multiplies on each consecutive failure, caps at `retry_max_delay`, and resets to the initial value after a successful yield.
+
+## Subclassing per exchange
+
+Override any of the `_place_*` methods to customise per-exchange params (Bybit `triggerBy`, OKX `tdMode`, Binance futures `closePosition`, etc.):
+
+```python
+class BybitBroker(CcxtBroker):
+    async def _place_stop_market(self, sym, side, sig):
+        await self.exchange.create_order(
+            sym, "stop_market", side, self._qty(sig), None,
+            {"stopPrice": self._trigger(sig), "triggerBy": "MarkPrice"},
         )
 ```
 
-For multi-exchange routing, instantiate a separate `CcxtFeed` per exchange.
+## Multi-exchange
 
-## API reference
+Instantiate one broker per exchange. Strategies attached to one broker only see that exchange's market data — there is no cross-broker symbol id sharing.
 
-### `CcxtFeed(exchange, runner, symbols, *, streams=("trades","book"), book_depth=20, on_error=None)`
+## Runnable example
 
-| Argument     | Type                          | Meaning |
-|--------------|-------------------------------|---------|
-| `exchange`   | ccxt.pro exchange instance    | Pre-configured (API keys if you'll trade) |
-| `runner`     | `flox_py.Runner`              | Started before `feed.run()` |
-| `symbols`    | `Mapping[str, Symbol]`        | `{ccxt_symbol: flox_symbol}`. CCXT format like `"BTC/USDT"` or `"BTC/USDT:USDT"` |
-| `streams`    | `Iterable[str]`               | Subset of `{"trades", "book"}` |
-| `book_depth` | `int`                         | L2 depth (number of bid/ask levels). Default 20 |
-| `on_error`   | `Callable[[str, BaseException], None]` | Per-stream error handler. Default: log via `logging`. Pass `None` to silence |
-
-### `await feed.run()`
-
-Runs all configured streams concurrently. Returns when every stream task is cancelled. Typically called via `asyncio.run(feed.run())`; clean shutdown comes from `KeyboardInterrupt` or external cancellation.
-
-### `await feed.stop()`
-
-Cancels all in-flight stream tasks. Idempotent.
-
-## Reconnection / errors
-
-`watch_trades` and `watch_order_book` are wrapped in retry loops with a 1-second backoff. On exception, `on_error(symbol, exc)` fires (logged by default) and the loop reconnects. There's no max retry — disconnects are treated as transient.
-
-For production strategies, monitor disconnects via your `on_error` callback and decide on a stop policy (e.g. flatten positions if disconnected for > 30 seconds).
+A complete script lives at [`docs/examples/python_ccxt_live.py`](../examples/python-ccxt-live.md): SMA(10/30) on `BTC/USDT` connected to Binance public WebSocket, no API key needed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - Strategy & Backtest:
           - Scaffold a Project (flox new): how-to/flox-new.md
           - Strategy Classes: how-to/strategy-classes.md
+          - Connect to CCXT exchange: how-to/ccxt-adapter.md
           - Backtesting: how-to/backtest.md
           - Realistic Backtest Fills: how-to/backtest-realistic-fills.md
           - Interactive Backtest: how-to/interactive-backtest.md

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -36,6 +36,7 @@ set(FLOX_PY_REQUIRED_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/__init__.py
   ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/cli.py
   ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/py.typed
+  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/ccxt.py
 )
 set(FLOX_PY_OPTIONAL_ROOT_STUBS
   ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/__init__.pyi

--- a/python/flox_py/ccxt.py
+++ b/python/flox_py/ccxt.py
@@ -1,11 +1,10 @@
 """CCXT live broker for FLOX.
 
-``CcxtBroker`` wraps a ``ccxt.pro`` exchange and gives a strategy a
-single entry point for both market data (trades, L2 books, order
-updates) and order routing. The strategy's ``self.market_buy(...)`` /
-``self.limit_sell(...)`` / ``self.stop_market(...)`` / etc. calls
-translate into real ``create_*_order`` calls on the underlying ccxt
-exchange.
+``CcxtBroker`` wraps a ``ccxt.pro`` exchange. Market data flows in
+(trades, L2 books, order updates), orders flow out
+(``self.market_buy(...)``, ``self.limit_sell(...)``,
+``self.stop_market(...)`` from inside the strategy translate into
+``create_*_order`` calls on the exchange).
 
 Quick start
 -----------
@@ -44,27 +43,25 @@ What the broker does
 --------------------
 
 - ``add_symbol(ccxt_sym)`` calls ``exchange.load_markets()`` once and
-  pulls ``precision.price`` from the market metadata to register the
-  symbol in an internal ``flox.SymbolRegistry`` with the right tick
-  size. The strategy never has to hard-code a tick.
+  reads ``markets[sym]["precision"]["price"]`` to register the symbol
+  in an internal ``flox.SymbolRegistry`` with the right tick size.
 - ``add_strategy(strategy)`` attaches the strategy to an internal
   ``flox.Runner``. The runner's signal callback is wired to
-  ``_place_order``, so emitting a signal from inside the strategy
-  results in an actual ccxt order placement.
+  ``_handle_signal``; emitting a signal from inside the strategy ends
+  up in a ``create_*_order`` call on the exchange.
 - ``run(streams=...)`` spawns one asyncio task per (symbol × stream)
   pair. ``"trades"`` and ``"book"`` forward into ``runner.on_trade`` /
-  ``runner.on_book_snapshot``. ``"orders"`` calls a per-strategy
-  ``on_order_update(ccxt_sym, status, filled, avg_price)`` callback if
-  the strategy defines one.
+  ``runner.on_book_snapshot``. ``"orders"`` dispatches to
+  ``strategy.on_order_update(ccxt_sym, status, filled, avg_price)``
+  when the strategy defines that method.
 - Before streams start, the broker calls ``fetch_balance()`` and
-  ``fetch_positions()`` and dispatches a per-strategy
-  ``on_initial_position(ccxt_sym, qty, avg_price)`` callback for any
-  open position. Strategies that don't define the method are skipped.
-- Stream errors are caught, reported via ``on_error``, and retried
-  with exponential backoff (configurable via
-  ``retry_initial_delay`` / ``retry_max_delay`` / ``retry_multiplier``).
-  The delay resets to ``retry_initial_delay`` after each successful
-  yield.
+  ``fetch_positions()`` and dispatches
+  ``strategy.on_initial_position(ccxt_sym, qty, avg_price)`` for any
+  open position. Strategies without that method see only the log line.
+- Stream errors are reported via ``on_error`` and retried with
+  exponential backoff (configurable via ``retry_initial_delay``,
+  ``retry_max_delay``, ``retry_multiplier``). Delay resets to
+  ``retry_initial_delay`` after each successful yield.
 
 Order types
 -----------
@@ -84,13 +81,14 @@ Mapped to ccxt's unified ``create_order`` API:
   ``CANCEL_ALL``              → ``cancel_order`` for every tracked id on this symbol
   ``MODIFY``                  → ``edit_order(...)``
 
-Stop / take-profit / trailing semantics vary by exchange (Binance,
-Bybit, OKX all use slightly different ``params`` keys). The mappings
-above are the unified-API defaults. If a particular exchange needs
-different params, override ``_place_order`` in a subclass.
+Stop, take-profit, and trailing param shapes differ across
+exchanges (Binance futures: ``triggerPrice``; OKX: ``triggerPx``;
+Bybit: ``triggerBy``). The mappings above are ccxt's unified-API
+defaults. To customise per exchange, subclass and override the
+relevant ``_place_*`` method.
 
-Anything not in the table above is reported through ``on_error`` as
-``UnsupportedOrderType``.
+Order types outside the table dispatch to ``on_error`` as
+``UnsupportedOrderType``. The exchange call is skipped.
 """
 
 from __future__ import annotations
@@ -713,8 +711,8 @@ class CcxtBroker:
         """Fetch balance / positions, dispatch to strategy callbacks.
 
         Both calls are best-effort. ``fetch_positions`` is a derivatives
-        concept — for spot-only exchanges ccxt raises ``NotSupported``,
-        which we treat as "no positions" rather than fail.
+        concept; spot-only exchanges raise ``NotSupported``, which the
+        broker swallows and proceeds with an empty position list.
         """
         try:
             await self.exchange.fetch_balance()

--- a/python/flox_py/ccxt.py
+++ b/python/flox_py/ccxt.py
@@ -1,8 +1,11 @@
-"""CCXT live data adapter for FLOX.
+"""CCXT live broker for FLOX.
 
-Wraps a ``ccxt.pro`` exchange and forwards trades / book updates into a
-``flox_py.Runner``. Lets you connect any of CCXT's 100+ supported
-exchanges to FLOX without writing the WebSocket plumbing yourself.
+``CcxtBroker`` wraps a ``ccxt.pro`` exchange and gives a strategy a
+single entry point for both market data (trades, L2 books, order
+updates) and order routing. The strategy's ``self.market_buy(...)`` /
+``self.limit_sell(...)`` / ``self.stop_market(...)`` / etc. calls
+translate into real ``create_*_order`` calls on the underlying ccxt
+exchange.
 
 Quick start
 -----------
@@ -10,47 +13,84 @@ Quick start
 .. code-block:: python
 
     import asyncio
-    import ccxt.pro as ccxtpro
     import flox_py as flox
-    from flox_py.ccxt import CcxtFeed
+    from flox_py.ccxt import CcxtBroker
 
-    registry = flox.SymbolRegistry()
-    btc = registry.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+    class SMA(flox.Strategy):
+        def __init__(self, symbols):
+            super().__init__(symbols)
+            self.fast = flox.SMA(10)
+            self.slow = flox.SMA(30)
 
-    runner = flox.Runner(registry, on_signal=lambda s: print(s))
-    runner.add_strategy(MyStrategy([btc]))
-    runner.start()
+        def on_trade(self, ctx, trade):
+            f = self.fast.update(trade.price)
+            s = self.slow.update(trade.price)
+            if f is None or s is None:
+                return
+            if f > s and ctx.is_flat():
+                self.market_buy(0.001)
+            elif f < s and ctx.is_long():
+                self.market_sell(0.001)
 
-    exchange = ccxtpro.binance()
-    feed = CcxtFeed(
-        exchange=exchange,
-        runner=runner,
-        symbols={"BTC/USDT": btc},
-        streams=("trades", "book"),
-    )
+    async def main():
+        async with CcxtBroker("binance") as broker:
+            btc = await broker.add_symbol("BTC/USDT")
+            broker.add_strategy(SMA([btc]))
+            await broker.run(streams=("trades", "book", "orders"))
 
-    try:
-        asyncio.run(feed.run())
-    finally:
-        runner.stop()
-        asyncio.run(exchange.close())
+    asyncio.run(main())
 
-Order routing
--------------
+What the broker does
+--------------------
 
-CcxtFeed only handles **inbound** market data. Order placement is up to
-your strategy's signal handler:
+- ``add_symbol(ccxt_sym)`` calls ``exchange.load_markets()`` once and
+  pulls ``precision.price`` from the market metadata to register the
+  symbol in an internal ``flox.SymbolRegistry`` with the right tick
+  size. The strategy never has to hard-code a tick.
+- ``add_strategy(strategy)`` attaches the strategy to an internal
+  ``flox.Runner``. The runner's signal callback is wired to
+  ``_place_order``, so emitting a signal from inside the strategy
+  results in an actual ccxt order placement.
+- ``run(streams=...)`` spawns one asyncio task per (symbol × stream)
+  pair. ``"trades"`` and ``"book"`` forward into ``runner.on_trade`` /
+  ``runner.on_book_snapshot``. ``"orders"`` calls a per-strategy
+  ``on_order_update(ccxt_sym, status, filled, avg_price)`` callback if
+  the strategy defines one.
+- Before streams start, the broker calls ``fetch_balance()`` and
+  ``fetch_positions()`` and dispatches a per-strategy
+  ``on_initial_position(ccxt_sym, qty, avg_price)`` callback for any
+  open position. Strategies that don't define the method are skipped.
+- Stream errors are caught, reported via ``on_error``, and retried
+  with exponential backoff (configurable via
+  ``retry_initial_delay`` / ``retry_max_delay`` / ``retry_multiplier``).
+  The delay resets to ``retry_initial_delay`` after each successful
+  yield.
 
-.. code-block:: python
+Order types
+-----------
 
-    def on_signal(sig):
-        if sig.side == "buy":
-            asyncio.create_task(
-                exchange.create_market_buy_order("BTC/USDT", sig.quantity)
-            )
+Mapped to ccxt's unified ``create_order`` API:
 
-This split keeps the inbound (FLOX-controlled) and outbound (broker-
-controlled) paths cleanly separable.
+  ``MARKET``                  → ``create_market_<side>_order``
+  ``LIMIT``                   → ``create_limit_<side>_order``
+  ``STOP_MARKET``             → ``create_order(type='stop_market', params={'stopPrice': trigger})``
+  ``STOP_LIMIT``              → ``create_order(type='stop_limit',  params={'stopPrice': trigger}, price=limit)``
+  ``TAKE_PROFIT_MARKET``      → ``create_order(type='take_profit_market', params={'stopPrice': trigger})``
+  ``TAKE_PROFIT_LIMIT``       → ``create_order(type='take_profit_limit',  params={'stopPrice': trigger}, price=limit)``
+  ``TRAILING_STOP``           → ``create_order(type='trailing_stop_market', params={'trailingDelta': offset})``
+  ``TRAILING_STOP_PERCENT``   → ``create_order(type='trailing_stop_market', params={'callbackRate': bps/100})``
+  ``CLOSE_POSITION``          → ``create_order(type='market', params={'reduceOnly': True})``
+  ``CANCEL``                  → ``cancel_order(ccxt_id, ccxt_sym)``
+  ``CANCEL_ALL``              → ``cancel_order`` for every tracked id on this symbol
+  ``MODIFY``                  → ``edit_order(...)``
+
+Stop / take-profit / trailing semantics vary by exchange (Binance,
+Bybit, OKX all use slightly different ``params`` keys). The mappings
+above are the unified-API defaults. If a particular exchange needs
+different params, override ``_place_order`` in a subclass.
+
+Anything not in the table above is reported through ``on_error`` as
+``UnsupportedOrderType``.
 """
 
 from __future__ import annotations
@@ -68,11 +108,10 @@ logger = logging.getLogger(__name__)
 
 
 def _ccxt_ts_ns(t: Any) -> int:
-    """Extract a nanosecond timestamp from a ccxt trade / book object.
+    """Convert a ccxt object's millisecond timestamp to nanoseconds.
 
-    ccxt timestamps are in milliseconds; we convert to ns. Falls back to
-    ``time.time_ns()`` if the field is missing or zero (some exchanges
-    occasionally emit updates without a ts).
+    Some exchanges emit updates without a ``timestamp`` field; fall
+    back to wall clock so downstream code never sees a zero ts.
     """
     ts_ms = t.get("timestamp") if isinstance(t, dict) else None
     if ts_ms:
@@ -81,124 +120,312 @@ def _ccxt_ts_ns(t: Any) -> int:
 
 
 def _trade_is_buy(t: Mapping[str, Any]) -> bool:
-    """Map a ccxt trade dict's ``side`` to a buy/sell boolean."""
-    side = (t.get("side") or "").lower()
-    return side == "buy"
+    return (t.get("side") or "").lower() == "buy"
 
 
-# ── Feed ───────────────────────────────────────────────────────────────
+def _market_tick_size(market: Mapping[str, Any]) -> float:
+    """Extract a tick size from a ccxt ``market`` dict.
+
+    ccxt's ``precision.price`` is overloaded across exchanges: some
+    expose it as the tick value (e.g. ``0.01``), others as the number
+    of decimal digits (e.g. ``2``). Convention: values >= 1 are read
+    as decimals. Falls back to 0.01 if neither shape parses.
+    """
+    p = market.get("precision") or {}
+    raw = p.get("price")
+    if raw is None:
+        return 0.01
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return 0.01
+    if v <= 0:
+        return 0.01
+    if v >= 1:
+        return 10.0 ** -int(v)
+    return v
+
+
+class UnsupportedOrderType(RuntimeError):
+    """Raised when a strategy emits an order type the adapter can't route."""
+
+
+# ── Broker ─────────────────────────────────────────────────────────────
 
 
 @dataclass
-class CcxtFeed:
-    """Bridges a ``ccxt.pro`` exchange into a ``flox_py.Runner``.
+class CcxtBroker:
+    """Async live broker glue for FLOX strategies on top of ccxt.pro.
+
+    Owns its own ``SymbolRegistry`` and ``Runner`` — call
+    ``add_symbol`` to register symbols, ``add_strategy`` to attach
+    strategies, then ``await run(...)`` to start streams.
 
     Parameters
     ----------
-    exchange
-        A ``ccxt.pro`` exchange instance, already configured (api keys
-        if you intend to trade — not needed for public market data).
-    runner
-        The FLOX ``Runner`` to forward events into. Must be started
-        *before* ``run()`` is awaited so its strategy callbacks are live.
-    symbols
-        Mapping ``{ccxt_symbol: flox_symbol}``. The CCXT symbol is the
-        format the exchange expects (e.g. ``"BTC/USDT"`` or
-        ``"BTC/USDT:USDT"`` for perpetuals); the FLOX symbol is whatever
-        ``SymbolRegistry.add_symbol()`` returned (or its ``.id``).
-    streams
-        Which streams to subscribe to. ``"trades"`` and/or ``"book"``.
-        Defaults to both.
-    book_depth
-        L2 depth (number of bid/ask levels) to forward. Most exchanges
-        publish 20 levels by default; set lower if your strategy doesn't
-        need full depth.
+    exchange_id
+        ccxt.pro exchange class name, e.g. ``"binance"`` or ``"bybit"``.
+    api_key, secret, password
+        Optional credentials. Leave blank for public market data only.
+    sandbox
+        Whether to call ``exchange.set_sandbox_mode(True)``. Not every
+        exchange supports a sandbox; if not, ccxt raises and the
+        broker reports it through ``on_error``.
+    retry_initial_delay, retry_max_delay, retry_multiplier
+        Exponential backoff parameters for stream errors. Delay starts
+        at ``retry_initial_delay`` seconds, multiplies by
+        ``retry_multiplier`` after each consecutive failure, caps at
+        ``retry_max_delay``, and resets to the initial value after a
+        successful yield.
     on_error
-        Optional callable ``(symbol_str, exception) -> None`` invoked
-        when a stream raises. Defaults to logging via the standard
-        ``logging`` module. Set to ``None`` to silence.
+        Callable ``(context_str, exception) -> None`` for stream and
+        order errors. ``context_str`` is the ccxt symbol or a short
+        tag like ``"balance"`` / ``"orders"``. Default logs at WARN.
+    exchange
+        Dependency injection for tests. Production callers leave this
+        ``None`` and the broker constructs the ccxt.pro exchange in
+        ``_ensure_exchange``.
     """
 
-    exchange: Any
-    runner: Any
-    symbols: Mapping[str, Any]
-    streams: Iterable[str] = ("trades", "book")
-    book_depth: int = 20
-    on_error: Optional[Callable[[str, BaseException], None]] = None
+    exchange_id: str
+    api_key: Optional[str] = None
+    secret: Optional[str] = None
+    password: Optional[str] = None
+    sandbox: bool = False
 
-    _tasks: list[asyncio.Task] = field(default_factory=list, init=False, repr=False)
+    retry_initial_delay: float = 1.0
+    retry_max_delay: float = 60.0
+    retry_multiplier: float = 2.0
+
+    on_error: Optional[Callable[[str, BaseException], None]] = None
+    exchange: Any = None
+
+    _registry: Any = field(default=None, init=False, repr=False)
+    _runner: Any = field(default=None, init=False, repr=False)
+    _strategies: list = field(default_factory=list, init=False, repr=False)
+    _sym_to_ccxt: dict = field(default_factory=dict, init=False, repr=False)
+    _ccxt_to_sym: dict = field(default_factory=dict, init=False, repr=False)
+    _flox_to_ccxt_order: dict = field(default_factory=dict, init=False, repr=False)
+    _ccxt_orders_by_sym: dict = field(default_factory=dict, init=False, repr=False)
+    _tasks: list = field(default_factory=list, init=False, repr=False)
+    _loop: Optional[asyncio.AbstractEventLoop] = field(default=None, init=False, repr=False)
+    _markets_loaded: bool = field(default=False, init=False, repr=False)
 
     def __post_init__(self) -> None:
-        # Validate streams up front so the user gets a TypeError now
-        # rather than mid-loop.
-        valid = {"trades", "book"}
-        for s in self.streams:
-            if s not in valid:
-                raise ValueError(
-                    f"unknown stream {s!r}; expected one of {sorted(valid)}"
-                )
-        if not self.symbols:
-            raise ValueError("CcxtFeed: symbols mapping must not be empty")
+        if self.retry_initial_delay <= 0:
+            raise ValueError("retry_initial_delay must be > 0")
+        if self.retry_max_delay < self.retry_initial_delay:
+            raise ValueError("retry_max_delay must be >= retry_initial_delay")
+        if self.retry_multiplier < 1.0:
+            raise ValueError("retry_multiplier must be >= 1")
         if self.on_error is None:
             self.on_error = self._default_on_error
+        import flox_py
+        self._registry = flox_py.SymbolRegistry()
 
     @staticmethod
-    def _default_on_error(symbol: str, exc: BaseException) -> None:
-        logger.warning("ccxt feed error on %s: %r", symbol, exc)
+    def _default_on_error(context: str, exc: BaseException) -> None:
+        logger.warning("ccxt broker error [%s]: %r", context, exc)
 
-    # ── Public API ────────────────────────────────────────────────────
+    # ── Lifecycle ─────────────────────────────────────────────────────
 
-    async def run(self) -> None:
-        """Run all configured streams concurrently. Cancellation-safe.
+    async def __aenter__(self) -> "CcxtBroker":
+        await self._ensure_exchange()
+        return self
 
-        Returns when every stream task has been cancelled. Typically
-        you'd call this with ``asyncio.run(feed.run())`` and let
-        Ctrl+C / signal cancellation tear it down; the calling code is
-        responsible for closing the ccxt exchange afterwards.
-        """
+    async def __aexit__(self, *exc_info: Any) -> None:
+        await self.close()
+
+    async def _ensure_exchange(self) -> None:
+        if self.exchange is not None:
+            return
         try:
-            for ccxt_sym, flox_sym in self.symbols.items():
-                if "trades" in self.streams:
-                    self._tasks.append(
-                        asyncio.create_task(self._trades_loop(ccxt_sym, flox_sym),
-                                             name=f"ccxt-trades-{ccxt_sym}")
-                    )
-                if "book" in self.streams:
-                    self._tasks.append(
-                        asyncio.create_task(self._book_loop(ccxt_sym, flox_sym),
-                                             name=f"ccxt-book-{ccxt_sym}")
-                    )
-            await asyncio.gather(*self._tasks)
-        except asyncio.CancelledError:
-            for t in self._tasks:
-                t.cancel()
-            raise
+            import ccxt.pro as ccxtpro  # type: ignore
+        except ImportError as e:
+            raise ImportError(
+                "CcxtBroker requires ccxt>=4 with the .pro async API. "
+                "Install with: pip install ccxt"
+            ) from e
+        cls = getattr(ccxtpro, self.exchange_id, None)
+        if cls is None:
+            raise ValueError(f"unknown ccxt exchange {self.exchange_id!r}")
+        config: dict = {}
+        if self.api_key:
+            config["apiKey"] = self.api_key
+        if self.secret:
+            config["secret"] = self.secret
+        if self.password:
+            config["password"] = self.password
+        self.exchange = cls(config)
+        if self.sandbox:
+            try:
+                self.exchange.set_sandbox_mode(True)
+            except BaseException as e:
+                if self.on_error:
+                    self.on_error("sandbox", e)
+
+    async def close(self) -> None:
+        """Cancel all stream tasks, stop the runner, close the exchange."""
+        await self.stop()
+        if self._runner is not None:
+            try:
+                self._runner.stop()
+            except BaseException as e:
+                if self.on_error:
+                    self.on_error("runner.stop", e)
+            self._runner = None
+        if self.exchange is not None:
+            close = getattr(self.exchange, "close", None)
+            if close is not None:
+                try:
+                    res = close()
+                    if asyncio.iscoroutine(res):
+                        await res
+                except BaseException as e:
+                    if self.on_error:
+                        self.on_error("exchange.close", e)
 
     async def stop(self) -> None:
-        """Cancel all running stream tasks. Idempotent."""
+        """Cancel all stream tasks. Idempotent. Does not close exchange."""
         for t in self._tasks:
             t.cancel()
         if self._tasks:
             await asyncio.gather(*self._tasks, return_exceptions=True)
         self._tasks.clear()
 
+    # ── Symbol registration ──────────────────────────────────────────
+
+    async def add_symbol(self, ccxt_sym: str) -> Any:
+        """Register a ccxt symbol, return the FLOX ``Symbol`` object.
+
+        First call triggers a one-time ``exchange.load_markets()``
+        round-trip; subsequent calls reuse the cached metadata. Tick
+        size comes from ``markets[ccxt_sym]["precision"]["price"]``
+        via :func:`_market_tick_size`.
+        """
+        await self._ensure_exchange()
+        if not self._markets_loaded:
+            await self.exchange.load_markets()
+            self._markets_loaded = True
+        markets = getattr(self.exchange, "markets", None) or {}
+        market = markets.get(ccxt_sym)
+        if market is None:
+            raise ValueError(
+                f"symbol {ccxt_sym!r} is not listed on {self.exchange_id} "
+                f"(after load_markets())"
+            )
+        tick = _market_tick_size(market)
+        sym = self._registry.add_symbol(self.exchange_id, ccxt_sym, tick)
+        self._sym_to_ccxt[int(sym)] = ccxt_sym
+        self._ccxt_to_sym[ccxt_sym] = sym
+        return sym
+
+    def add_strategy(self, strategy: Any) -> None:
+        """Queue a strategy to attach when ``run()`` starts the runner."""
+        self._strategies.append(strategy)
+
+    # ── Run loop ──────────────────────────────────────────────────────
+
+    async def run(
+        self,
+        *,
+        streams: Iterable[str] = ("trades", "book"),
+        book_depth: int = 20,
+        reconcile: bool = True,
+    ) -> None:
+        """Start the runner, dispatch positions, spawn streams, await.
+
+        ``streams`` may include ``"trades"``, ``"book"``, and
+        ``"orders"``. The orders stream is a single
+        ``watch_orders()`` task — ccxt aggregates updates across
+        symbols. Returns when every task is cancelled (typically via
+        ``Ctrl+C`` or an outer ``async with`` exit).
+        """
+        await self._ensure_exchange()
+        valid = {"trades", "book", "orders"}
+        unknown = [s for s in streams if s not in valid]
+        if unknown:
+            raise ValueError(
+                f"unknown stream(s) {unknown}; expected subset of {sorted(valid)}"
+            )
+        if not self._ccxt_to_sym:
+            raise ValueError(
+                "no symbols registered — call await broker.add_symbol(...) first"
+            )
+
+        import flox_py
+        self._runner = flox_py.Runner(self._registry, on_signal=self._on_signal)
+        for strat in self._strategies:
+            self._runner.add_strategy(strat)
+        self._runner.start()
+
+        self._loop = asyncio.get_running_loop()
+
+        if reconcile:
+            await self._reconcile_positions()
+
+        if "trades" in streams:
+            for ccxt_sym, flox_sym in self._ccxt_to_sym.items():
+                self._tasks.append(asyncio.create_task(
+                    self._trades_loop(ccxt_sym, flox_sym),
+                    name=f"ccxt-trades-{ccxt_sym}",
+                ))
+        if "book" in streams:
+            for ccxt_sym, flox_sym in self._ccxt_to_sym.items():
+                self._tasks.append(asyncio.create_task(
+                    self._book_loop(ccxt_sym, flox_sym, book_depth),
+                    name=f"ccxt-book-{ccxt_sym}",
+                ))
+        if "orders" in streams:
+            self._tasks.append(asyncio.create_task(
+                self._orders_loop(), name="ccxt-orders",
+            ))
+
+        try:
+            await asyncio.gather(*self._tasks)
+        except asyncio.CancelledError:
+            for t in self._tasks:
+                t.cancel()
+            raise
+
     # ── Stream loops ──────────────────────────────────────────────────
 
-    async def _trades_loop(self, ccxt_sym: str, flox_sym: Any) -> None:
-        sym_id = int(flox_sym)
+    async def _stream(
+        self,
+        fn: Callable[..., Any],
+        context: str,
+        *args: Any,
+        **kwargs: Any,
+    ):
+        """Async generator: yield results from ``fn`` with backoff retry.
+
+        After a non-cancel exception, sleep ``delay``, multiply
+        ``delay`` by ``retry_multiplier`` (capped at
+        ``retry_max_delay``), retry. Reset to ``retry_initial_delay``
+        after each successful yield.
+        """
+        delay = self.retry_initial_delay
         while True:
             try:
-                trades = await self.exchange.watch_trades(ccxt_sym)
+                result = await fn(*args, **kwargs)
             except asyncio.CancelledError:
                 raise
             except BaseException as e:
                 if self.on_error:
-                    self.on_error(ccxt_sym, e)
-                # Brief backoff to avoid busy-looping on persistent errors.
-                await asyncio.sleep(1.0)
+                    self.on_error(context, e)
+                await asyncio.sleep(delay)
+                delay = min(delay * self.retry_multiplier, self.retry_max_delay)
                 continue
+            delay = self.retry_initial_delay
+            yield result
+
+    async def _trades_loop(self, ccxt_sym: str, flox_sym: Any) -> None:
+        sym_id = int(flox_sym)
+        async for trades in self._stream(
+            self.exchange.watch_trades, ccxt_sym, ccxt_sym
+        ):
             for t in trades:
-                self.runner.on_trade(
+                self._runner.on_trade(
                     sym_id,
                     float(t["price"]),
                     float(t["amount"]),
@@ -206,30 +433,342 @@ class CcxtFeed:
                     _ccxt_ts_ns(t),
                 )
 
-    async def _book_loop(self, ccxt_sym: str, flox_sym: Any) -> None:
+    async def _book_loop(self, ccxt_sym: str, flox_sym: Any, depth: int) -> None:
         sym_id = int(flox_sym)
-        while True:
-            try:
-                ob = await self.exchange.watch_order_book(ccxt_sym, limit=self.book_depth)
-            except asyncio.CancelledError:
-                raise
-            except BaseException as e:
-                if self.on_error:
-                    self.on_error(ccxt_sym, e)
-                await asyncio.sleep(1.0)
-                continue
-            bids_raw = ob.get("bids", [])[: self.book_depth]
-            asks_raw = ob.get("asks", [])[: self.book_depth]
-            bid_prices = [float(b[0]) for b in bids_raw]
-            bid_qtys = [float(b[1]) for b in bids_raw]
-            ask_prices = [float(a[0]) for a in asks_raw]
-            ask_qtys = [float(a[1]) for a in asks_raw]
-            self.runner.on_book_snapshot(
+        async for ob in self._stream(
+            self.exchange.watch_order_book, ccxt_sym, ccxt_sym, limit=depth
+        ):
+            bids_raw = (ob.get("bids") or [])[:depth]
+            asks_raw = (ob.get("asks") or [])[:depth]
+            self._runner.on_book_snapshot(
                 sym_id,
-                bid_prices, bid_qtys,
-                ask_prices, ask_qtys,
+                [float(b[0]) for b in bids_raw],
+                [float(b[1]) for b in bids_raw],
+                [float(a[0]) for a in asks_raw],
+                [float(a[1]) for a in asks_raw],
                 _ccxt_ts_ns(ob),
             )
 
+    async def _orders_loop(self) -> None:
+        async for orders in self._stream(self.exchange.watch_orders, "orders"):
+            for o in orders:
+                self._dispatch_order_update(o)
 
-__all__ = ["CcxtFeed"]
+    # ── Outbound: signal → exchange order ─────────────────────────────
+
+    def _on_signal(self, sig: Any) -> None:
+        """Runner signal callback. Schedules order placement on the loop.
+
+        Called synchronously from inside the C++ runner — sync runner
+        means same asyncio thread, threaded runner means a worker
+        thread. Both paths funnel into ``_handle_signal`` via
+        ``run_coroutine_threadsafe`` so the ccxt call always runs on
+        the broker's event loop.
+        """
+        try:
+            sym_id = int(sig.symbol)
+        except BaseException as e:
+            if self.on_error:
+                self.on_error("?", e)
+            return
+        ccxt_sym = self._sym_to_ccxt.get(sym_id)
+        if ccxt_sym is None and (sig.order_type or "").upper() != "CANCEL":
+            # CANCEL signals carry order_id, not necessarily a tracked
+            # symbol — let _handle_signal sort it out.
+            if self.on_error:
+                self.on_error(
+                    f"sym_id={sym_id}",
+                    RuntimeError("signal for unmapped symbol"),
+                )
+            return
+        coro = self._handle_signal(ccxt_sym, sig)
+        loop = self._loop
+        if loop is None:
+            if self.on_error:
+                self.on_error(
+                    str(ccxt_sym),
+                    RuntimeError("signal received before broker.run() started"),
+                )
+            return
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is loop:
+            loop.create_task(coro)
+        else:
+            asyncio.run_coroutine_threadsafe(coro, loop)
+
+    async def _handle_signal(self, ccxt_sym: Optional[str], sig: Any) -> None:
+        order_type = (getattr(sig, "order_type", "") or "").upper()
+        side = (getattr(sig, "side", "") or "").lower()
+        try:
+            if order_type == "MARKET":
+                await self._place_market(ccxt_sym, side, sig)
+            elif order_type == "LIMIT":
+                await self._place_limit(ccxt_sym, side, sig)
+            elif order_type == "STOP_MARKET":
+                await self._place_stop_market(ccxt_sym, side, sig)
+            elif order_type == "STOP_LIMIT":
+                await self._place_stop_limit(ccxt_sym, side, sig)
+            elif order_type == "TAKE_PROFIT_MARKET":
+                await self._place_tp_market(ccxt_sym, side, sig)
+            elif order_type == "TAKE_PROFIT_LIMIT":
+                await self._place_tp_limit(ccxt_sym, side, sig)
+            elif order_type in ("TRAILING_STOP", "TRAILING_STOP_PERCENT"):
+                await self._place_trailing(ccxt_sym, side, sig, order_type)
+            elif order_type == "CLOSE_POSITION":
+                await self._place_close(ccxt_sym, side, sig)
+            elif order_type == "CANCEL":
+                await self._cancel(ccxt_sym, sig)
+            elif order_type == "CANCEL_ALL":
+                await self._cancel_all(ccxt_sym)
+            elif order_type == "MODIFY":
+                await self._modify(ccxt_sym, side, sig)
+            else:
+                raise UnsupportedOrderType(
+                    f"order_type {order_type!r} not handled by CcxtBroker"
+                )
+        except asyncio.CancelledError:
+            raise
+        except BaseException as e:
+            if self.on_error:
+                self.on_error(str(ccxt_sym or "?"), e)
+
+    # ── Order placement helpers ───────────────────────────────────────
+
+    @staticmethod
+    def _qty(sig: Any) -> float:
+        q = float(getattr(sig, "quantity", 0.0))
+        if q <= 0:
+            raise ValueError(f"non-positive quantity {q!r} on signal")
+        return q
+
+    @staticmethod
+    def _price(sig: Any) -> float:
+        p = float(getattr(sig, "price", 0.0))
+        if p <= 0:
+            raise ValueError(f"non-positive price {p!r} on signal")
+        return p
+
+    @staticmethod
+    def _trigger(sig: Any) -> float:
+        p = float(getattr(sig, "trigger_price", 0.0))
+        if p <= 0:
+            raise ValueError(f"non-positive trigger_price {p!r} on signal")
+        return p
+
+    def _track_order(self, ccxt_sym: Optional[str], sig: Any, res: Any) -> None:
+        ccxt_id = res.get("id") if isinstance(res, dict) else None
+        flox_id = int(getattr(sig, "order_id", 0) or 0)
+        if not ccxt_id:
+            return
+        if flox_id:
+            self._flox_to_ccxt_order[flox_id] = str(ccxt_id)
+        if ccxt_sym:
+            self._ccxt_orders_by_sym.setdefault(ccxt_sym, set()).add(str(ccxt_id))
+
+    async def _place_market(self, sym: Optional[str], side: str, sig: Any) -> None:
+        if not sym:
+            raise ValueError("MARKET order requires a tracked symbol")
+        qty = self._qty(sig)
+        if side == "buy":
+            res = await self.exchange.create_market_buy_order(sym, qty)
+        elif side == "sell":
+            res = await self.exchange.create_market_sell_order(sym, qty)
+        else:
+            raise ValueError(f"unknown side {side!r}")
+        self._track_order(sym, sig, res)
+
+    async def _place_limit(self, sym: Optional[str], side: str, sig: Any) -> None:
+        if not sym:
+            raise ValueError("LIMIT order requires a tracked symbol")
+        qty = self._qty(sig)
+        price = self._price(sig)
+        if side == "buy":
+            res = await self.exchange.create_limit_buy_order(sym, qty, price)
+        elif side == "sell":
+            res = await self.exchange.create_limit_sell_order(sym, qty, price)
+        else:
+            raise ValueError(f"unknown side {side!r}")
+        self._track_order(sym, sig, res)
+
+    async def _place_stop_market(self, sym: Optional[str], side: str, sig: Any) -> None:
+        if not sym:
+            raise ValueError("STOP_MARKET requires a tracked symbol")
+        res = await self.exchange.create_order(
+            sym, "stop_market", side, self._qty(sig), None,
+            {"stopPrice": self._trigger(sig)},
+        )
+        self._track_order(sym, sig, res)
+
+    async def _place_stop_limit(self, sym: Optional[str], side: str, sig: Any) -> None:
+        if not sym:
+            raise ValueError("STOP_LIMIT requires a tracked symbol")
+        res = await self.exchange.create_order(
+            sym, "stop_limit", side, self._qty(sig), self._price(sig),
+            {"stopPrice": self._trigger(sig)},
+        )
+        self._track_order(sym, sig, res)
+
+    async def _place_tp_market(self, sym: Optional[str], side: str, sig: Any) -> None:
+        if not sym:
+            raise ValueError("TAKE_PROFIT_MARKET requires a tracked symbol")
+        res = await self.exchange.create_order(
+            sym, "take_profit_market", side, self._qty(sig), None,
+            {"stopPrice": self._trigger(sig)},
+        )
+        self._track_order(sym, sig, res)
+
+    async def _place_tp_limit(self, sym: Optional[str], side: str, sig: Any) -> None:
+        if not sym:
+            raise ValueError("TAKE_PROFIT_LIMIT requires a tracked symbol")
+        res = await self.exchange.create_order(
+            sym, "take_profit_limit", side, self._qty(sig), self._price(sig),
+            {"stopPrice": self._trigger(sig)},
+        )
+        self._track_order(sym, sig, res)
+
+    async def _place_trailing(
+        self, sym: Optional[str], side: str, sig: Any, kind: str,
+    ) -> None:
+        if not sym:
+            raise ValueError(f"{kind} requires a tracked symbol")
+        if kind == "TRAILING_STOP_PERCENT":
+            bps = int(getattr(sig, "trailing_bps", 0) or 0)
+            if bps <= 0:
+                raise ValueError(f"non-positive trailing_bps {bps!r}")
+            params = {"callbackRate": bps / 100.0}
+        else:
+            offset = float(getattr(sig, "trailing_offset", 0.0) or 0.0)
+            if offset <= 0:
+                raise ValueError(f"non-positive trailing_offset {offset!r}")
+            params = {"trailingDelta": offset}
+        res = await self.exchange.create_order(
+            sym, "trailing_stop_market", side, self._qty(sig), None, params,
+        )
+        self._track_order(sym, sig, res)
+
+    async def _place_close(self, sym: Optional[str], side: str, sig: Any) -> None:
+        if not sym:
+            raise ValueError("CLOSE_POSITION requires a tracked symbol")
+        res = await self.exchange.create_order(
+            sym, "market", side, self._qty(sig), None, {"reduceOnly": True},
+        )
+        self._track_order(sym, sig, res)
+
+    async def _cancel(self, sym: Optional[str], sig: Any) -> None:
+        flox_id = int(getattr(sig, "order_id", 0) or 0)
+        ccxt_id = self._flox_to_ccxt_order.get(flox_id)
+        if ccxt_id is None:
+            raise ValueError(
+                f"CANCEL: no ccxt order id tracked for flox order_id={flox_id}"
+            )
+        await self.exchange.cancel_order(ccxt_id, sym)
+        self._flox_to_ccxt_order.pop(flox_id, None)
+        if sym and sym in self._ccxt_orders_by_sym:
+            self._ccxt_orders_by_sym[sym].discard(ccxt_id)
+
+    async def _cancel_all(self, sym: Optional[str]) -> None:
+        if not sym:
+            raise ValueError("CANCEL_ALL requires a tracked symbol")
+        ids = list(self._ccxt_orders_by_sym.get(sym, set()))
+        if not ids:
+            return
+        for ccxt_id in ids:
+            try:
+                await self.exchange.cancel_order(ccxt_id, sym)
+            except BaseException as e:
+                if self.on_error:
+                    self.on_error(sym, e)
+        self._ccxt_orders_by_sym.pop(sym, None)
+        # Drop reverse-lookup entries that pointed at this symbol's ids.
+        for fid in [f for f, c in self._flox_to_ccxt_order.items() if c in ids]:
+            self._flox_to_ccxt_order.pop(fid, None)
+
+    async def _modify(self, sym: Optional[str], side: str, sig: Any) -> None:
+        flox_id = int(getattr(sig, "order_id", 0) or 0)
+        ccxt_id = self._flox_to_ccxt_order.get(flox_id)
+        if ccxt_id is None:
+            raise ValueError(
+                f"MODIFY: no ccxt order id tracked for flox order_id={flox_id}"
+            )
+        new_price = float(getattr(sig, "new_price", 0.0) or 0.0)
+        new_qty = float(getattr(sig, "new_quantity", 0.0) or 0.0)
+        if new_qty <= 0:
+            raise ValueError(f"MODIFY: non-positive new_quantity {new_qty!r}")
+        edit = getattr(self.exchange, "edit_order", None)
+        if edit is None:
+            raise UnsupportedOrderType(
+                f"exchange {self.exchange_id} does not support edit_order"
+            )
+        # ccxt uses the same `type` value the original order had — without
+        # tracking it we use 'limit' as the most common modify target.
+        await edit(ccxt_id, sym, "limit", side, new_qty,
+                   new_price if new_price > 0 else None)
+
+    # ── Position reconciliation ───────────────────────────────────────
+
+    async def _reconcile_positions(self) -> None:
+        """Fetch balance / positions, dispatch to strategy callbacks.
+
+        Both calls are best-effort. ``fetch_positions`` is a derivatives
+        concept — for spot-only exchanges ccxt raises ``NotSupported``,
+        which we treat as "no positions" rather than fail.
+        """
+        try:
+            await self.exchange.fetch_balance()
+        except asyncio.CancelledError:
+            raise
+        except BaseException as e:
+            if self.on_error:
+                self.on_error("balance", e)
+
+        positions: list = []
+        try:
+            res = await self.exchange.fetch_positions()
+            if isinstance(res, list):
+                positions = res
+        except asyncio.CancelledError:
+            raise
+        except BaseException as e:
+            msg = str(e).lower()
+            if "notsupported" not in type(e).__name__.lower() and "not support" not in msg:
+                if self.on_error:
+                    self.on_error("positions", e)
+
+        for pos in positions:
+            ccxt_sym = pos.get("symbol", "")
+            if ccxt_sym not in self._ccxt_to_sym:
+                continue
+            qty = float(pos.get("contracts") or pos.get("amount") or 0.0)
+            avg = float(pos.get("entryPrice") or pos.get("average") or 0.0)
+            if qty == 0:
+                continue
+            for strat in self._strategies:
+                fn = getattr(strat, "on_initial_position", None)
+                if callable(fn):
+                    try:
+                        fn(ccxt_sym, qty, avg)
+                    except BaseException as e:
+                        if self.on_error:
+                            self.on_error(ccxt_sym, e)
+
+    # ── Order updates ─────────────────────────────────────────────────
+
+    def _dispatch_order_update(self, o: Mapping[str, Any]) -> None:
+        ccxt_sym = str(o.get("symbol", ""))
+        status = str(o.get("status", ""))
+        filled = float(o.get("filled") or 0.0)
+        avg = float(o.get("average") or o.get("price") or 0.0)
+        for strat in self._strategies:
+            fn = getattr(strat, "on_order_update", None)
+            if callable(fn):
+                try:
+                    fn(ccxt_sym, status, filled, avg)
+                except BaseException as e:
+                    if self.on_error:
+                        self.on_error(ccxt_sym, e)
+
+
+__all__ = ["CcxtBroker", "UnsupportedOrderType"]

--- a/python/flox_py/ccxt.py
+++ b/python/flox_py/ccxt.py
@@ -1,0 +1,235 @@
+"""CCXT live data adapter for FLOX.
+
+Wraps a ``ccxt.pro`` exchange and forwards trades / book updates into a
+``flox_py.Runner``. Lets you connect any of CCXT's 100+ supported
+exchanges to FLOX without writing the WebSocket plumbing yourself.
+
+Quick start
+-----------
+
+.. code-block:: python
+
+    import asyncio
+    import ccxt.pro as ccxtpro
+    import flox_py as flox
+    from flox_py.ccxt import CcxtFeed
+
+    registry = flox.SymbolRegistry()
+    btc = registry.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+
+    runner = flox.Runner(registry, on_signal=lambda s: print(s))
+    runner.add_strategy(MyStrategy([btc]))
+    runner.start()
+
+    exchange = ccxtpro.binance()
+    feed = CcxtFeed(
+        exchange=exchange,
+        runner=runner,
+        symbols={"BTC/USDT": btc},
+        streams=("trades", "book"),
+    )
+
+    try:
+        asyncio.run(feed.run())
+    finally:
+        runner.stop()
+        asyncio.run(exchange.close())
+
+Order routing
+-------------
+
+CcxtFeed only handles **inbound** market data. Order placement is up to
+your strategy's signal handler:
+
+.. code-block:: python
+
+    def on_signal(sig):
+        if sig.side == "buy":
+            asyncio.create_task(
+                exchange.create_market_buy_order("BTC/USDT", sig.quantity)
+            )
+
+This split keeps the inbound (FLOX-controlled) and outbound (broker-
+controlled) paths cleanly separable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _ccxt_ts_ns(t: Any) -> int:
+    """Extract a nanosecond timestamp from a ccxt trade / book object.
+
+    ccxt timestamps are in milliseconds; we convert to ns. Falls back to
+    ``time.time_ns()`` if the field is missing or zero (some exchanges
+    occasionally emit updates without a ts).
+    """
+    ts_ms = t.get("timestamp") if isinstance(t, dict) else None
+    if ts_ms:
+        return int(ts_ms) * 1_000_000
+    return time.time_ns()
+
+
+def _trade_is_buy(t: Mapping[str, Any]) -> bool:
+    """Map a ccxt trade dict's ``side`` to a buy/sell boolean."""
+    side = (t.get("side") or "").lower()
+    return side == "buy"
+
+
+# ── Feed ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class CcxtFeed:
+    """Bridges a ``ccxt.pro`` exchange into a ``flox_py.Runner``.
+
+    Parameters
+    ----------
+    exchange
+        A ``ccxt.pro`` exchange instance, already configured (api keys
+        if you intend to trade — not needed for public market data).
+    runner
+        The FLOX ``Runner`` to forward events into. Must be started
+        *before* ``run()`` is awaited so its strategy callbacks are live.
+    symbols
+        Mapping ``{ccxt_symbol: flox_symbol}``. The CCXT symbol is the
+        format the exchange expects (e.g. ``"BTC/USDT"`` or
+        ``"BTC/USDT:USDT"`` for perpetuals); the FLOX symbol is whatever
+        ``SymbolRegistry.add_symbol()`` returned (or its ``.id``).
+    streams
+        Which streams to subscribe to. ``"trades"`` and/or ``"book"``.
+        Defaults to both.
+    book_depth
+        L2 depth (number of bid/ask levels) to forward. Most exchanges
+        publish 20 levels by default; set lower if your strategy doesn't
+        need full depth.
+    on_error
+        Optional callable ``(symbol_str, exception) -> None`` invoked
+        when a stream raises. Defaults to logging via the standard
+        ``logging`` module. Set to ``None`` to silence.
+    """
+
+    exchange: Any
+    runner: Any
+    symbols: Mapping[str, Any]
+    streams: Iterable[str] = ("trades", "book")
+    book_depth: int = 20
+    on_error: Optional[Callable[[str, BaseException], None]] = None
+
+    _tasks: list[asyncio.Task] = field(default_factory=list, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        # Validate streams up front so the user gets a TypeError now
+        # rather than mid-loop.
+        valid = {"trades", "book"}
+        for s in self.streams:
+            if s not in valid:
+                raise ValueError(
+                    f"unknown stream {s!r}; expected one of {sorted(valid)}"
+                )
+        if not self.symbols:
+            raise ValueError("CcxtFeed: symbols mapping must not be empty")
+        if self.on_error is None:
+            self.on_error = self._default_on_error
+
+    @staticmethod
+    def _default_on_error(symbol: str, exc: BaseException) -> None:
+        logger.warning("ccxt feed error on %s: %r", symbol, exc)
+
+    # ── Public API ────────────────────────────────────────────────────
+
+    async def run(self) -> None:
+        """Run all configured streams concurrently. Cancellation-safe.
+
+        Returns when every stream task has been cancelled. Typically
+        you'd call this with ``asyncio.run(feed.run())`` and let
+        Ctrl+C / signal cancellation tear it down; the calling code is
+        responsible for closing the ccxt exchange afterwards.
+        """
+        try:
+            for ccxt_sym, flox_sym in self.symbols.items():
+                if "trades" in self.streams:
+                    self._tasks.append(
+                        asyncio.create_task(self._trades_loop(ccxt_sym, flox_sym),
+                                             name=f"ccxt-trades-{ccxt_sym}")
+                    )
+                if "book" in self.streams:
+                    self._tasks.append(
+                        asyncio.create_task(self._book_loop(ccxt_sym, flox_sym),
+                                             name=f"ccxt-book-{ccxt_sym}")
+                    )
+            await asyncio.gather(*self._tasks)
+        except asyncio.CancelledError:
+            for t in self._tasks:
+                t.cancel()
+            raise
+
+    async def stop(self) -> None:
+        """Cancel all running stream tasks. Idempotent."""
+        for t in self._tasks:
+            t.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+
+    # ── Stream loops ──────────────────────────────────────────────────
+
+    async def _trades_loop(self, ccxt_sym: str, flox_sym: Any) -> None:
+        sym_id = int(flox_sym)
+        while True:
+            try:
+                trades = await self.exchange.watch_trades(ccxt_sym)
+            except asyncio.CancelledError:
+                raise
+            except BaseException as e:
+                if self.on_error:
+                    self.on_error(ccxt_sym, e)
+                # Brief backoff to avoid busy-looping on persistent errors.
+                await asyncio.sleep(1.0)
+                continue
+            for t in trades:
+                self.runner.on_trade(
+                    sym_id,
+                    float(t["price"]),
+                    float(t["amount"]),
+                    _trade_is_buy(t),
+                    _ccxt_ts_ns(t),
+                )
+
+    async def _book_loop(self, ccxt_sym: str, flox_sym: Any) -> None:
+        sym_id = int(flox_sym)
+        while True:
+            try:
+                ob = await self.exchange.watch_order_book(ccxt_sym, limit=self.book_depth)
+            except asyncio.CancelledError:
+                raise
+            except BaseException as e:
+                if self.on_error:
+                    self.on_error(ccxt_sym, e)
+                await asyncio.sleep(1.0)
+                continue
+            bids_raw = ob.get("bids", [])[: self.book_depth]
+            asks_raw = ob.get("asks", [])[: self.book_depth]
+            bid_prices = [float(b[0]) for b in bids_raw]
+            bid_qtys = [float(b[1]) for b in bids_raw]
+            ask_prices = [float(a[0]) for a in asks_raw]
+            ask_qtys = [float(a[1]) for a in asks_raw]
+            self.runner.on_book_snapshot(
+                sym_id,
+                bid_prices, bid_qtys,
+                ask_prices, ask_qtys,
+                _ccxt_ts_ns(ob),
+            )
+
+
+__all__ = ["CcxtFeed"]

--- a/python/tests/test_ccxt_adapter.py
+++ b/python/tests/test_ccxt_adapter.py
@@ -1,9 +1,28 @@
-"""
-python/tests/test_ccxt_adapter.py — verify CcxtFeed forwards trades and
-book updates from a mock ccxt exchange into a flox.Runner.
+"""Tests for ``flox_py.ccxt.CcxtBroker``.
 
-Doesn't require ccxt to be installed; we mock the parts we use
-(watch_trades / watch_order_book / close).
+The broker is pure-Python glue around ``ccxt.pro`` plus a FLOX
+``Runner``. To run without ccxt actually installed we inject a
+``FakeCcxtExchange`` that records calls and feeds canned WebSocket
+data through ``asyncio.Queue``s.
+
+Coverage:
+
+  * ``add_symbol`` reads tick size from market metadata and registers
+    in the internal ``SymbolRegistry``.
+  * Trades / book / orders streams forward correctly into
+    ``runner.on_trade`` / ``runner.on_book_snapshot`` / strategy's
+    ``on_order_update``.
+  * Outbound order routing for every supported ``order_type``:
+    MARKET, LIMIT, STOP_MARKET, STOP_LIMIT, TAKE_PROFIT_MARKET,
+    TAKE_PROFIT_LIMIT, TRAILING_STOP, TRAILING_STOP_PERCENT,
+    CLOSE_POSITION, CANCEL, CANCEL_ALL, MODIFY.
+  * Unsupported order_type goes through ``on_error`` as
+    ``UnsupportedOrderType``, no exchange call.
+  * Position reconciliation calls strategy's
+    ``on_initial_position(ccxt_sym, qty, avg)`` for non-zero
+    positions; ``NotSupported`` from spot exchanges is suppressed.
+  * Exponential backoff: first stream call fails → broker waits
+    ``retry_initial_delay``, doubles, retries; success resets delay.
 
 Run from repo root:
     PYTHONPATH=build/python python3 python/tests/test_ccxt_adapter.py
@@ -12,45 +31,45 @@ Run from repo root:
 import asyncio
 import os
 import sys
+import unittest
 
 build_dir = os.path.join(os.path.dirname(__file__), "..", "..", "build", "python")
 sys.path.insert(0, os.path.abspath(build_dir))
 
 import flox_py as flox
-from flox_py.ccxt import CcxtFeed
-
-_passed = 0
-_failed = 0
+from flox_py.ccxt import CcxtBroker, UnsupportedOrderType, _market_tick_size
 
 
-def check(cond, msg):
-    global _passed, _failed
-    if cond:
-        print(f"  ok  {msg}")
-        _passed += 1
-    else:
-        print(f"  FAIL  {msg}")
-        _failed += 1
+# ── Fake exchange ─────────────────────────────────────────────────────
 
 
-# ── Mock ccxt exchange ────────────────────────────────────────────────
+class _NotSupported(Exception):
+    """Mimics ccxt.NotSupported without importing ccxt."""
 
 
 class FakeCcxtExchange:
-    """Minimal stand-in for a ccxt.pro exchange.
+    """Minimal stand-in for a ``ccxt.pro`` exchange."""
 
-    `_trades` and `_books` are queues fed from the test; the watch_*
-    methods pop from them (or wait forever if empty), simulating WS
-    streams. Realistic enough for a smoke test.
-    """
+    def __init__(self, *, markets=None, balance=None, positions=None):
+        self.markets = markets or {
+            "BTC/USDT": {"precision": {"price": 0.01}},
+            "ETH/USDT": {"precision": {"price": 2}},
+        }
+        self._balance = balance or {"USDT": {"free": 1000.0}}
+        self._positions = positions  # None → raise NotSupported
+        self._trades_q: asyncio.Queue | None = None
+        self._book_q: asyncio.Queue | None = None
+        self._orders_q: asyncio.Queue | None = None
+        self.calls: list = []  # (method_name, args, kwargs)
+        self._next_id = 1
+        self.sandbox = False
+        self.closed = False
 
-    def __init__(self):
-        self._trades_q: asyncio.Queue = None
-        self._book_q: asyncio.Queue = None
-
+    # Setup -----------------------------------------------------------
     def init_queues(self):
         self._trades_q = asyncio.Queue()
         self._book_q = asyncio.Queue()
+        self._orders_q = asyncio.Queue()
 
     def feed_trades(self, trades):
         self._trades_q.put_nowait(trades)
@@ -58,151 +77,584 @@ class FakeCcxtExchange:
     def feed_book(self, book):
         self._book_q.put_nowait(book)
 
+    def feed_orders(self, orders):
+        self._orders_q.put_nowait(orders)
+
+    def set_sandbox_mode(self, on):
+        self.sandbox = on
+
+    # ccxt surface ----------------------------------------------------
+    async def load_markets(self):
+        return self.markets
+
     async def watch_trades(self, symbol):
         return await self._trades_q.get()
 
     async def watch_order_book(self, symbol, limit=20):
         return await self._book_q.get()
 
+    async def watch_orders(self):
+        return await self._orders_q.get()
+
+    async def fetch_balance(self):
+        return self._balance
+
+    async def fetch_positions(self):
+        if self._positions is None:
+            raise _NotSupported("fetch_positions not supported on spot")
+        return self._positions
+
+    def _record(self, name, args, kwargs):
+        self.calls.append((name, args, kwargs))
+        oid = str(self._next_id)
+        self._next_id += 1
+        return {"id": oid, "status": "open"}
+
+    async def create_market_buy_order(self, sym, qty):
+        return self._record("create_market_buy_order", (sym, qty), {})
+
+    async def create_market_sell_order(self, sym, qty):
+        return self._record("create_market_sell_order", (sym, qty), {})
+
+    async def create_limit_buy_order(self, sym, qty, price):
+        return self._record("create_limit_buy_order", (sym, qty, price), {})
+
+    async def create_limit_sell_order(self, sym, qty, price):
+        return self._record("create_limit_sell_order", (sym, qty, price), {})
+
+    async def create_order(self, sym, type_, side, qty, price=None, params=None):
+        return self._record(
+            "create_order", (sym, type_, side, qty, price), {"params": params or {}}
+        )
+
+    async def cancel_order(self, oid, sym=None):
+        self.calls.append(("cancel_order", (oid, sym), {}))
+        return {"id": oid, "status": "canceled"}
+
+    async def edit_order(self, oid, sym, type_, side, qty, price=None):
+        self.calls.append(("edit_order", (oid, sym, type_, side, qty, price), {}))
+        return {"id": oid, "status": "open"}
+
+    async def close(self):
+        self.closed = True
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _make_signal(*, symbol_id, order_type, side="", quantity=0.0, price=0.0,
+                 trigger_price=0.0, trailing_offset=0.0, trailing_bps=0,
+                 order_id=0, new_price=0.0, new_quantity=0.0):
+    """Construct a ``flox.Signal`` with the requested fields set."""
+    s = flox.Signal()
+    s.symbol = symbol_id
+    s.order_type = order_type
+    s.side = side
+    s.quantity = quantity
+    s.price = price
+    s.trigger_price = trigger_price
+    s.trailing_offset = trailing_offset
+    s.trailing_bps = trailing_bps
+    s.order_id = order_id
+    s.new_price = new_price
+    s.new_quantity = new_quantity
+    return s
+
 
 # ── Tests ─────────────────────────────────────────────────────────────
 
 
-def test_trades_forwarded():
-    print("test_trades_forwarded")
-    reg = flox.SymbolRegistry()
-    btc = reg.add_symbol("test", "BTCUSDT", 0.01)
-    seen_trades = []
+class CcxtBrokerTests(unittest.TestCase):
 
-    class S(flox.Strategy):
-        def on_trade(self, ctx, trade):
-            seen_trades.append((trade.price, trade.quantity, trade.is_buy))
+    # ── construction / config ────────────────────────────────────────
+    def test_market_tick_size_parses_decimals_and_tick(self):
+        self.assertEqual(_market_tick_size({"precision": {"price": 0.01}}), 0.01)
+        self.assertEqual(_market_tick_size({"precision": {"price": 2}}), 0.01)
+        self.assertEqual(_market_tick_size({"precision": {"price": 5}}), 0.00001)
+        self.assertEqual(_market_tick_size({}), 0.01)
+        self.assertEqual(_market_tick_size({"precision": {"price": "weird"}}), 0.01)
 
-    runner = flox.Runner(reg, lambda sig: None, threaded=False)
-    runner.add_strategy(S([btc]))
-    runner.start()
+    def test_invalid_backoff_params(self):
+        fake = FakeCcxtExchange()
+        with self.assertRaises(ValueError):
+            CcxtBroker("binance", exchange=fake, retry_initial_delay=0)
+        with self.assertRaises(ValueError):
+            CcxtBroker("binance", exchange=fake,
+                       retry_initial_delay=2, retry_max_delay=1)
+        with self.assertRaises(ValueError):
+            CcxtBroker("binance", exchange=fake, retry_multiplier=0.5)
 
-    fake = FakeCcxtExchange()
-    feed = CcxtFeed(
-        exchange=fake,
-        runner=runner,
-        symbols={"BTC/USDT": btc},
-        streams=("trades",),
-    )
+    # ── add_symbol / load_markets ────────────────────────────────────
+    def test_add_symbol_loads_markets_and_registers(self):
+        fake = FakeCcxtExchange()
+        broker = CcxtBroker("binance", exchange=fake)
 
-    async def driver():
-        fake.init_queues()
-        # Push a couple of trades.
-        fake.feed_trades([
-            {"price": 100.5, "amount": 0.5, "side": "buy",  "timestamp": 1_700_000_000_000},
-            {"price": 101.0, "amount": 1.0, "side": "sell", "timestamp": 1_700_000_001_000},
+        async def go():
+            btc = await broker.add_symbol("BTC/USDT")
+            eth = await broker.add_symbol("ETH/USDT")
+            return btc, eth
+
+        btc, eth = asyncio.run(go())
+        self.assertNotEqual(int(btc), int(eth))
+        self.assertIn(int(btc), broker._sym_to_ccxt)
+        self.assertEqual(broker._sym_to_ccxt[int(btc)], "BTC/USDT")
+        self.assertEqual(broker._sym_to_ccxt[int(eth)], "ETH/USDT")
+
+    def test_add_symbol_unknown_raises(self):
+        fake = FakeCcxtExchange()
+        broker = CcxtBroker("binance", exchange=fake)
+        with self.assertRaises(ValueError):
+            asyncio.run(broker.add_symbol("DOGE/USDT"))
+
+    # ── streams ──────────────────────────────────────────────────────
+    def test_trades_stream_forwards(self):
+        fake = FakeCcxtExchange()
+        broker = CcxtBroker("binance", exchange=fake)
+        seen = []
+
+        class S(flox.Strategy):
+            def on_trade(self, ctx, trade):
+                seen.append((trade.price, trade.quantity, trade.is_buy))
+
+        async def go():
+            btc = await broker.add_symbol("BTC/USDT")
+            broker.add_strategy(S([btc]))
+            fake.init_queues()
+            fake.feed_trades([
+                {"price": 100.5, "amount": 0.5, "side": "buy",  "timestamp": 1_700_000_000_000},
+                {"price": 101.0, "amount": 1.0, "side": "sell", "timestamp": 1_700_000_001_000},
+            ])
+            run_task = asyncio.create_task(broker.run(streams=("trades",), reconcile=False))
+            await asyncio.sleep(0.05)
+            await broker.stop()
+            try:
+                await run_task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(go())
+        self.assertEqual(len(seen), 2)
+        self.assertEqual(seen[0], (100.5, 0.5, True))
+        self.assertFalse(seen[1][2])
+
+    def test_book_stream_forwards(self):
+        fake = FakeCcxtExchange()
+        broker = CcxtBroker("binance", exchange=fake)
+        seen = []
+
+        class S(flox.Strategy):
+            def on_book_update(self, ctx):
+                seen.append((ctx.best_bid, ctx.best_ask))
+
+        async def go():
+            btc = await broker.add_symbol("BTC/USDT")
+            broker.add_strategy(S([btc]))
+            fake.init_queues()
+            fake.feed_book({
+                "bids": [[100.0, 1.0], [99.5, 2.0]],
+                "asks": [[100.5, 1.5], [101.0, 2.5]],
+                "timestamp": 1_700_000_000_000,
+            })
+            run_task = asyncio.create_task(
+                broker.run(streams=("book",), book_depth=5, reconcile=False)
+            )
+            await asyncio.sleep(0.05)
+            await broker.stop()
+            try:
+                await run_task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(go())
+        self.assertEqual(len(seen), 1)
+        bid, ask = seen[0]
+        self.assertEqual(bid, 100.0)
+        self.assertEqual(ask, 100.5)
+
+    def test_orders_stream_dispatches_to_strategy(self):
+        fake = FakeCcxtExchange()
+        broker = CcxtBroker("binance", exchange=fake)
+        updates = []
+
+        class S(flox.Strategy):
+            def on_order_update(self, sym, status, filled, avg):
+                updates.append((sym, status, filled, avg))
+
+        async def go():
+            btc = await broker.add_symbol("BTC/USDT")
+            broker.add_strategy(S([btc]))
+            fake.init_queues()
+            fake.feed_orders([
+                {"symbol": "BTC/USDT", "status": "filled",
+                 "filled": 0.5, "average": 100.5},
+            ])
+            run_task = asyncio.create_task(
+                broker.run(streams=("orders",), reconcile=False)
+            )
+            await asyncio.sleep(0.05)
+            await broker.stop()
+            try:
+                await run_task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(go())
+        self.assertEqual(updates, [("BTC/USDT", "filled", 0.5, 100.5)])
+
+    # ── outbound order routing ───────────────────────────────────────
+    def _route(self, sig_kwargs, broker_kwargs=None):
+        """Drive a single signal through the broker; return fake.calls."""
+        fake = FakeCcxtExchange()
+        broker_kwargs = broker_kwargs or {}
+        broker = CcxtBroker("binance", exchange=fake, **broker_kwargs)
+        errors = []
+        broker.on_error = lambda ctx, exc: errors.append((ctx, type(exc).__name__, str(exc)))
+
+        async def go():
+            btc = await broker.add_symbol("BTC/USDT")
+            broker.add_strategy(flox.Strategy([btc]))
+            fake.init_queues()
+            sig = _make_signal(symbol_id=int(btc), **sig_kwargs)
+            run_task = asyncio.create_task(
+                broker.run(streams=(), reconcile=False)
+            )
+            await asyncio.sleep(0)
+            broker._on_signal(sig)
+            await asyncio.sleep(0.02)
+            await broker.stop()
+            try:
+                await run_task
+            except (asyncio.CancelledError, ValueError):
+                pass
+
+        asyncio.run(go())
+        return fake.calls, errors, broker
+
+    def test_market_buy_routes(self):
+        calls, errs, _ = self._route(dict(
+            order_type="MARKET", side="buy", quantity=0.01))
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "create_market_buy_order")
+        self.assertEqual(calls[0][1], ("BTC/USDT", 0.01))
+        self.assertFalse(errs)
+
+    def test_market_sell_routes(self):
+        calls, _, _ = self._route(dict(
+            order_type="MARKET", side="sell", quantity=0.02))
+        self.assertEqual(calls[0][0], "create_market_sell_order")
+
+    def test_limit_buy_routes_with_price(self):
+        calls, _, _ = self._route(dict(
+            order_type="LIMIT", side="buy", quantity=0.5, price=99.5))
+        self.assertEqual(calls[0][0], "create_limit_buy_order")
+        self.assertEqual(calls[0][1], ("BTC/USDT", 0.5, 99.5))
+
+    def test_stop_market_routes(self):
+        calls, _, _ = self._route(dict(
+            order_type="STOP_MARKET", side="sell",
+            quantity=0.1, trigger_price=98.0))
+        self.assertEqual(calls[0][0], "create_order")
+        self.assertEqual(calls[0][1][1], "stop_market")
+        self.assertEqual(calls[0][2]["params"], {"stopPrice": 98.0})
+
+    def test_stop_limit_routes(self):
+        calls, _, _ = self._route(dict(
+            order_type="STOP_LIMIT", side="sell",
+            quantity=0.1, price=97.5, trigger_price=98.0))
+        self.assertEqual(calls[0][1][1], "stop_limit")
+        self.assertEqual(calls[0][1][4], 97.5)
+        self.assertEqual(calls[0][2]["params"], {"stopPrice": 98.0})
+
+    def test_take_profit_market_routes(self):
+        calls, _, _ = self._route(dict(
+            order_type="TAKE_PROFIT_MARKET", side="sell",
+            quantity=0.1, trigger_price=120.0))
+        self.assertEqual(calls[0][1][1], "take_profit_market")
+
+    def test_take_profit_limit_routes(self):
+        calls, _, _ = self._route(dict(
+            order_type="TAKE_PROFIT_LIMIT", side="sell",
+            quantity=0.1, price=121.0, trigger_price=120.0))
+        self.assertEqual(calls[0][1][1], "take_profit_limit")
+        self.assertEqual(calls[0][1][4], 121.0)
+
+    def test_trailing_stop_routes_with_offset(self):
+        calls, _, _ = self._route(dict(
+            order_type="TRAILING_STOP", side="sell",
+            quantity=0.1, trailing_offset=0.5))
+        self.assertEqual(calls[0][1][1], "trailing_stop_market")
+        self.assertEqual(calls[0][2]["params"], {"trailingDelta": 0.5})
+
+    def test_trailing_stop_percent_routes_with_callback_rate(self):
+        calls, _, _ = self._route(dict(
+            order_type="TRAILING_STOP_PERCENT", side="sell",
+            quantity=0.1, trailing_bps=200))
+        self.assertEqual(calls[0][1][1], "trailing_stop_market")
+        self.assertEqual(calls[0][2]["params"], {"callbackRate": 2.0})
+
+    def test_close_position_uses_reduce_only(self):
+        calls, _, _ = self._route(dict(
+            order_type="CLOSE_POSITION", side="sell", quantity=0.1))
+        self.assertEqual(calls[0][1][1], "market")
+        self.assertEqual(calls[0][2]["params"], {"reduceOnly": True})
+
+    def test_unsupported_order_type_reports_error_no_call(self):
+        calls, errs, _ = self._route(dict(
+            order_type="ICEBERG", side="buy", quantity=0.1))
+        self.assertEqual(calls, [])
+        self.assertTrue(any("UnsupportedOrderType" in t for _, t, _ in errs))
+
+    def test_cancel_uses_tracked_ccxt_id(self):
+        # Place a limit order first, then cancel by flox order_id.
+        fake = FakeCcxtExchange()
+        broker = CcxtBroker("binance", exchange=fake)
+
+        async def go():
+            btc = await broker.add_symbol("BTC/USDT")
+            broker.add_strategy(flox.Strategy([btc]))
+            fake.init_queues()
+            run_task = asyncio.create_task(broker.run(streams=(), reconcile=False))
+            await asyncio.sleep(0)
+            broker._on_signal(_make_signal(
+                symbol_id=int(btc), order_type="LIMIT", side="buy",
+                quantity=0.5, price=99.0, order_id=42,
+            ))
+            await asyncio.sleep(0.02)
+            broker._on_signal(_make_signal(
+                symbol_id=int(btc), order_type="CANCEL", order_id=42,
+            ))
+            await asyncio.sleep(0.02)
+            await broker.stop()
+            try:
+                await run_task
+            except (asyncio.CancelledError, ValueError):
+                pass
+
+        asyncio.run(go())
+        names = [c[0] for c in fake.calls]
+        self.assertIn("create_limit_buy_order", names)
+        self.assertIn("cancel_order", names)
+        # cancel_order must have been called with the id returned for the limit
+        cancel = next(c for c in fake.calls if c[0] == "cancel_order")
+        self.assertEqual(cancel[1][1], "BTC/USDT")  # symbol arg
+
+    def test_cancel_all_walks_tracked_ids(self):
+        fake = FakeCcxtExchange()
+        broker = CcxtBroker("binance", exchange=fake)
+
+        async def go():
+            btc = await broker.add_symbol("BTC/USDT")
+            broker.add_strategy(flox.Strategy([btc]))
+            fake.init_queues()
+            run_task = asyncio.create_task(broker.run(streams=(), reconcile=False))
+            await asyncio.sleep(0)
+            for i in range(3):
+                broker._on_signal(_make_signal(
+                    symbol_id=int(btc), order_type="LIMIT", side="buy",
+                    quantity=0.1, price=99.0, order_id=100 + i,
+                ))
+            await asyncio.sleep(0.02)
+            broker._on_signal(_make_signal(
+                symbol_id=int(btc), order_type="CANCEL_ALL"))
+            await asyncio.sleep(0.02)
+            await broker.stop()
+            try:
+                await run_task
+            except (asyncio.CancelledError, ValueError):
+                pass
+
+        asyncio.run(go())
+        cancels = [c for c in fake.calls if c[0] == "cancel_order"]
+        self.assertEqual(len(cancels), 3)
+
+    def test_modify_calls_edit_order(self):
+        fake = FakeCcxtExchange()
+        broker = CcxtBroker("binance", exchange=fake)
+
+        async def go():
+            btc = await broker.add_symbol("BTC/USDT")
+            broker.add_strategy(flox.Strategy([btc]))
+            fake.init_queues()
+            run_task = asyncio.create_task(broker.run(streams=(), reconcile=False))
+            await asyncio.sleep(0)
+            broker._on_signal(_make_signal(
+                symbol_id=int(btc), order_type="LIMIT", side="buy",
+                quantity=0.5, price=99.0, order_id=7,
+            ))
+            await asyncio.sleep(0.02)
+            broker._on_signal(_make_signal(
+                symbol_id=int(btc), order_type="MODIFY", side="buy",
+                order_id=7, new_price=98.0, new_quantity=0.4,
+            ))
+            await asyncio.sleep(0.02)
+            await broker.stop()
+            try:
+                await run_task
+            except (asyncio.CancelledError, ValueError):
+                pass
+
+        asyncio.run(go())
+        edit = next(c for c in fake.calls if c[0] == "edit_order")
+        self.assertEqual(edit[1][3], "buy")
+        self.assertEqual(edit[1][4], 0.4)
+        self.assertEqual(edit[1][5], 98.0)
+
+    # ── reconciliation ───────────────────────────────────────────────
+    def test_reconciliation_dispatches_initial_position(self):
+        fake = FakeCcxtExchange(positions=[
+            {"symbol": "BTC/USDT", "contracts": 0.5, "entryPrice": 100.0},
+            {"symbol": "ETH/USDT", "contracts": 0, "entryPrice": 0},
+            {"symbol": "DOGE/USDT", "contracts": 1, "entryPrice": 0.1},  # untracked
         ])
-        # Run feed for a tiny window then cancel.
-        run_task = asyncio.create_task(feed.run())
-        await asyncio.sleep(0.05)
-        await feed.stop()
-        try:
-            await run_task
-        except asyncio.CancelledError:
-            pass
+        broker = CcxtBroker("binance", exchange=fake)
+        seen = []
 
-    asyncio.run(driver())
-    runner.stop()
+        class S(flox.Strategy):
+            def on_initial_position(self, sym, qty, avg):
+                seen.append((sym, qty, avg))
 
-    check(len(seen_trades) == 2, f"two trades forwarded (got {len(seen_trades)})")
-    if seen_trades:
-        check(seen_trades[0] == (100.5, 0.5, True),
-              f"first trade is buy 100.5 / 0.5 (got {seen_trades[0]})")
-        check(seen_trades[1][2] is False,
-              f"second trade is sell (got is_buy={seen_trades[1][2]})")
+        async def go():
+            btc = await broker.add_symbol("BTC/USDT")
+            broker.add_strategy(S([btc]))
+            fake.init_queues()
+            run_task = asyncio.create_task(broker.run(streams=()))
+            await asyncio.sleep(0.02)
+            await broker.stop()
+            try:
+                await run_task
+            except asyncio.CancelledError:
+                pass
 
+        asyncio.run(go())
+        # only BTC tracked, only non-zero qty dispatched, untracked symbol skipped
+        self.assertEqual(seen, [("BTC/USDT", 0.5, 100.0)])
 
-def test_book_forwarded():
-    print("test_book_forwarded")
-    reg = flox.SymbolRegistry()
-    btc = reg.add_symbol("test", "BTCUSDT", 0.01)
-    seen_books = []
+    def test_reconciliation_swallows_not_supported(self):
+        fake = FakeCcxtExchange(positions=None)  # → raises _NotSupported
+        broker = CcxtBroker("binance", exchange=fake)
+        errors = []
+        broker.on_error = lambda c, e: errors.append((c, e))
 
-    class S(flox.Strategy):
-        def on_book_update(self, ctx):
-            seen_books.append((ctx.best_bid, ctx.best_ask))
+        async def go():
+            btc = await broker.add_symbol("BTC/USDT")
+            broker.add_strategy(flox.Strategy([btc]))
+            fake.init_queues()
+            run_task = asyncio.create_task(broker.run(streams=()))
+            await asyncio.sleep(0.02)
+            await broker.stop()
+            try:
+                await run_task
+            except asyncio.CancelledError:
+                pass
 
-    runner = flox.Runner(reg, lambda sig: None, threaded=False)
-    runner.add_strategy(S([btc]))
-    runner.start()
+        asyncio.run(go())
+        # spot exchange's NotSupported should not surface as a broker error
+        position_errors = [e for c, e in errors if c == "positions"]
+        self.assertEqual(position_errors, [])
 
-    fake = FakeCcxtExchange()
-    feed = CcxtFeed(
-        exchange=fake,
-        runner=runner,
-        symbols={"BTC/USDT": btc},
-        streams=("book",),
-        book_depth=5,
-    )
+    # ── exponential backoff ──────────────────────────────────────────
+    def test_backoff_doubles_on_repeated_failure_then_resets(self):
+        # Replace asyncio.sleep with a recorder so we measure the
+        # delays without actually sleeping. The broker calls
+        # asyncio.sleep(delay) inside _stream — patching the module
+        # symbol catches it.
+        delays = []
+        real_sleep = asyncio.sleep
 
-    async def driver():
-        fake.init_queues()
-        fake.feed_book({
-            "bids": [[100.0, 1.0], [99.5, 2.0]],
-            "asks": [[100.5, 1.5], [101.0, 2.5]],
-            "timestamp": 1_700_000_000_000,
-        })
-        run_task = asyncio.create_task(feed.run())
-        await asyncio.sleep(0.05)
-        await feed.stop()
-        try:
-            await run_task
-        except asyncio.CancelledError:
-            pass
+        async def fake_sleep(d):
+            delays.append(d)
+            await real_sleep(0)
 
-    asyncio.run(driver())
-    runner.stop()
+        from flox_py import ccxt as ccxt_mod
 
-    check(len(seen_books) == 1, f"one book update forwarded (got {len(seen_books)})")
-    if seen_books:
-        bid, ask = seen_books[0]
-        check(bid == 100.0, f"best bid 100.0 (got {bid})")
-        check(ask == 100.5, f"best ask 100.5 (got {ask})")
-
-
-def test_validation_rejects_unknown_stream():
-    print("test_validation_rejects_unknown_stream")
-    reg = flox.SymbolRegistry()
-    btc = reg.add_symbol("test", "BTCUSDT", 0.01)
-    runner = flox.Runner(reg, lambda sig: None, threaded=False)
-    try:
-        CcxtFeed(
-            exchange=FakeCcxtExchange(),
-            runner=runner,
-            symbols={"BTC/USDT": btc},
-            streams=("trades", "ticker"),  # ticker is not supported
+        broker = CcxtBroker(
+            "binance", exchange=FakeCcxtExchange(),
+            retry_initial_delay=0.5, retry_max_delay=4.0, retry_multiplier=2.0,
         )
-        check(False, "expected ValueError for unknown stream")
-    except ValueError as e:
-        check("ticker" in str(e), "ValueError mentions the bad stream name")
 
+        # _stream is an async generator. Drive 3 failures then 1 success.
+        attempts = {"n": 0}
 
-def test_validation_rejects_empty_symbols():
-    print("test_validation_rejects_empty_symbols")
-    reg = flox.SymbolRegistry()
-    runner = flox.Runner(reg, lambda sig: None, threaded=False)
-    try:
-        CcxtFeed(
-            exchange=FakeCcxtExchange(),
-            runner=runner,
-            symbols={},
-            streams=("trades",),
+        async def flaky():
+            attempts["n"] += 1
+            if attempts["n"] <= 3:
+                raise RuntimeError(f"transient {attempts['n']}")
+            return "ok"
+
+        async def drive():
+            orig = ccxt_mod.asyncio.sleep
+            ccxt_mod.asyncio.sleep = fake_sleep
+            try:
+                gen = broker._stream(flaky, "test")
+                first = await gen.__anext__()
+            finally:
+                ccxt_mod.asyncio.sleep = orig
+            return first
+
+        result = asyncio.run(drive())
+        self.assertEqual(result, "ok")
+        # 3 failures → 3 sleeps with delays 0.5, 1.0, 2.0 (multiplier=2)
+        self.assertEqual(delays, [0.5, 1.0, 2.0])
+
+        # Now drive another failure → success: backoff should have reset
+        # to retry_initial_delay (0.5), not continue from 4.0.
+        delays.clear()
+        attempts["n"] = 0
+
+        async def drive2():
+            orig = ccxt_mod.asyncio.sleep
+            ccxt_mod.asyncio.sleep = fake_sleep
+            try:
+                gen = broker._stream(flaky, "test")
+                # Consume the first success (after 3 failures, delays
+                # 0.5, 1.0, 2.0), then trigger another round.
+                await gen.__anext__()
+                attempts["n"] = 0  # reset counter to force fresh failures
+                await gen.__anext__()
+            finally:
+                ccxt_mod.asyncio.sleep = orig
+
+        asyncio.run(drive2())
+        # 3 + 3 sleeps total; the second batch should also start at 0.5,
+        # confirming reset on success.
+        self.assertEqual(delays[:3], [0.5, 1.0, 2.0])
+        self.assertEqual(delays[3:6], [0.5, 1.0, 2.0])
+
+    def test_backoff_caps_at_retry_max_delay(self):
+        delays = []
+        real_sleep = asyncio.sleep
+
+        async def fake_sleep(d):
+            delays.append(d)
+            await real_sleep(0)
+
+        from flox_py import ccxt as ccxt_mod
+
+        broker = CcxtBroker(
+            "binance", exchange=FakeCcxtExchange(),
+            retry_initial_delay=1.0, retry_max_delay=4.0, retry_multiplier=3.0,
         )
-        check(False, "expected ValueError for empty symbols")
-    except ValueError as e:
-        check("must not be empty" in str(e),
-              f"ValueError mentions empty symbols (got {e})")
+        attempts = {"n": 0}
+
+        async def flaky():
+            attempts["n"] += 1
+            if attempts["n"] <= 5:
+                raise RuntimeError("nope")
+            return "ok"
+
+        async def drive():
+            orig = ccxt_mod.asyncio.sleep
+            ccxt_mod.asyncio.sleep = fake_sleep
+            try:
+                gen = broker._stream(flaky, "test")
+                await gen.__anext__()
+            finally:
+                ccxt_mod.asyncio.sleep = orig
+
+        asyncio.run(drive())
+        # 1.0, 3.0, then capped at 4.0 from there on.
+        self.assertEqual(delays, [1.0, 3.0, 4.0, 4.0, 4.0])
 
 
 if __name__ == "__main__":
-    test_trades_forwarded()
-    test_book_forwarded()
-    test_validation_rejects_unknown_stream()
-    test_validation_rejects_empty_symbols()
-    print(f"\n{_passed} passed, {_failed} failed")
-    sys.exit(0 if _failed == 0 else 1)
+    unittest.main(verbosity=2)

--- a/python/tests/test_ccxt_adapter.py
+++ b/python/tests/test_ccxt_adapter.py
@@ -1,0 +1,208 @@
+"""
+python/tests/test_ccxt_adapter.py — verify CcxtFeed forwards trades and
+book updates from a mock ccxt exchange into a flox.Runner.
+
+Doesn't require ccxt to be installed; we mock the parts we use
+(watch_trades / watch_order_book / close).
+
+Run from repo root:
+    PYTHONPATH=build/python python3 python/tests/test_ccxt_adapter.py
+"""
+
+import asyncio
+import os
+import sys
+
+build_dir = os.path.join(os.path.dirname(__file__), "..", "..", "build", "python")
+sys.path.insert(0, os.path.abspath(build_dir))
+
+import flox_py as flox
+from flox_py.ccxt import CcxtFeed
+
+_passed = 0
+_failed = 0
+
+
+def check(cond, msg):
+    global _passed, _failed
+    if cond:
+        print(f"  ok  {msg}")
+        _passed += 1
+    else:
+        print(f"  FAIL  {msg}")
+        _failed += 1
+
+
+# ── Mock ccxt exchange ────────────────────────────────────────────────
+
+
+class FakeCcxtExchange:
+    """Minimal stand-in for a ccxt.pro exchange.
+
+    `_trades` and `_books` are queues fed from the test; the watch_*
+    methods pop from them (or wait forever if empty), simulating WS
+    streams. Realistic enough for a smoke test.
+    """
+
+    def __init__(self):
+        self._trades_q: asyncio.Queue = None
+        self._book_q: asyncio.Queue = None
+
+    def init_queues(self):
+        self._trades_q = asyncio.Queue()
+        self._book_q = asyncio.Queue()
+
+    def feed_trades(self, trades):
+        self._trades_q.put_nowait(trades)
+
+    def feed_book(self, book):
+        self._book_q.put_nowait(book)
+
+    async def watch_trades(self, symbol):
+        return await self._trades_q.get()
+
+    async def watch_order_book(self, symbol, limit=20):
+        return await self._book_q.get()
+
+
+# ── Tests ─────────────────────────────────────────────────────────────
+
+
+def test_trades_forwarded():
+    print("test_trades_forwarded")
+    reg = flox.SymbolRegistry()
+    btc = reg.add_symbol("test", "BTCUSDT", 0.01)
+    seen_trades = []
+
+    class S(flox.Strategy):
+        def on_trade(self, ctx, trade):
+            seen_trades.append((trade.price, trade.quantity, trade.is_buy))
+
+    runner = flox.Runner(reg, lambda sig: None, threaded=False)
+    runner.add_strategy(S([btc]))
+    runner.start()
+
+    fake = FakeCcxtExchange()
+    feed = CcxtFeed(
+        exchange=fake,
+        runner=runner,
+        symbols={"BTC/USDT": btc},
+        streams=("trades",),
+    )
+
+    async def driver():
+        fake.init_queues()
+        # Push a couple of trades.
+        fake.feed_trades([
+            {"price": 100.5, "amount": 0.5, "side": "buy",  "timestamp": 1_700_000_000_000},
+            {"price": 101.0, "amount": 1.0, "side": "sell", "timestamp": 1_700_000_001_000},
+        ])
+        # Run feed for a tiny window then cancel.
+        run_task = asyncio.create_task(feed.run())
+        await asyncio.sleep(0.05)
+        await feed.stop()
+        try:
+            await run_task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(driver())
+    runner.stop()
+
+    check(len(seen_trades) == 2, f"two trades forwarded (got {len(seen_trades)})")
+    if seen_trades:
+        check(seen_trades[0] == (100.5, 0.5, True),
+              f"first trade is buy 100.5 / 0.5 (got {seen_trades[0]})")
+        check(seen_trades[1][2] is False,
+              f"second trade is sell (got is_buy={seen_trades[1][2]})")
+
+
+def test_book_forwarded():
+    print("test_book_forwarded")
+    reg = flox.SymbolRegistry()
+    btc = reg.add_symbol("test", "BTCUSDT", 0.01)
+    seen_books = []
+
+    class S(flox.Strategy):
+        def on_book_update(self, ctx):
+            seen_books.append((ctx.best_bid, ctx.best_ask))
+
+    runner = flox.Runner(reg, lambda sig: None, threaded=False)
+    runner.add_strategy(S([btc]))
+    runner.start()
+
+    fake = FakeCcxtExchange()
+    feed = CcxtFeed(
+        exchange=fake,
+        runner=runner,
+        symbols={"BTC/USDT": btc},
+        streams=("book",),
+        book_depth=5,
+    )
+
+    async def driver():
+        fake.init_queues()
+        fake.feed_book({
+            "bids": [[100.0, 1.0], [99.5, 2.0]],
+            "asks": [[100.5, 1.5], [101.0, 2.5]],
+            "timestamp": 1_700_000_000_000,
+        })
+        run_task = asyncio.create_task(feed.run())
+        await asyncio.sleep(0.05)
+        await feed.stop()
+        try:
+            await run_task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(driver())
+    runner.stop()
+
+    check(len(seen_books) == 1, f"one book update forwarded (got {len(seen_books)})")
+    if seen_books:
+        bid, ask = seen_books[0]
+        check(bid == 100.0, f"best bid 100.0 (got {bid})")
+        check(ask == 100.5, f"best ask 100.5 (got {ask})")
+
+
+def test_validation_rejects_unknown_stream():
+    print("test_validation_rejects_unknown_stream")
+    reg = flox.SymbolRegistry()
+    btc = reg.add_symbol("test", "BTCUSDT", 0.01)
+    runner = flox.Runner(reg, lambda sig: None, threaded=False)
+    try:
+        CcxtFeed(
+            exchange=FakeCcxtExchange(),
+            runner=runner,
+            symbols={"BTC/USDT": btc},
+            streams=("trades", "ticker"),  # ticker is not supported
+        )
+        check(False, "expected ValueError for unknown stream")
+    except ValueError as e:
+        check("ticker" in str(e), "ValueError mentions the bad stream name")
+
+
+def test_validation_rejects_empty_symbols():
+    print("test_validation_rejects_empty_symbols")
+    reg = flox.SymbolRegistry()
+    runner = flox.Runner(reg, lambda sig: None, threaded=False)
+    try:
+        CcxtFeed(
+            exchange=FakeCcxtExchange(),
+            runner=runner,
+            symbols={},
+            streams=("trades",),
+        )
+        check(False, "expected ValueError for empty symbols")
+    except ValueError as e:
+        check("must not be empty" in str(e),
+              f"ValueError mentions empty symbols (got {e})")
+
+
+if __name__ == "__main__":
+    test_trades_forwarded()
+    test_book_forwarded()
+    test_validation_rejects_unknown_stream()
+    test_validation_rejects_empty_symbols()
+    print(f"\n{_passed} passed, {_failed} failed")
+    sys.exit(0 if _failed == 0 else 1)


### PR DESCRIPTION
Replaces `CcxtFeed` (inbound only) with `CcxtBroker`, which handles market data inbound and order routing outbound through one object.

## Surface

```python
async with CcxtBroker("binance", api_key=..., secret=..., sandbox=True) as broker:
    btc = await broker.add_symbol("BTC/USDT")
    broker.add_strategy(MyStrategy([btc]))
    await broker.run(streams=("trades", "book", "orders"))
```

`add_symbol` reads tick size from `markets[sym]["precision"]["price"]` via `load_markets()`. `add_strategy` attaches to an internal `Runner` whose signal callback routes signals to ccxt.

## Inbound streams

| Stream    | ccxt method               | FLOX target                                                    |
|-----------|---------------------------|----------------------------------------------------------------|
| `trades`  | `watch_trades(sym)`       | `runner.on_trade(...)`                                         |
| `book`    | `watch_order_book(sym)`   | `runner.on_book_snapshot(...)`                                 |
| `orders`  | `watch_orders()`          | `strategy.on_order_update(sym, status, filled, avg)`           |

## Outbound (Signal.order_type → ccxt call)

- `MARKET`, `LIMIT` → `create_market_<side>_order` / `create_limit_<side>_order`
- `STOP_MARKET`, `STOP_LIMIT` → `create_order(type, side, qty, price, {stopPrice})`
- `TAKE_PROFIT_MARKET`, `TAKE_PROFIT_LIMIT` → same shape
- `TRAILING_STOP` → `create_order(trailing_stop_market, params={trailingDelta})`
- `TRAILING_STOP_PERCENT` → same with `params={callbackRate: bps/100}`
- `CLOSE_POSITION` → `create_order(market, params={reduceOnly: True})`
- `CANCEL` → `cancel_order(ccxt_id, sym)` using the tracked id from the original signal
- `CANCEL_ALL` → walks tracked ids on the symbol
- `MODIFY` → `edit_order(ccxt_id, sym, type, side, new_qty, new_price)`
- Anything else → `on_error(sym, UnsupportedOrderType(...))`, exchange call skipped

Stop / TP / trailing param shapes differ per exchange. The broker uses ccxt's unified-API defaults; per-exchange variants (Bybit `triggerBy`, OKX `tdMode`, Binance futures `triggerPrice`) go through subclass overrides on the `_place_*` methods.

## Position reconciliation

`run(reconcile=True)` (default) calls `fetch_balance()` and `fetch_positions()` before streams start. For each non-zero position on a registered symbol the broker calls `strategy.on_initial_position(ccxt_sym, qty, avg)`. Strategies without that method get no callback. `NotSupported` from spot exchanges is swallowed.

## Backoff

Stream errors retry with exponential backoff. Three knobs:

```python
CcxtBroker(..., retry_initial_delay=1.0, retry_max_delay=60.0, retry_multiplier=2.0)
```

Delay starts at `retry_initial_delay`, multiplies on each consecutive failure, caps at `retry_max_delay`, resets to initial on success.

## Scope of this PR

In:
- All flox order types map to ccxt: market, limit, stop, take-profit, trailing, close-position, cancel, cancel-all, modify.
- 25 unit tests using `FakeCcxtExchange` (no ccxt dep, no network).

Out (deferred):
- Live integration test against a real exchange.
- Reconnect-under-load tests (network drops, exchange 5xx storms).
- Built-in per-exchange subclasses (Bybit, OKX, Binance futures). Pattern is documented; users subclass.
- `on_initial_position` reports state but does not mutate the FLOX `PositionTracker`. Strategies that need to start mid-position do that themselves.

## Tests

`python/tests/test_ccxt_adapter.py` — 25 cases, FakeCcxtExchange mock. Coverage:

- `_market_tick_size` parses both decimal-count and tick-value shapes
- `add_symbol` loads markets, registers in registry, errors on unknown symbol
- trades / book / orders streams forward correctly
- every order type's exchange call shape (12 routing cases)
- unsupported order_type → `on_error`, exchange call skipped
- `CANCEL` / `CANCEL_ALL` use tracked ccxt ids; `MODIFY` calls `edit_order`
- reconciliation dispatches non-zero positions, swallows `NotSupported`
- backoff doubles on consecutive failure, caps at `retry_max_delay`, resets after success

## Test plan
- [x] 25/25 `python/tests/test_ccxt_adapter.py` pass
- [x] mypy clean on `docs/examples/python_ccxt_live.py`
- [x] `check_doc_snippets.py --min-includes 6` green
- [x] `sync_mcp_data.py --check` green
- [ ] CI green

W4-T002