### PR TITLE
feat(python): flox new CLI scaffolder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
     - name: Verify Python extension hooks
       run: PYTHONPATH=build/python python3 python/tests/test_hooks.py
 
+    - name: Verify flox new CLI scaffolder
+      run: PYTHONPATH=build/python python3 python/tests/test_flox_new_cli.py
+
     - name: Verify .pyi stubs are in sync with the binding
       run: python3 scripts/gen_pyi_stubs.py --check
 

--- a/docs/how-to/flox-new.md
+++ b/docs/how-to/flox-new.md
@@ -1,0 +1,65 @@
+# Scaffold a project with `flox new`
+
+`flox-py` ships a small CLI that scaffolds new strategy projects from
+bundled templates. It is registered as a console script, so after
+`pip install flox-py` you have `flox` on your `PATH`.
+
+## Usage
+
+```bash
+flox new my-strategy                      # default template (research)
+flox new my-strategy --template=research  # explicit
+flox new --here .                         # scaffold into current dir
+flox templates                            # list available templates
+```
+
+`flox new <name>` creates a directory `<name>/` in the current working
+directory and copies the chosen template into it. Two placeholders are
+substituted in every text file:
+
+| Placeholder         | Replaced with                           |
+|---------------------|-----------------------------------------|
+| `__PROJECT_NAME__`  | The name you passed (verbatim).         |
+| `__PROJECT_SLUG__`  | A snake_case slug derived from the name. |
+
+For example, `flox new Hedge-Bot` produces files where
+`__PROJECT_NAME__` becomes `Hedge-Bot` and `__PROJECT_SLUG__` becomes
+`hedge_bot`. The slug is safe to use as a Python identifier, env var
+prefix, or directory name.
+
+## Templates
+
+### `research` (default)
+
+A single-file SMA(10/30) crossover on BTCUSDT plus an optional
+backtest path. After scaffolding:
+
+```bash
+cd my-strategy
+pip install -r requirements.txt
+python main.py
+```
+
+Without a CSV the script runs the strategy against a synthetic price
+path so the round-trip is short. To run a real backtest, point the
+`<SLUG>_DATA` env var at a CSV with columns
+`timestamp_ms,price,qty,is_buyer_maker`:
+
+```bash
+MY_STRATEGY_DATA=/path/to/btcusdt_1m.csv python main.py
+```
+
+The strategy class itself is the same shape as in
+[strategy classes](strategy-classes.md), so once you've replaced the
+SMA crossover with your own logic, the same file runs identically
+under [backtest](backtest.md), [grid search](grid-search.md), and live
+data feeds.
+
+## Why a CLI scaffolder?
+
+The friction in starting a new strategy is rarely the indicator math —
+it's setting up the imports, a SymbolRegistry, a Runner, and a
+backtest harness so the first line of strategy code can run. The
+scaffolder collapses that to one command, which makes it cheap to
+spin up throwaway research notebooks without copy-pasting from a
+canonical example each time.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
   - How-To Guides:
       - how-to/README.md
       - Strategy & Backtest:
