### PR TITLE
feat(template): live trading scaffold via flox new --template=live

### DIFF
--- a/docs/how-to/flox-new.md
+++ b/docs/how-to/flox-new.md
@@ -17,15 +17,15 @@ flox templates                            # list available templates
 directory and copies the chosen template into it. Two placeholders are
 substituted in every text file:
 
-| Placeholder         | Replaced with                           |
-|---------------------|-----------------------------------------|
-| `__PROJECT_NAME__`  | The name you passed (verbatim).         |
-| `__PROJECT_SLUG__`  | A snake_case slug derived from the name. |
+| Placeholder           | Replaced with                                          |
+|-----------------------|--------------------------------------------------------|
+| `__PROJECT_NAME__`    | The name you passed (verbatim).                        |
+| `__PROJECT_SLUG__`    | A snake_case slug derived from the name.               |
+| `__PROJECT_PREFIX__`  | The slug, upper-cased — used as a generic env-var prefix. |
+| `__PROJECT_ENV__`     | `<PREFIX>_DATA` — used by the research template's CSV-path env var. |
 
-For example, `flox new Hedge-Bot` produces files where
-`__PROJECT_NAME__` becomes `Hedge-Bot` and `__PROJECT_SLUG__` becomes
-`hedge_bot`. The slug is safe to use as a Python identifier, env var
-prefix, or directory name.
+For example, `flox new Hedge-Bot` substitutes `Hedge-Bot`, `hedge_bot`,
+`HEDGE_BOT`, and `HEDGE_BOT_DATA` respectively.
 
 ## Templates
 
@@ -54,6 +54,30 @@ The strategy class itself is the same shape as in
 SMA crossover with your own logic, the same file runs identically
 under [backtest](backtest.md), [grid search](grid-search.md), and live
 data feeds.
+
+### `live`
+
+Live-trading scaffold built on `CcxtBroker`. Ships with:
+
+- `main.py` — strategy + asyncio entry point with graceful SIGINT / SIGTERM shutdown.
+- `config.py` — Pydantic config model with validation.
+- `config.toml.example` — copy to `config.toml` and edit.
+- `requirements.txt` — `flox-py`, `ccxt`, `pydantic`, `tomli` (for Python 3.10).
+
+Defaults are conservative: `dry_run = true`, `sandbox = true`. Orders
+are logged but not sent until you set `FLOX_LIVE=1` plus
+`<PREFIX>_API_KEY` / `<PREFIX>_SECRET` env vars. See the template's
+README for the full sequence and the [CCXT how-to](ccxt-adapter.md)
+for the exchange wiring.
+
+```bash
+flox new my-bot --template=live
+cd my-bot
+pip install -r requirements.txt
+cp config.toml.example config.toml
+python main.py                    # dry-run
+FLOX_LIVE=1 python main.py        # live (sandbox by default)
+```
 
 ## Why a CLI scaffolder?
 

--- a/python/flox_py/cli.py
+++ b/python/flox_py/cli.py
@@ -14,9 +14,11 @@ Usage::
 
 Each template is a directory under ``flox_py/templates/<name>/`` shipped
 with the wheel. ``flox new`` copies the directory verbatim, then
