### PR TITLE
feat(template): notebook variant of research scaffold

### DIFF
--- a/python/flox_py/templates/research/README.md
+++ b/python/flox_py/templates/research/README.md
@@ -32,6 +32,8 @@ __PROJECT_ENV__=/path/to/btcusdt_1h.csv python main.py
 
 - `main.py` — single-file entry point. Edit the `__PROJECT_SLUG___strategy`
   class to change indicators and signal logic.
+- `main.ipynb` — Jupyter variant of the same strategy, split into cells
+  for interactive iteration. Open with `jupyter lab main.ipynb`.
 - `requirements.txt` — `flox-py` plus numpy for offline analysis.
 - `data/btcusdt_sample.csv` — 500 BTC/USDT 1m bars.
   Replace or delete once you have your own data.

--- a/python/flox_py/templates/research/main.ipynb
+++ b/python/flox_py/templates/research/main.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# __PROJECT_NAME__\n",
+    "\n",
+    "Notebook variant of the FLOX research scaffold. Same SMA(10/30)\n",
+    "crossover as `main.py`, split into cells so you can iterate on\n",
+    "indicators and parameters interactively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import flox_py as flox"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data\n",
+    "\n",
+    "The bundled `data/btcusdt_sample.csv` ships 500 BTC/USDT 1m bars.\n",
+    "Set `__PROJECT_ENV__` to swap in your own CSV with columns\n",
+    "`timestamp,open,high,low,close,volume`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HERE = os.getcwd()\n",
+    "DEFAULT_CSV = os.path.join(HERE, \"data\", \"btcusdt_sample.csv\")\n",
+    "DATA_CSV = os.environ.get(\"__PROJECT_ENV__\", DEFAULT_CSV)\n",
+    "DATA_CSV"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Symbols and strategy\n",
+    "\n",
+    "Edit the strategy class below to plug in your own indicators and\n",
+    "signal logic. Anything that satisfies the `flox.Strategy` interface\n",
+    "works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "registry = flox.SymbolRegistry()\n",
+    "btc = registry.add_symbol(\"exchange\", \"BTCUSDT\", tick_size=0.01)\n",
+    "btc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class __PROJECT_SLUG___strategy(flox.Strategy):\n",
+    "    \"\"\"SMA(10/30) crossover.\"\"\"\n",
+    "\n",
+    "    def __init__(self, symbols):\n",
+    "        super().__init__(symbols)\n",
+    "        self.fast = flox.SMA(10)\n",
+    "        self.slow = flox.SMA(30)\n",
+    "\n",
+    "    def on_trade(self, ctx, trade):\n",
+    "        fv = self.fast.update(trade.price)\n",
+    "        sv = self.slow.update(trade.price)\n",
+    "        if fv is None or sv is None or not self.slow.ready:\n",
+    "            return\n",
+    "        if fv > sv and ctx.is_flat():\n",
+    "            self.market_buy(0.01)\n",
+    "        elif fv < sv and ctx.is_flat():\n",
+    "            self.market_sell(0.01)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run a backtest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bt = flox.BacktestRunner(registry, fee_rate=0.0004,\n",
+    "                         initial_capital=10_000)\n",
+    "bt.set_strategy(__PROJECT_SLUG___strategy([btc]))\n",
+    "stats = bt.run_csv(DATA_CSV, symbol=\"BTCUSDT\")\n",
+    "stats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"return : {stats['return_pct']:+.4f}%\")\n",
+    "print(f\"trades : {stats['total_trades']}  win={stats['win_rate']*100:.1f}%\")\n",
+    "print(f\"sharpe : {stats['sharpe']:.4f}\")\n",
+    "print(f\"max DD : {stats['max_drawdown_pct']:.4f}%\")\n",
+    "print(f\"net PnL: {stats['net_pnl']:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- Replace the SMA crossover with your own indicators (`flox.EMA`,\n",
+    "  `flox.RSI`, `flox.ADX`, ...).\n",
+    "- Run a parameter sweep with `flox.Optimizer`.\n",
+    "- Move the same strategy class to live data via\n",
+    "  `flox_py.ccxt.CcxtBroker`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/tests/test_flox_new_cli.py
+++ b/python/tests/test_flox_new_cli.py
@@ -51,6 +51,7 @@ class FloxNewCliTests(unittest.TestCase):
         self.assertEqual(rc, 0, out.getvalue())
         proj = self.tmp / "alpha"
         self.assertTrue((proj / "main.py").exists())
+        self.assertTrue((proj / "main.ipynb").exists())
         self.assertTrue((proj / "requirements.txt").exists())
         self.assertTrue((proj / "README.md").exists())
         # Bundled sample CSV must come along — the template's main.py
@@ -61,6 +62,24 @@ class FloxNewCliTests(unittest.TestCase):
         with sample.open() as f:
             header = f.readline().strip()
         self.assertEqual(header, "timestamp,open,high,low,close,volume")
+
+    def test_notebook_parses_and_is_substituted(self) -> None:
+        import json
+        rc = cli.main(["new", "Hedge-Bot"])
+        self.assertEqual(rc, 0)
+        nb_path = self.tmp / "Hedge-Bot" / "main.ipynb"
+        with nb_path.open() as f:
+            nb = json.load(f)
+        self.assertEqual(nb.get("nbformat"), 4)
+        self.assertGreater(len(nb.get("cells", [])), 0)
+        joined = "".join("".join(c.get("source", []))
+                         for c in nb["cells"])
+        self.assertIn("Hedge-Bot", joined)
+        self.assertIn("hedge_bot_strategy", joined)
+        self.assertIn("HEDGE_BOT_DATA", joined)
+        self.assertNotIn("__PROJECT_NAME__", joined)
+        self.assertNotIn("__PROJECT_SLUG__", joined)
+        self.assertNotIn("__PROJECT_ENV__", joined)
 
     def test_placeholder_substitution(self) -> None:
         rc = cli.main(["new", "Hedge-Bot"])


### PR DESCRIPTION
Adds `main.ipynb` next to `main.py` in the `research` template. Same SMA(10/30) strategy, split into cells (intro markdown, imports, data path, registry/strategy, backtest run, summary, next steps).

## Why

The `research` template's last open acceptance item is "Jupyter notebook variant". Some users iterate on indicator parameters interactively; a `.ipynb` is the natural surface for that.

## How substitution stays safe

The CLI's `__PROJECT_NAME__` / `__PROJECT_SLUG__` / `__PROJECT_ENV__` text replace runs over the whole file. Placeholders only appear inside cell `source` strings (free text), so the surrounding JSON stays valid.

## Test plan

- [x] `python3 python/tests/test_flox_new_cli.py` — 7 cases pass, including a new one that loads the scaffolded `main.ipynb` via stdlib `json`, asserts `nbformat == 4`, and asserts all three placeholders substituted.
- [x] Manual scaffold: `flox new demo && python -c "import json; json.load(open('demo/main.ipynb'))"` parses cleanly.
- [x] `python3 scripts/check_doc_snippets.py --min-includes 6` green.
- [x] `python3 scripts/gen_llms_txt.py --check` green.
- [x] `python3 scripts/sync_mcp_data.py --check` green.
- [ ] CI green.

W4-T004