+          - Scaffold a Project (flox new): how-to/flox-new.md
           - Strategy Classes: how-to/strategy-classes.md
           - Backtesting: how-to/backtest.md
           - Realistic Backtest Fills: how-to/backtest-realistic-fills.md

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -34,6 +34,7 @@ set_target_properties(_flox_py PROPERTIES
 # needs as input — is not blocked on them existing.
 set(FLOX_PY_REQUIRED_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/__init__.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/cli.py
   ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/py.typed
 )
 set(FLOX_PY_OPTIONAL_ROOT_STUBS
@@ -49,6 +50,9 @@ add_custom_command(TARGET _flox_py POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
     ${FLOX_PY_REQUIRED_FILES}
     ${CMAKE_CURRENT_BINARY_DIR}/flox_py/
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/templates
+    ${CMAKE_CURRENT_BINARY_DIR}/flox_py/templates
 )
 foreach(opt_file IN LISTS FLOX_PY_OPTIONAL_ROOT_STUBS)
   if(EXISTS ${opt_file})
@@ -104,6 +108,12 @@ endif()
 install(TARGETS _flox_py LIBRARY DESTINATION flox_py COMPONENT python_module)
 install(FILES ${FLOX_PY_REQUIRED_FILES}
         DESTINATION flox_py COMPONENT python_module)
+# Bundled `flox new` templates. Shipped as data alongside the package
+# so `flox new <project>` works after `pip install flox-py`. Walked at
+# runtime by flox_py.cli via importlib.resources.
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/templates/
+        DESTINATION flox_py/templates
+        COMPONENT python_module)
 foreach(opt_file IN LISTS FLOX_PY_OPTIONAL_ROOT_STUBS)
   if(EXISTS ${opt_file})
     install(FILES ${opt_file} DESTINATION flox_py COMPONENT python_module)

--- a/python/flox_py/cli.py
+++ b/python/flox_py/cli.py
@@ -1,0 +1,179 @@
+"""``flox`` CLI — scaffolds new FLOX projects from templates.
+
+Installed as a console_script via [project.scripts] in pyproject.toml,
+so `flox new my-strategy` works after `pip install flox-py`.
+
+Usage::
+
+    flox new <project-name>                     # default template (research)
+    flox new <project-name> --template=research
+    flox new <project-name> --template=live
+    flox new <project-name> --template=indicator-library
+    flox new <project-name> --here              # scaffold into the current dir
+    flox templates                              # list available templates
+
+Each template is a directory under ``flox_py/templates/<name>/`` shipped
+with the wheel. ``flox new`` copies the directory verbatim, then
+substitutes ``__PROJECT_NAME__`` and ``__PROJECT_SLUG__`` placeholders.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from importlib import resources
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+# ── Template helpers ───────────────────────────────────────────────────
+
+
+def _slug(name: str) -> str:
+    """Lower-snake-case slug from a project name."""
+    s = re.sub(r"[^A-Za-z0-9_-]+", "_", name).strip("_")
+    return s.lower().replace("-", "_") or "project"
+
+
+def _templates_root():
+    """Return Traversable for the bundled templates directory, or None."""
+    try:
+        return resources.files("flox_py").joinpath("templates")
+    except ModuleNotFoundError:
+        return None
+
+
+def _list_templates() -> list[str]:
+    """List bundled template names by walking flox_py/templates/."""
+    root = _templates_root()
+    if root is None or not root.is_dir():
+        return []
+    out: list[str] = []
+    for entry in root.iterdir():
+        if entry.is_dir():
+            out.append(entry.name)
+    out.sort()
+    return out
+
+
+def _copy_template(template: str, dest: Path, project_name: str) -> int:
+    """Copy bundled template to ``dest`` with placeholder substitution.
+
+    Returns 0 on success, non-zero on error (with a printed message).
+    """
+    root = _templates_root()
+    src_root = root.joinpath(template) if root is not None else None
+    if src_root is None or not src_root.is_dir():
+        avail = ", ".join(_list_templates()) or "(none)"
+        print(f"flox new: unknown template '{template}'. "
+              f"Available: {avail}",
+              file=sys.stderr)
+        return 1
+
+    if dest.exists() and any(dest.iterdir()):
+        print(f"flox new: destination '{dest}' is not empty. "
+              f"Pick a fresh path or remove existing files.",
+              file=sys.stderr)
+        return 1
+
+    dest.mkdir(parents=True, exist_ok=True)
+    slug = _slug(project_name)
+
+    def _walk(node, target: Path) -> None:
+        for child in node.iterdir():
+            child_target = target / child.name
+            if child.is_dir():
+                child_target.mkdir(exist_ok=True)
+                _walk(child, child_target)
+            else:
+                # Read the template file as text and substitute. Binary
+                # files (data, images) shouldn't appear in templates;
+                # fall back to a raw copy if decoding fails.
+                try:
+                    text = child.read_text()
+                except UnicodeDecodeError:
+                    child_target.write_bytes(child.read_bytes())
+                    continue
+                text = text.replace("__PROJECT_NAME__", project_name)
+                text = text.replace("__PROJECT_SLUG__", slug)
+                child_target.write_text(text)
+
+    _walk(src_root, dest)
+    return 0
+
+
+# ── Command handlers ───────────────────────────────────────────────────
+
+
+def cmd_new(args: argparse.Namespace) -> int:
+    project_name: str = args.name
+    template: str = args.template
+
+    if args.here:
+        dest = Path.cwd()
+    else:
+        dest = Path.cwd() / project_name
+
+    rc = _copy_template(template, dest, project_name)
+    if rc != 0:
+        return rc
+
+    print(f"created '{project_name}' from template '{template}' at {dest}")
+    print()
+    print("next steps:")
+    print(f"  cd {dest.relative_to(Path.cwd()) if not args.here else '.'}")
+    print(f"  pip install -r requirements.txt")
+    print(f"  python main.py")
+    return 0
+
+
+def cmd_templates(_args: argparse.Namespace) -> int:
+    names = _list_templates()
+    if not names:
+        print("no templates found (is flox-py installed?)", file=sys.stderr)
+        return 1
+    for n in names:
+        print(n)
+    return 0
+
+
+# ── Argparse setup ─────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="flox",
+        description="FLOX project scaffolding & utilities.",
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    p_new = sub.add_parser("new", help="Scaffold a new FLOX project.")
+    p_new.add_argument("name", help="project name (used as directory & slug)")
+    p_new.add_argument(
+        "--template", default="research",
+        help="template to use (default: research). "
+             "Run `flox templates` to list.",
+    )
+    p_new.add_argument(
+        "--here", action="store_true",
+        help="scaffold into the current directory instead of "
+             "creating a new one",
+    )
+    p_new.set_defaults(handler=cmd_new)
+
+    p_t = sub.add_parser("templates", help="List available templates.")
+    p_t.set_defaults(handler=cmd_templates)
+
+    return p
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    return args.handler(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/python/flox_py/templates/research/.gitignore
+++ b/python/flox_py/templates/research/.gitignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+env/
+.env
+.ipynb_checkpoints/
+.DS_Store
+
+# Local data + outputs
+data/
+*.csv
+*.parquet
+*.feather
+*.log
+runs/
+results/

--- a/python/flox_py/templates/research/README.md
+++ b/python/flox_py/templates/research/README.md
@@ -1,0 +1,35 @@
+# __PROJECT_NAME__
+
+A FLOX research scaffold. Generated with `flox new __PROJECT_NAME__`.
+
+## Quickstart
+
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+By default `main.py` runs the bundled SMA(10/30) crossover against a
+synthetic price path. To run it as a backtest, point it at a CSV with
+columns `timestamp_ms,price,qty,is_buyer_maker`:
+
+```bash
+__PROJECT_SLUG___DATA=/path/to/btcusdt_1m.csv python main.py
+```
+
+## Layout
+
+- `main.py` — single-file entry point. Edit the `__PROJECT_SLUG___strategy`
+  class to change indicators and signal logic.
+- `requirements.txt` — minimal pin: `flox-py` plus numpy for offline
+  analysis.
+
+## Next steps
+
+- Swap the SMA crossover for your own indicator stack
+  (`flox.SMA`, `flox.EMA`, `flox.ADX`, `flox.ATR`, ...).
+- Wire a live data feed via `flox_py.ccxt.CcxtFeed` to drive the same
+  strategy class against an exchange WebSocket.
+- Run sweeps via `flox.Optimizer` to grid-search parameters.
+
+See https://flox-foundation.github.io/flox/ for the full reference.

--- a/python/flox_py/templates/research/main.py
+++ b/python/flox_py/templates/research/main.py
@@ -1,0 +1,94 @@
+"""__PROJECT_NAME__ — FLOX research scaffold.
+
+Edit this file to plug in your own indicators, signals, and execution
+logic. The template ships with an SMA(10/30) crossover on BTCUSDT to
+keep the round-trip short: clone, run, get a backtest report.
+
+Run::
+
+    pip install -r requirements.txt
+    python main.py
+"""
+from __future__ import annotations
+
+import os
+import time
+
+import flox_py as flox
+
+
+# Replace with your own CSV (timestamp_ms,price,qty,is_buyer_maker).
+# An empty path triggers the synthetic price path below — handy for
+# the very first run before you wire up real data.
+DATA_CSV = os.environ.get("__PROJECT_SLUG___DATA", "")
+
+
+registry = flox.SymbolRegistry()
+btc = registry.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+
+
+class __PROJECT_SLUG___strategy(flox.Strategy):
+    """SMA(10/30) crossover — replace with your own logic."""
+
+    def __init__(self, symbols):
+        super().__init__(symbols)
+        self.fast = flox.SMA(10)
+        self.slow = flox.SMA(30)
+        self.trade_count = 0
+
+    def on_start(self):
+        print("  __PROJECT_NAME__ strategy started")
+
+    def on_stop(self):
+        print(f"  __PROJECT_NAME__ stopped  ({self.trade_count} signals)")
+
+    def on_trade(self, ctx, trade):
+        fv = self.fast.update(trade.price)
+        sv = self.slow.update(trade.price)
+        if fv is None or sv is None or not self.slow.ready:
+            return
+        if fv > sv and ctx.is_flat():
+            self.market_buy(0.01)
+            self.trade_count += 1
+        elif fv < sv and ctx.is_flat():
+            self.market_sell(0.01)
+            self.trade_count += 1
+
+
+def run_backtest() -> None:
+    print("-- backtest -------------------------------------------------")
+    strat = __PROJECT_SLUG___strategy([btc])
+    bt = flox.BacktestRunner(registry, fee_rate=0.0004,
+                             initial_capital=10_000)
+    bt.set_strategy(strat)
+    stats = bt.run_csv(DATA_CSV)
+    print(f"  return : {stats['return_pct']:+.4f}%")
+    print(f"  trades : {stats['total_trades']}  "
+          f"win={stats['win_rate']*100:.1f}%")
+    print(f"  sharpe : {stats['sharpe']:.4f}")
+    print(f"  max DD : {stats['max_drawdown_pct']:.4f}%")
+
+
+def run_synthetic() -> None:
+    print("-- synthetic live ------------------------------------------")
+    signals: list[flox.Signal] = []
+    runner = flox.Runner(registry, signals.append)
+    runner.add_strategy(__PROJECT_SLUG___strategy([btc]))
+    runner.start()
+
+    ts_ns = int(time.time()) * 1_000_000_000
+    for i in range(60):
+        price = 50_000 + i * 50
+        runner.on_trade(btc, float(price), 0.1, i % 2 == 0, ts_ns)
+        ts_ns += 1_000_000_000
+
+    runner.stop()
+    print(f"  signals: {len(signals)}")
+
+
+if __name__ == "__main__":
+    if DATA_CSV and os.path.exists(DATA_CSV):
+        run_backtest()
+    else:
+        print(f"  (set __PROJECT_SLUG___DATA=<csv> for backtest mode)")
+        run_synthetic()

--- a/python/flox_py/templates/research/requirements.txt
+++ b/python/flox_py/templates/research/requirements.txt
@@ -1,0 +1,2 @@
+flox-py>=0.5.6
+numpy

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,6 +22,9 @@ classifiers = [
 [project.urls]
 Repository = "https://github.com/FLOX-Foundation/flox"
 
+[project.scripts]
+flox = "flox_py.cli:main"
+
 [tool.scikit-build]
 cmake.args = ["-DFLOX_ENABLE_BACKTEST=ON", "-DFLOX_ENABLE_PYTHON=ON", "-DFLOX_ENABLE_LZ4=ON"]
 cmake.source-dir = ".."

--- a/python/tests/test_flox_new_cli.py
+++ b/python/tests/test_flox_new_cli.py
@@ -1,0 +1,90 @@
+"""Smoke tests for the ``flox new`` CLI scaffolder.
+
+These tests exercise flox_py.cli end-to-end without the compiled
+extension: the CLI is pure-Python and just walks bundled template
+files. We assert that:
+
+  * `flox templates` lists at least the `research` template.
+  * `flox new <name>` creates a directory with main.py + requirements.txt.
+  * Placeholder substitution actually replaces __PROJECT_NAME__.
+  * Re-running into a non-empty destination errors out cleanly.
+"""
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+# Allow `python -m unittest python.tests.test_flox_new_cli` from repo root
+# whether or not the build artefact is on PYTHONPATH.
+HERE = Path(__file__).resolve().parent
+PY_PKG = HERE.parent
+sys.path.insert(0, str(PY_PKG))
+
+from flox_py import cli  # noqa: E402
+
+
+class FloxNewCliTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="flox-new-"))
+        self.cwd = Path.cwd()
+        os.chdir(self.tmp)
+
+    def tearDown(self) -> None:
+        os.chdir(self.cwd)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_templates_lists_research(self) -> None:
+        names = cli._list_templates()
+        self.assertIn("research", names,
+                      f"expected 'research' in templates, got {names!r}")
+
+    def test_new_creates_project(self) -> None:
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cli.main(["new", "alpha"])
+        self.assertEqual(rc, 0, out.getvalue())
+        proj = self.tmp / "alpha"
+        self.assertTrue((proj / "main.py").exists())
+        self.assertTrue((proj / "requirements.txt").exists())
+        self.assertTrue((proj / "README.md").exists())
+
+    def test_placeholder_substitution(self) -> None:
+        rc = cli.main(["new", "Hedge-Bot"])
+        self.assertEqual(rc, 0)
+        main_py = (self.tmp / "Hedge-Bot" / "main.py").read_text()
+        self.assertIn("Hedge-Bot", main_py)
+        self.assertIn("hedge_bot_strategy", main_py,
+                      "slug substitution should produce hedge_bot_strategy")
+        self.assertNotIn("__PROJECT_NAME__", main_py)
+        self.assertNotIn("__PROJECT_SLUG__", main_py)
+
+    def test_unknown_template_errors(self) -> None:
+        err = io.StringIO()
+        with redirect_stderr(err):
+            rc = cli.main(["new", "x", "--template", "does-not-exist"])
+        self.assertNotEqual(rc, 0)
+        self.assertIn("unknown template", err.getvalue())
+
+    def test_destination_must_be_empty(self) -> None:
+        (self.tmp / "occupied").mkdir()
+        (self.tmp / "occupied" / "stale.txt").write_text("hi")
+        err = io.StringIO()
+        with redirect_stderr(err):
+            rc = cli.main(["new", "occupied"])
+        self.assertNotEqual(rc, 0)
+        self.assertIn("not empty", err.getvalue())
+
+    def test_slug_helper(self) -> None:
+        self.assertEqual(cli._slug("Hedge-Bot"), "hedge_bot")
+        self.assertEqual(cli._slug("a strategy 2"), "a_strategy_2")
+        self.assertEqual(cli._slug("___"), "project")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `flox` console_script that scaffolds new strategy projects from bundled templates: `flox new <name>` copies a template tree verbatim and substitutes `__PROJECT_NAME__` / `__PROJECT_SLUG__` placeholders.
- Default template `research`: single-file SMA(10/30) crossover that runs synthetically out of the box and switches to a CSV backtest when `<SLUG>_DATA` is set — collapses cold-start friction (SymbolRegistry, Runner, backtest harness setup) to one command.
- Templates ship as package data alongside the wheel via `install(DIRECTORY ...)` and are mirrored into the build tree for `PYTHONPATH=build/python` dev imports.

## Test plan

- [x] `python3 python/tests/test_flox_new_cli.py` — 6 unit tests pass locally (template listing, project creation, placeholder substitution, slug helper, unknown-template error, non-empty-destination error).
- [x] `python3 scripts/check_doc_snippets.py --min-includes 6` — green.
- [x] `python3 scripts/sync_mcp_data.py --check` — green.
- [x] `python3 scripts/gen_llms_txt.py --check` — green.
- [ ] CI green (linux/macos/windows + sanitizers).

W4-T003