-substitutes ``__PROJECT_NAME__``, ``__PROJECT_SLUG__``, and
-``__PROJECT_ENV__`` placeholders (the env-var prefix is the upper-cased
-slug suffixed with ``_DATA``).
+substitutes ``__PROJECT_NAME__``, ``__PROJECT_SLUG__``,
+``__PROJECT_PREFIX__`` (upper-cased slug — used as a generic env-var
+prefix, e.g. ``MYBOT``), and ``__PROJECT_ENV__``
+(``<PREFIX>_DATA`` — used by the research template for the CSV path
+env var).
 """
 
 from __future__ import annotations
@@ -98,9 +100,11 @@ def _copy_template(template: str, dest: Path, project_name: str) -> int:
                 except UnicodeDecodeError:
                     child_target.write_bytes(child.read_bytes())
                     continue
+                upper = slug.upper()
                 text = text.replace("__PROJECT_NAME__", project_name)
                 text = text.replace("__PROJECT_SLUG__", slug)
-                text = text.replace("__PROJECT_ENV__", slug.upper() + "_DATA")
+                text = text.replace("__PROJECT_PREFIX__", upper)
+                text = text.replace("__PROJECT_ENV__", upper + "_DATA")
                 child_target.write_text(text)
 
     _walk(src_root, dest)

--- a/python/flox_py/templates/live/.gitignore
+++ b/python/flox_py/templates/live/.gitignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+env/
+.env
+.ipynb_checkpoints/
+.DS_Store
+
+# Local config carries secrets — never commit. Only the .example
+# template lives in version control.
+config.toml
+
+# Logs and runtime artefacts.
+*.log
+runs/
+results/

--- a/python/flox_py/templates/live/README.md
+++ b/python/flox_py/templates/live/README.md
@@ -1,0 +1,72 @@
+# __PROJECT_NAME__
+
+A FLOX live-trading scaffold. Generated with `flox new __PROJECT_NAME__ --template=live`.
+
+## Read this first
+
+This template can place real orders on a real exchange. Defaults are
+conservative — `dry_run = true` and `sandbox = true` — but they are
+**defaults**, not hard guards. Confirm what mode you are in before
+running on production credentials. The first WARNING line printed at
+start tells you the mode and the exchange.
+
+Recommended path:
+
+1. Verify the strategy on bundled `research` template's backtest
+   (or your own backtest) first.
+2. Create testnet credentials on your exchange. Export them as
+   `__PROJECT_PREFIX___API_KEY` and `__PROJECT_PREFIX___SECRET`.
+3. Copy `config.toml.example` to `config.toml`. Keep `dry_run = true`
+   and `sandbox = true` for the first run.
+4. `FLOX_LIVE=1 python main.py` — this overrides `dry_run` to false
+   and connects to the testnet sandbox. Watch the logs.
+5. Once you trust the behavior, set `sandbox = false` in
+   `config.toml` and supply production credentials.
+
+## Quickstart (dry-run)
+
+```bash
+pip install -r requirements.txt
+cp config.toml.example config.toml
+python main.py
+```
+
+Without `FLOX_LIVE=1`, the script logs candidate orders and never
+calls the exchange. Useful for paper-trading-style verification.
+
+## Layout
+
+- `main.py` — entry point. Edit the `__PROJECT_SLUG___strategy` class.
+- `config.py` — Pydantic config model with validation.
+- `config.toml.example` — template. Copy to `config.toml`.
+- `requirements.txt` — `flox-py`, `ccxt`, `pydantic`.
+
+## Order types
+
+Strategy emits `market_buy` / `market_sell`. `CcxtBroker` also routes
+`limit_*`, `stop_*`, `take_profit_*`, `trailing_stop`, `cancel`,
+`cancel_all`, `modify`, `close_position` if the strategy emits them.
+See [CCXT how-to](https://flox-foundation.github.io/flox/how-to/ccxt-adapter/)
+for the full mapping table.
+
+## Health and observability
+
+Logs are structured: `INFO` lines mark lifecycle events and tick
+counts; `WARNING` for live-mode startup and unexpected initial
+positions; `WARNING` from the broker on stream errors (then exponential
+backoff and retry).
+
+For metrics / traces / alerts, wrap the strategy callbacks with your
+existing instrumentation. The strategy class is plain Python so any
+APM library that monkeypatches methods works.
+
+## Next steps
+
+- Replace SMA with your own signal logic.
+- Add a stop-loss via `self.stop_market(...)` from the strategy.
+- For multiple strategies, instantiate `CcxtBroker` once and call
+  `broker.add_strategy(...)` more than once.
+- Run alongside `research` template — same strategy class can sit
+  in both projects.
+
+See https://flox-foundation.github.io/flox/ for the full reference.

--- a/python/flox_py/templates/live/config.py
+++ b/python/flox_py/templates/live/config.py
@@ -1,0 +1,102 @@
+"""Pydantic config schema for __PROJECT_NAME__.
+
+Loads ``config.toml`` (or the path set via ``__PROJECT_PREFIX___CONFIG``)
+into a typed ``LiveConfig`` model. Validation errors fail fast at
+startup rather than midway through a live session.
+
+The ``dry_run`` and ``sandbox`` defaults are intentionally
+conservative — flip both off only after you have verified the
+strategy works on testnet keys.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Literal
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class LiveConfig(BaseModel):
+    """Validated live-trading config. See config.toml for defaults."""
+
+    # ── Connection ─────────────────────────────────────────────────────
+    exchange: str = "binance"
+    sandbox: bool = True
+    env_prefix: str = "__PROJECT_PREFIX__"
+
+    # ── Trading control ────────────────────────────────────────────────
+    dry_run: bool = True
+    symbols: List[str] = Field(default_factory=lambda: ["BTC/USDT"])
+    streams: List[Literal["trades", "book", "orders"]] = Field(
+        default_factory=lambda: ["trades", "orders"]
+    )
+    book_depth: int = 20
+    reconcile_positions: bool = True
+
+    # ── Strategy params ────────────────────────────────────────────────
+    fast_period: int = 10
+    slow_period: int = 30
+    order_qty: float = 0.001
+
+    # ── Backoff (passed to CcxtBroker) ─────────────────────────────────
+    retry_initial_delay: float = 1.0
+    retry_max_delay: float = 60.0
+    retry_multiplier: float = 2.0
+
+    # ── Observability ──────────────────────────────────────────────────
+    log_level: str = "INFO"
+
+    @field_validator("symbols")
+    @classmethod
+    def _non_empty_symbols(cls, v):
+        if not v:
+            raise ValueError("symbols must not be empty")
+        return v
+
+    @field_validator("fast_period", "slow_period")
+    @classmethod
+    def _positive_period(cls, v):
+        if v <= 0:
+            raise ValueError("period must be > 0")
+        return v
+
+    @field_validator("order_qty")
+    @classmethod
+    def _positive_qty(cls, v):
+        if v <= 0:
+            raise ValueError("order_qty must be > 0")
+        return v
+
+
+def load_config(path: str | Path | None = None) -> LiveConfig:
+    """Load config from ``path`` (or ``__PROJECT_PREFIX___CONFIG``, or
+    ``./config.toml``).
+    """
+    if path is None:
+        path = os.environ.get("__PROJECT_PREFIX___CONFIG", "config.toml")
+    p = Path(path)
+    if not p.exists():
+        print(f"config file not found: {p}\n"
+              f"copy config.toml.example to config.toml or set "
+              f"__PROJECT_PREFIX___CONFIG", file=sys.stderr)
+        sys.exit(2)
+
+    with p.open("rb") as f:
+        data = tomllib.load(f)
+
+    # Honor FLOX_LIVE env var as a global override on dry_run.
+    if os.environ.get("FLOX_LIVE", "0") == "1":
+        data["dry_run"] = False
+
+    try:
+        return LiveConfig(**data)
+    except Exception as e:
+        print(f"config validation failed:\n{e}", file=sys.stderr)
+        sys.exit(2)

--- a/python/flox_py/templates/live/config.toml.example
+++ b/python/flox_py/templates/live/config.toml.example
@@ -1,0 +1,37 @@
+# __PROJECT_NAME__ live trading config.
+#
+# Copy this file to `config.toml` and edit. `config.toml` is gitignored
+# so secrets do not leak.
+#
+# To go live:
+#   1. Set `dry_run = false` AND `sandbox = false` (testnet first!)
+#   2. Export __PROJECT_PREFIX___API_KEY, __PROJECT_PREFIX___SECRET in your shell
+#   3. Run `FLOX_LIVE=1 python main.py`
+#
+# Without FLOX_LIVE=1 the script always runs in dry-run mode regardless
+# of this file.
+
+# ── Exchange ──────────────────────────────────────────────────────────
+exchange = "binance"
+sandbox  = true              # testnet — flip to false only after verifying
+env_prefix = "__PROJECT_PREFIX__"
+
+# ── Trading control ───────────────────────────────────────────────────
+dry_run             = true   # log orders, do not send (FLOX_LIVE=1 overrides)
+symbols             = ["BTC/USDT"]
+streams             = ["trades", "orders"]
+book_depth          = 20
+reconcile_positions = true
+
+# ── Strategy params ───────────────────────────────────────────────────
+fast_period = 10
+slow_period = 30
+order_qty   = 0.001
+
+# ── Backoff (CcxtBroker) ──────────────────────────────────────────────
+retry_initial_delay = 1.0
+retry_max_delay     = 60.0
+retry_multiplier    = 2.0
+
+# ── Observability ─────────────────────────────────────────────────────
+log_level = "INFO"

--- a/python/flox_py/templates/live/main.py
+++ b/python/flox_py/templates/live/main.py
@@ -1,0 +1,160 @@
+"""__PROJECT_NAME__ — FLOX live trading scaffold.
+
+Edit ``__PROJECT_SLUG___strategy`` below. The scaffold runs in
+**dry-run** mode by default — order placements are logged, the
+exchange call is skipped. Set ``FLOX_LIVE=1`` and supply api keys via
+``__PROJECT_PREFIX___API_KEY`` / ``__PROJECT_PREFIX___SECRET`` env vars to
+route orders through the exchange (sandbox by default — see ``config.toml``).
+
+Run::
+
+    pip install -r requirements.txt
+    python main.py
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+
+import flox_py as flox
+from flox_py.ccxt import CcxtBroker
+
+from config import LiveConfig, load_config
+
+
+logger = logging.getLogger(__name__)
+
+
+class __PROJECT_SLUG___strategy(flox.Strategy):
+    """SMA(fast/slow) crossover. Replace with your own logic."""
+
+    def __init__(self, symbols, *, fast: int, slow: int, qty: float,
+                 dry_run: bool):
+        super().__init__(symbols)
+        self.fast = flox.SMA(fast)
+        self.slow = flox.SMA(slow)
+        self.qty = qty
+        self.dry_run = dry_run
+        self.tick_count = 0
+
+    def on_start(self):
+        mode = "dry-run" if self.dry_run else "LIVE"
+        logger.info("__PROJECT_NAME__ started in %s mode", mode)
+
+    def on_stop(self):
+        logger.info("__PROJECT_NAME__ stopped after %d ticks",
+                    self.tick_count)
+
+    def on_trade(self, ctx, trade):
+        self.tick_count += 1
+        if self.tick_count % 100 == 0:
+            logger.info("processed %d ticks, last price %.2f",
+                        self.tick_count, trade.price)
+        f = self.fast.update(trade.price)
+        s = self.slow.update(trade.price)
+        if f is None or s is None or not self.slow.ready:
+            return
+        if self.dry_run:
+            if f > s and ctx.is_flat():
+                logger.info("[dry] would buy %.4f @ ~%.2f", self.qty, trade.price)
+            elif f < s and ctx.is_long():
+                logger.info("[dry] would sell %.4f @ ~%.2f", self.qty, trade.price)
+            return
+        if f > s and ctx.is_flat():
+            self.market_buy(self.qty)
+        elif f < s and ctx.is_long():
+            self.market_sell(self.qty)
+
+    def on_order_update(self, sym, status, filled, avg):
+        logger.info("order %s %s filled=%s avg=%s", sym, status, filled, avg)
+
+    def on_initial_position(self, sym, qty, avg):
+        logger.warning("starting with non-zero position on %s: qty=%s avg=%s",
+                       sym, qty, avg)
+
+
+async def run(config: LiveConfig) -> None:
+    broker = CcxtBroker(
+        exchange_id=config.exchange,
+        api_key=os.environ.get(f"{config.env_prefix}_API_KEY"),
+        secret=os.environ.get(f"{config.env_prefix}_SECRET"),
+        password=os.environ.get(f"{config.env_prefix}_PASSPHRASE"),
+        sandbox=config.sandbox,
+        retry_initial_delay=config.retry_initial_delay,
+        retry_max_delay=config.retry_max_delay,
+        retry_multiplier=config.retry_multiplier,
+    )
+    async with broker:
+        flox_symbols = []
+        for sym in config.symbols:
+            flox_symbols.append(await broker.add_symbol(sym))
+
+        strat = __PROJECT_SLUG___strategy(
+            flox_symbols,
+            fast=config.fast_period,
+            slow=config.slow_period,
+            qty=config.order_qty,
+            dry_run=config.dry_run,
+        )
+        broker.add_strategy(strat)
+
+        # Graceful shutdown on SIGINT / SIGTERM. asyncio.run installs
+        # its own SIGINT handler on POSIX; we override to also stop
+        # the broker cleanly.
+        loop = asyncio.get_running_loop()
+        stop_event = asyncio.Event()
+
+        def _shutdown():
+            logger.info("shutdown signal received")
+            stop_event.set()
+
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                loop.add_signal_handler(sig, _shutdown)
+            except (NotImplementedError, RuntimeError):
+                # Windows / non-main thread.
+                pass
+
+        run_task = asyncio.create_task(
+            broker.run(streams=tuple(config.streams),
+                       book_depth=config.book_depth,
+                       reconcile=config.reconcile_positions))
+
+        try:
+            await stop_event.wait()
+        finally:
+            run_task.cancel()
+            try:
+                await run_task
+            except asyncio.CancelledError:
+                pass
+
+
+def _setup_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def main() -> None:
+    config = load_config()
+    _setup_logging(config.log_level)
+    if config.dry_run:
+        logger.info("dry-run mode — orders will be logged, not placed")
+    else:
+        logger.warning("LIVE mode — orders will be sent to %s (%s)",
+                       config.exchange,
+                       "sandbox" if config.sandbox else "PRODUCTION")
+    try:
+        asyncio.run(run(config))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/python/flox_py/templates/live/requirements.txt
+++ b/python/flox_py/templates/live/requirements.txt
@@ -1,0 +1,5 @@
+flox-py>=0.5.6
+ccxt>=4.0
+pydantic>=2.0
+# Python 3.10 needs tomli; 3.11+ has tomllib in stdlib.
+tomli>=2.0; python_version < "3.11"

--- a/python/tests/test_flox_new_cli.py
+++ b/python/tests/test_flox_new_cli.py
@@ -115,6 +115,37 @@ class FloxNewCliTests(unittest.TestCase):
         self.assertEqual(cli._slug("a strategy 2"), "a_strategy_2")
         self.assertEqual(cli._slug("___"), "project")
 
+    def test_templates_lists_live(self) -> None:
+        names = cli._list_templates()
+        self.assertIn("live", names,
+                      f"expected 'live' template, got {names!r}")
+
+    def test_live_template_layout(self) -> None:
+        rc = cli.main(["new", "MyBot", "--template", "live"])
+        self.assertEqual(rc, 0)
+        proj = self.tmp / "MyBot"
+        for f in ("main.py", "config.py", "config.toml.example",
+                  "requirements.txt", "README.md", ".gitignore"):
+            self.assertTrue((proj / f).exists(),
+                            f"live template should ship {f}")
+        # Ensure the example config does NOT carry secrets and that
+        # the scaffolded project's actual config.toml is absent (only
+        # the example is in git; the runtime file is created by the
+        # user from the example).
+        self.assertFalse((proj / "config.toml").exists())
+
+    def test_live_template_substitutes_prefix_without_data_suffix(self) -> None:
+        rc = cli.main(["new", "Live-Bot", "--template", "live"])
+        self.assertEqual(rc, 0)
+        cfg = (self.tmp / "Live-Bot" / "config.py").read_text()
+        # Prefix is upper-cased slug WITHOUT the "_DATA" suffix.
+        self.assertIn("LIVE_BOT", cfg)
+        self.assertNotIn("LIVE_BOT_DATA", cfg)
+        self.assertNotIn("__PROJECT_NAME__", cfg)
+        self.assertNotIn("__PROJECT_PREFIX__", cfg)
+        self.assertNotIn("__PROJECT_ENV__", cfg)
+        self.assertNotIn("__PROJECT_SLUG__", cfg)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A second `flox new` template wired to `CcxtBroker`. Defaults are dry-run + sandbox so the scaffold is safe to run unattended; flipping to live takes an explicit sequence (set `FLOX_LIVE=1`, supply api keys, set `sandbox = false`).

## Layout

- `main.py` — asyncio entry point. Strategy with `on_trade`, `on_order_update`, `on_initial_position`. SIGINT / SIGTERM handlers cancel the broker run task cleanly.
- `config.py` — Pydantic `LiveConfig` model. Reads `config.toml`; honors `FLOX_LIVE=1` to override `dry_run`. Validates symbols (non-empty), periods (>0), order quantity (>0). `tomllib` on Python 3.11+, `tomli` fallback for 3.10.
- `config.toml.example` — copy to `config.toml` and edit. `.gitignore` keeps the runtime `config.toml` out of source control so secrets do not leak.
- `requirements.txt` — `flox-py`, `ccxt>=4.0`, `pydantic>=2.0`, `tomli>=2.0; python_version < "3.11"`.
- `README.md` — explicit go-live sequence (testnet first, `FLOX_LIVE=1`, `sandbox = false` flip) and what each file is for.

## Why a separate template

The `research` template's defaults (synthetic mode, no broker) are wrong for a live process. Splitting keeps each template short and the failure modes explicit.

## CLI placeholder layer

New `__PROJECT_PREFIX__` placeholder expands to the upper-cased slug without the `_DATA` suffix. `flox new MyBot --template=live` produces `MYBOT_API_KEY`, `MYBOT_SECRET`, `MYBOT_CONFIG`. The research template's `__PROJECT_ENV__` (which expands to `<PREFIX>_DATA`) is unchanged.

## Tests

`python/tests/test_flox_new_cli.py` — 3 new cases:
- `live` shows up in `flox templates`.
- Scaffolded live project ships expected files (`main.py`, `config.py`, `config.toml.example`, `requirements.txt`, `README.md`, `.gitignore`); `config.toml` is *not* shipped (only the example is in git).
- Prefix substitution produces `LIVE_BOT` (not `LIVE_BOT_DATA`) for `flox new Live-Bot`.

## Manual verification

`flox new mybot --template=live && cd mybot && cp config.toml.example config.toml` then `python -c "import config; c = config.load_config('config.toml'); print(c)"` loads the validated config.

## Test plan

- [x] `python3 python/tests/test_flox_new_cli.py` — 9 / 9 pass.
- [x] `python3 scripts/check_doc_snippets.py --min-includes 6` — green.
- [x] `python3 scripts/gen_llms_txt.py --check` — green.
- [x] `python3 scripts/sync_mcp_data.py --check` — green.
- [x] Manual scaffold round-trip with pydantic installed.
- [ ] CI green.

W4-T005