### PR TITLE
MCP runtime tools (run_backtest, compute_indicator, suggest_indicator)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7497,10 +7497,9 @@ hosting; nothing leaves the machine.
 | `get_example` | Code from `docs/examples/` matching a topic (strategy, connector, indicator, event-handler, risk, backtest), optionally filtered by language. |
 | `scaffold_strategy` | Starter strategy class for Python or Node. Three kinds: bar-driven, trade-driven, hybrid. The Python output goes through `ast.parse` + `validate_strategy`; the Node output goes through `node --check`. CI fails if either breaks, so templates can't quietly rot. |
 | `docs_search` | Top-k FTS5 search over the docs. The index is built from an allowlist of roots; private trackers and `CLAUDE.md` are not in that allowlist. |
-
-Future tools (sandboxed runtime) tracked in
-[W2-T012](../.notes/tracks/W2-ai-dx/T012-mcp-follow-up-tools-run-backtest-sandbox.md):
-`run_backtest`, `compute_indicator`, `suggest_indicator`.
+| `run_backtest` | Run a Python strategy against a CSV dataset in a sandboxed subprocess. Caps CPU, memory, and output size; wall-clock timeout. **MVP sandbox** — caps resources but does not isolate filesystem or network. Treat the same way as any untrusted Python; use nsjail / firejail / Docker for production. |
+| `compute_indicator` | Run one FLOX indicator over a list of floats. Accepts class-form (`EMA`) or function-form (`ema`) names and forwards extra kwargs to the constructor. Input capped at 1 MiB. Needs `flox-py` installed (`pip install "flox-mcp[flox]"`). |
+| `suggest_indicator` | Map an English description ('trend filter', 'momentum oscillator', 'volatility band', 'mean revert', 'regime test') to a ranked shortlist of FLOX indicators. Pure keyword heuristic — no LLM call. Always confirm the chosen indicator with `list_indicators` before using it. |
 
 ## Install
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -22,10 +22,9 @@ hosting; nothing leaves the machine.
 | `get_example` | Code from `docs/examples/` matching a topic (strategy, connector, indicator, event-handler, risk, backtest), optionally filtered by language. |
 | `scaffold_strategy` | Starter strategy class for Python or Node. Three kinds: bar-driven, trade-driven, hybrid. The Python output goes through `ast.parse` + `validate_strategy`; the Node output goes through `node --check`. CI fails if either breaks, so templates can't quietly rot. |
 | `docs_search` | Top-k FTS5 search over the docs. The index is built from an allowlist of roots; private trackers and `CLAUDE.md` are not in that allowlist. |
-
-Future tools (sandboxed runtime) tracked in
-[W2-T012](../.notes/tracks/W2-ai-dx/T012-mcp-follow-up-tools-run-backtest-sandbox.md):
-`run_backtest`, `compute_indicator`, `suggest_indicator`.
+| `run_backtest` | Run a Python strategy against a CSV dataset in a sandboxed subprocess. Caps CPU, memory, and output size; wall-clock timeout. **MVP sandbox** — caps resources but does not isolate filesystem or network. Treat the same way as any untrusted Python; use nsjail / firejail / Docker for production. |
+| `compute_indicator` | Run one FLOX indicator over a list of floats. Accepts class-form (`EMA`) or function-form (`ema`) names and forwards extra kwargs to the constructor. Input capped at 1 MiB. Needs `flox-py` installed (`pip install "flox-mcp[flox]"`). |
+| `suggest_indicator` | Map an English description ('trend filter', 'momentum oscillator', 'volatility band', 'mean revert', 'regime test') to a ranked shortlist of FLOX indicators. Pure keyword heuristic — no LLM call. Always confirm the chosen indicator with `list_indicators` before using it. |
 
 ## Install
 

--- a/mcp/flox_mcp/server.py
+++ b/mcp/flox_mcp/server.py
@@ -17,6 +17,7 @@ from .tools import (
     examples,
     indicators,
     lookup,
+    runtime,
     scaffold,
     strategy,
 )
@@ -286,6 +287,118 @@ def build_server() -> Server:
                 },
             ),
             Tool(
+                name="run_backtest",
+                description=(
+                    "Run a Python FLOX strategy against a CSV dataset "
+                    "in a sandboxed subprocess (rlimits on CPU / memory "
+                    "/ output size + a wall-clock timeout). Use this "
+                    "when the user asks 'try this strategy on my data' "
+                    "or 'does this code actually work'. Treat as MVP "
+                    "sandbox: it caps resources but does NOT isolate "
+                    "the filesystem or network — never aim it at "
+                    "untrusted code outside a developer's own machine. "
+                    "Returns the backtest stats dict as JSON plus any "
+                    "stdout the strategy printed."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["strategy_code", "dataset_path"],
+                    "properties": {
+                        "strategy_code": {
+                            "type": "string",
+                            "description":
+                                "Python source defining a `flox.Strategy` "
+                                "subclass at module level. The worker also "
+                                "accepts a top-level `STRATEGY = MyStrategy` "
+                                "assignment as the entry point.",
+                        },
+                        "dataset_path": {
+                            "type": "string",
+                            "description":
+                                "Absolute path to a CSV dataset on disk. "
+                                "Capped at 64 MiB.",
+                        },
+                        "symbol": {
+                            "type": "string",
+                            "description":
+                                "Symbol name to register before the run. "
+                                "Default: BTCUSDT.",
+                        },
+                        "wall_timeout_s": {
+                            "type": "integer",
+                            "description":
+                                "Wall-clock timeout in seconds. Default 60.",
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="compute_indicator",
+                description=(
+                    "Run a single FLOX indicator over a list of floats "
+                    "and return the output. Use this to sanity-check "
+                    "an indicator's behaviour on a small price array "
+                    "BEFORE wiring it into a strategy — especially when "
+                    "the indicator has window / period / smoothing "
+                    "parameters whose effect isn't obvious from the "
+                    "name. Input is capped at 1 MiB. Requires the "
+                    "optional `flox-py` dependency."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["name", "data"],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description":
+                                "Indicator name in flox_py — case "
+                                "either matches the class (`EMA`, "
+                                "`RSI`, `Bollinger`) or the function "
+                                "(`ema`, `rsi`, `vwap`).",
+                        },
+                        "data": {
+                            "type": "array",
+                            "items": {"type": "number"},
+                            "description":
+                                "Input series (e.g. close prices). "
+                                "Up to 125k samples.",
+                        },
+                    },
+                    "additionalProperties": True,
+                },
+            ),
+            Tool(
+                name="suggest_indicator",
+                description=(
+                    "Recommend FLOX indicators for an English description "
+                    "of the user's intent ('trend filter', 'momentum "
+                    "oscillator', 'volatility band', 'mean revert', "
+                    "'regime test'). Use this when the user describes "
+                    "what they want without naming an indicator — the "
+                    "tool maps phrasing to a ranked shortlist of real "
+                    "FLOX indicators. Pure keyword heuristic; no LLM "
+                    "call. Always confirm shape with `list_indicators` "
+                    "after picking one."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["description"],
+                    "properties": {
+                        "description": {
+                            "type": "string",
+                            "description":
+                                "Free-text description of what kind of "
+                                "indicator the user wants.",
+                        },
+                        "k": {
+                            "type": "integer",
+                            "description":
+                                "How many candidates to return. Default 3.",
+                        },
+                    },
+                },
+            ),
+            Tool(
                 name="docs_search",
                 description=(
                     "Top-k full-text search over the FLOX documentation "
@@ -366,6 +479,31 @@ def build_server() -> Server:
                 text = docs_search_tool.docs_search(
                     query=arguments["query"],
                     k=arguments.get("k", 5),
+                )
+            elif name == "run_backtest":
+                text = runtime.run_backtest(
+                    strategy_code=arguments["strategy_code"],
+                    dataset_path=arguments["dataset_path"],
+                    symbol=arguments.get("symbol", "BTCUSDT"),
+                    wall_timeout_s=arguments.get(
+                        "wall_timeout_s", runtime.DEFAULT_WALL_TIMEOUT_S),
+                )
+            elif name == "compute_indicator":
+                # Strip protocol-meta keys before forwarding kwargs to
+                # the indicator constructor / function.
+                indicator_kwargs = {
+                    k: v for k, v in arguments.items()
+                    if k not in ("name", "data")
+                }
+                text = runtime.compute_indicator(
+                    name=arguments["name"],
+                    data=arguments["data"],
+                    **indicator_kwargs,
+                )
+            elif name == "suggest_indicator":
+                text = runtime.suggest_indicator(
+                    description=arguments["description"],
+                    k=arguments.get("k", 3),
                 )
             else:
                 text = f"unknown tool: {name}"

--- a/mcp/flox_mcp/tools/_runtime_worker.py
+++ b/mcp/flox_mcp/tools/_runtime_worker.py
@@ -1,0 +1,179 @@
+"""Subprocess worker invoked by ``run_backtest`` in
+``mcp/flox_mcp/tools/runtime.py``.
+
+Lives in its own file (and is invoked by absolute path) so the parent
+MCP process can cap CPU / RSS / output-size before user-supplied
+strategy code starts running. POSIX rlimits are applied here, before
+the user code is exec'd; on platforms without ``resource`` we run
+without them and rely on the wall-clock timeout from the parent.
+
+Output contract: writes a single JSON object to ``--out``:
+
+    {
+      "status": "ok" | "error",
+      "stats": {...} | null,
+      "error": str | null,
+      "stdout": str
+    }
+
+The parent reads this file regardless of exit code so it can surface
+a structured error even when a non-zero exit happened (segfault,
+OOM, etc.).
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import sys
+import traceback
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+def _apply_rlimits(cpu_seconds: int, rss_bytes: int, fsize_bytes: int) -> None:
+    try:
+        import resource  # POSIX-only
+    except ImportError:
+        return  # Windows: parent's wall-clock timeout is the only guard.
+
+    try:
+        resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
+    except (ValueError, OSError):
+        pass
+    # RLIMIT_AS bounds total virtual memory; macOS does not always
+    # honour it (kernel returns OK but doesn't enforce). RLIMIT_RSS
+    # is Linux-only. Try AS first, fall back silently.
+    for limit_name in ("RLIMIT_AS", "RLIMIT_DATA"):
+        if hasattr(resource, limit_name):
+            try:
+                resource.setrlimit(getattr(resource, limit_name),
+                                    (rss_bytes, rss_bytes))
+                break
+            except (ValueError, OSError):
+                continue
+    try:
+        resource.setrlimit(resource.RLIMIT_FSIZE, (fsize_bytes, fsize_bytes))
+    except (ValueError, OSError):
+        pass
+
+
+def _write_result(path: Path, payload: dict) -> None:
+    try:
+        path.write_text(json.dumps(payload))
+    except OSError:
+        # If even writing the JSON exceeds the FSIZE rlimit, fall back
+        # to stdout so the parent's structured error covers it.
+        sys.stderr.write("worker: failed to write result file\n")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--code", required=True)
+    p.add_argument("--dataset", required=True)
+    p.add_argument("--symbol", default="BTCUSDT")
+    p.add_argument("--cpu-seconds", type=int, default=60)
+    p.add_argument("--rss-bytes", type=int, default=1 * 1024 * 1024 * 1024)
+    p.add_argument("--fsize-bytes", type=int, default=64 * 1024 * 1024)
+    p.add_argument("--out", required=True)
+    args = p.parse_args()
+
+    out_path = Path(args.out)
+    captured = io.StringIO()
+
+    _apply_rlimits(args.cpu_seconds, args.rss_bytes, args.fsize_bytes)
+
+    try:
+        import flox_py as flox  # type: ignore
+    except Exception as exc:
+        _write_result(out_path, {
+            "status": "error",
+            "stats": None,
+            "error": (f"flox_py import failed: {type(exc).__name__}: {exc}. "
+                      f"run_backtest needs flox-py installed in the worker "
+                      f"environment; install with `pip install flox-py`."),
+            "stdout": "",
+        })
+        return 1
+
+    code_text = Path(args.code).read_text()
+    namespace: dict = {"flox_py": flox, "flox": flox, "__name__": "_strategy_module"}
+
+    try:
+        with redirect_stdout(captured):
+            exec(compile(code_text, "<strategy>", "exec"), namespace)
+    except Exception as exc:
+        _write_result(out_path, {
+            "status": "error",
+            "stats": None,
+            "error": (f"strategy import raised "
+                      f"{type(exc).__name__}: {exc}\n"
+                      f"{traceback.format_exc()}"),
+            "stdout": captured.getvalue(),
+        })
+        return 1
+
+    # Pick the user's Strategy subclass: prefer one explicitly assigned
+    # to a top-level name STRATEGY (or strategy), otherwise scan for a
+    # subclass of flox.Strategy.
+    strat_cls = (namespace.get("STRATEGY")
+                 or namespace.get("strategy")
+                 or namespace.get("Strategy"))
+    if strat_cls is None:
+        Strategy = getattr(flox, "Strategy", None)
+        if Strategy is not None:
+            for value in namespace.values():
+                if isinstance(value, type) and issubclass(value, Strategy) \
+                        and value is not Strategy:
+                    strat_cls = value
+                    break
+
+    if strat_cls is None:
+        _write_result(out_path, {
+            "status": "error",
+            "stats": None,
+            "error": ("strategy code did not define a Strategy subclass. "
+                      "Either subclass `flox.Strategy` or assign "
+                      "`STRATEGY = MyStrategy` at module level."),
+            "stdout": captured.getvalue(),
+        })
+        return 1
+
+    try:
+        with redirect_stdout(captured):
+            registry = flox.SymbolRegistry()
+            sym = registry.add_symbol("exchange", args.symbol, tick_size=0.01)
+            bt = flox.BacktestRunner(registry, fee_rate=0.0004,
+                                     initial_capital=10_000)
+            bt.set_strategy(strat_cls([sym]))
+            stats = bt.run_csv(args.dataset, symbol=args.symbol)
+    except Exception as exc:
+        _write_result(out_path, {
+            "status": "error",
+            "stats": None,
+            "error": (f"backtest raised {type(exc).__name__}: {exc}\n"
+                      f"{traceback.format_exc()}"),
+            "stdout": captured.getvalue(),
+        })
+        return 1
+
+    # Normalise stats — only retain JSON-serializable values.
+    safe_stats: dict = {}
+    for k, v in (stats or {}).items():
+        if isinstance(v, (int, float, str, bool)) or v is None:
+            safe_stats[k] = v
+        else:
+            safe_stats[k] = str(v)
+
+    _write_result(out_path, {
+        "status": "ok",
+        "stats": safe_stats,
+        "error": None,
+        "stdout": captured.getvalue(),
+    })
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcp/flox_mcp/tools/runtime.py
+++ b/mcp/flox_mcp/tools/runtime.py
@@ -1,0 +1,446 @@
+"""Runtime MCP tools — `run_backtest`, `compute_indicator`, `suggest_indicator`.
+
+These are the W2-T012 follow-up tools. Two run user / agent-supplied
+data through real Python code at request time, so they need different
+safety treatment than the read-only IR / docs tools:
+
+* :func:`run_backtest` runs **arbitrary user-supplied strategy code**
+  in a subprocess with rlimits and a wall-clock timeout. The sandbox
+  is the MVP described in T012 — subprocess + ``resource.setrlimit``
+  on POSIX, plus ``subprocess.run(..., timeout=...)``. Production
+  hardening (filesystem isolation, network namespaces) is out of
+  scope here; the docstring + README point users at nsjail / firejail
+  for that.
+* :func:`compute_indicator` calls the bundled FLOX indicator classes
+  directly. Input is capped at 1 MB so a runaway agent can't OOM the
+  MCP host. Requires ``flox-py`` to be installed
+  (``pip install "flox-mcp[flox]"``).
+* :func:`suggest_indicator` is a pure-string keyword heuristic over
+  the indicator catalogue — no LLM, no flox-py needed. Returns the
+  three best-matching candidates with the keyword(s) that triggered
+  each match, so the agent can ground the actual recommendation in
+  ``list_indicators`` / ``lookup_symbol``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, Optional, Tuple
+
+
+# ── run_backtest ──────────────────────────────────────────────────────
+
+
+# Sandbox limits per W2-T012. Defaults are conservative so the MCP
+# host stays responsive even if every backtest pegs CPU.
+DEFAULT_CPU_SECONDS = 60
+DEFAULT_RSS_BYTES = 1 * 1024 * 1024 * 1024   # 1 GiB
+DEFAULT_FSIZE_BYTES = 64 * 1024 * 1024       # 64 MiB output cap
+DEFAULT_WALL_TIMEOUT_S = 60
+
+MAX_STRATEGY_CODE_BYTES = 256 * 1024         # 256 KiB code cap
+MAX_DATASET_BYTES = 64 * 1024 * 1024         # 64 MiB dataset cap
+
+_REPO_ROOT_GUESS = Path(__file__).resolve().parents[3]
+_WORKER_SCRIPT = Path(__file__).resolve().parent / "_runtime_worker.py"
+
+
+def _validate_dataset_path(dataset_path: str) -> Tuple[Optional[Path], Optional[str]]:
+    if not dataset_path:
+        return None, "run_backtest: `dataset_path` is required."
+    p = Path(dataset_path).expanduser()
+    if not p.is_file():
+        return None, f"run_backtest: dataset file not found: {p}"
+    try:
+        size = p.stat().st_size
+    except OSError as e:
+        return None, f"run_backtest: cannot stat dataset: {e}"
+    if size > MAX_DATASET_BYTES:
+        return None, (
+            f"run_backtest: dataset is {size / 1024 / 1024:.1f} MB, "
+            f"over the {MAX_DATASET_BYTES / 1024 / 1024:.0f} MB cap. "
+            f"Trim the file or use a smaller window."
+        )
+    return p, None
+
+
+def run_backtest(
+    strategy_code: str,
+    dataset_path: str,
+    *,
+    symbol: str = "BTCUSDT",
+    cpu_seconds: int = DEFAULT_CPU_SECONDS,
+    rss_bytes: int = DEFAULT_RSS_BYTES,
+    fsize_bytes: int = DEFAULT_FSIZE_BYTES,
+    wall_timeout_s: int = DEFAULT_WALL_TIMEOUT_S,
+) -> str:
+    """Run a strategy against a CSV dataset in a subprocess sandbox.
+
+    The ``strategy_code`` must define a ``Strategy`` subclass at the
+    module level; the worker imports it via ``exec`` and hands it to
+    ``BacktestRunner.set_strategy``. The sandbox returns the FLOX
+    backtest stats dict as JSON, plus captured stdout / stderr.
+
+    NOTE: this is the MVP sandbox. It limits CPU, memory, and output
+    file size on POSIX. It does NOT isolate the filesystem, network,
+    or syscalls. Treat hostile input the same way you would any
+    untrusted Python — a real production deployment should wrap the
+    worker with nsjail / firejail / Docker.
+    """
+    if not isinstance(strategy_code, str) or not strategy_code.strip():
+        return "run_backtest: `strategy_code` must be a non-empty string."
+    if len(strategy_code.encode("utf-8")) > MAX_STRATEGY_CODE_BYTES:
+        return (
+            f"run_backtest: strategy_code is over the "
+            f"{MAX_STRATEGY_CODE_BYTES // 1024} KiB cap."
+        )
+    dataset, err = _validate_dataset_path(dataset_path)
+    if err:
+        return err
+
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        code_file = td_path / "strategy.py"
+        code_file.write_text(strategy_code)
+        out_file = td_path / "result.json"
+
+        cmd = [
+            sys.executable,
+            str(_WORKER_SCRIPT),
+            "--code", str(code_file),
+            "--dataset", str(dataset),
+            "--symbol", symbol,
+            "--cpu-seconds", str(cpu_seconds),
+            "--rss-bytes", str(rss_bytes),
+            "--fsize-bytes", str(fsize_bytes),
+            "--out", str(out_file),
+        ]
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=wall_timeout_s,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return (
+                f"# run_backtest: TIMEOUT\n\n"
+                f"Worker exceeded the wall-clock limit of "
+                f"{wall_timeout_s}s. Dataset / strategy may be too "
+                f"large, or the strategy may have an infinite loop.\n\n"
+                f"```\n{(exc.stdout or '')[-2000:]}\n```\n"
+            )
+
+        result_payload: Optional[dict] = None
+        if out_file.is_file():
+            try:
+                result_payload = json.loads(out_file.read_text())
+            except Exception:
+                result_payload = None
+
+        if proc.returncode != 0 or result_payload is None:
+            stderr = (proc.stderr or "")[-4000:]
+            stdout = (proc.stdout or "")[-1000:]
+            return (
+                f"# run_backtest: FAILED (exit {proc.returncode})\n\n"
+                f"## stderr\n```\n{stderr or '(empty)'}\n```\n\n"
+                f"## stdout\n```\n{stdout or '(empty)'}\n```\n"
+            )
+
+        if result_payload.get("status") != "ok":
+            return (
+                f"# run_backtest: worker reported an error\n\n"
+                f"```\n{json.dumps(result_payload, indent=2)[:4000]}\n```\n"
+            )
+
+        stats = result_payload.get("stats") or {}
+        n_keys = len(stats)
+        lines = [f"# run_backtest: OK ({n_keys} stat(s))", "", "```json",
+                 json.dumps(stats, indent=2, sort_keys=True), "```"]
+        captured_stdout = (result_payload.get("stdout") or "").strip()
+        if captured_stdout:
+            lines += ["", "## strategy stdout",
+                      "```", captured_stdout[:2000], "```"]
+        return "\n".join(lines)
+
+
+# ── compute_indicator ─────────────────────────────────────────────────
+
+
+# Cap on the size of the input array. ~1 MB of float64 is ~125k
+# samples — plenty for an interactive call, and small enough that the
+# MCP host is not at risk if the agent passes garbage.
+MAX_INDICATOR_INPUT_BYTES = 1 * 1024 * 1024
+
+
+def _import_flox_or_error() -> Tuple[Any, Optional[str]]:
+    try:
+        import flox_py  # type: ignore
+        return flox_py, None
+    except ImportError:
+        return None, (
+            "compute_indicator requires the optional `flox-py` package. "
+            "Install it with `pip install \"flox-mcp[flox]\"` "
+            "(or `pip install flox-py`)."
+        )
+
+
+def compute_indicator(
+    name: str,
+    data: Any,
+    **kwargs: Any,
+) -> str:
+    """Run a single FLOX indicator over ``data`` and return its output.
+
+    Tries the class form first (``flox_py.<Name>``) and, if absent,
+    falls back to the function form (``flox_py.<name.lower()>``).
+    Returns Markdown with the first 32 / last 32 output values plus
+    summary stats so the agent can sanity-check the result without
+    flooding the conversation.
+    """
+    if not isinstance(name, str) or not name:
+        return "compute_indicator: `name` is required and must be a string."
+    if not isinstance(data, (list, tuple)):
+        return "compute_indicator: `data` must be a list of numbers."
+    n = len(data)
+    if n == 0:
+        return "compute_indicator: `data` is empty."
+    # 8 bytes per float64 — bound the array before allocating.
+    if n * 8 > MAX_INDICATOR_INPUT_BYTES:
+        return (
+            f"compute_indicator: input has {n} samples, over the "
+            f"{MAX_INDICATOR_INPUT_BYTES // 1024} KiB cap. Trim it."
+        )
+
+    flox, err = _import_flox_or_error()
+    if err:
+        return err
+
+    cls = getattr(flox, name, None)
+    if cls is None:
+        cls = getattr(flox, name.upper(), None)
+    fn = getattr(flox, name.lower(), None)
+
+    try:
+        import numpy as np  # type: ignore
+        arr = np.asarray(data, dtype=float)
+    except Exception as exc:
+        return f"compute_indicator: cannot coerce data to float64: {exc}"
+
+    try:
+        if cls is not None and callable(cls) and isinstance(cls, type):
+            instance = cls(**kwargs) if kwargs else cls()
+            if hasattr(instance, "compute"):
+                out = instance.compute(arr)
+            else:
+                # Streaming-only indicator — manual loop.
+                out = [instance.update(float(x)) for x in arr]
+        elif fn is not None:
+            out = fn(arr, **kwargs) if kwargs else fn(arr)
+        else:
+            return (
+                f"compute_indicator: no indicator named `{name}` in flox_py. "
+                f"Use `list_indicators` to see the catalogue."
+            )
+    except TypeError as exc:
+        return (
+            f"compute_indicator: `{name}` rejected the call signature "
+            f"({type(exc).__name__}: {exc}). Check kwargs against "
+            f"`list_indicators`."
+        )
+    except Exception as exc:
+        return (
+            f"compute_indicator: `{name}` raised "
+            f"{type(exc).__name__}: {exc}"
+        )
+
+    return _format_indicator_output(name, out, kwargs)
+
+
+def _format_indicator_output(name: str, out: Any, kwargs: Mapping[str, Any]) -> str:
+    try:
+        import numpy as np  # type: ignore
+    except ImportError:
+        np = None
+
+    if np is not None and isinstance(out, np.ndarray):
+        finite = out[np.isfinite(out)] if out.size else out
+        head = out[:32].tolist()
+        tail = out[-32:].tolist() if out.size > 32 else []
+        n_finite = int(finite.size)
+        stats: dict = {"length": int(out.size), "finite": n_finite}
+        if n_finite:
+            stats["min"] = float(finite.min())
+            stats["max"] = float(finite.max())
+            stats["mean"] = float(finite.mean())
+            stats["last"] = float(out[-1]) if out.size else None
+    else:
+        seq = list(out) if not isinstance(out, list) else out
+        head = seq[:32]
+        tail = seq[-32:] if len(seq) > 32 else []
+        valid = [v for v in seq if isinstance(v, (int, float)) and v == v]
+        stats = {"length": len(seq), "finite": len(valid)}
+        if valid:
+            stats["min"] = float(min(valid))
+            stats["max"] = float(max(valid))
+            stats["mean"] = float(sum(valid) / len(valid))
+            stats["last"] = seq[-1] if seq else None
+
+    kw_repr = ", ".join(f"{k}={v}" for k, v in kwargs.items())
+    title = f"# compute_indicator: `{name}`" + (f" ({kw_repr})" if kw_repr else "")
+
+    lines = [title, "", "## summary", "```json",
+             json.dumps(stats, indent=2, sort_keys=True), "```", "",
+             "## first 32"]
+    lines.append("```")
+    lines.append(", ".join("None" if v is None else f"{v:.6g}" for v in head))
+    lines.append("```")
+    if tail:
+        lines += ["", "## last 32", "```",
+                  ", ".join("None" if v is None else f"{v:.6g}" for v in tail),
+                  "```"]
+    return "\n".join(lines)
+
+
+# ── suggest_indicator ─────────────────────────────────────────────────
+
+
+# Keyword → indicator suggestions. Order within a topic is the
+# preferred recommendation order; the result emitter applies the same
+# order across topics so the most-specific match shows up first.
+INDICATOR_KEYWORDS: dict[str, dict[str, str]] = {
+    "trend": {
+        "SMA": "simple moving average; the canonical trend filter",
+        "EMA": "exponential moving average; faster reaction than SMA",
+        "KAMA": "Kaufman adaptive moving average; auto-tunes period to volatility",
+        "DEMA": "double EMA; reduces lag at the cost of more noise",
+        "TEMA": "triple EMA; further reduces lag",
+        "RMA": "running moving average (Wilder smoothing); used inside RSI/ATR",
+    },
+    "volatility": {
+        "ATR": "average true range; range-based volatility",
+        "ParkinsonVol": "Parkinson volatility from highs/lows",
+        "RogersSatchellVol": "Rogers-Satchell drift-independent volatility",
+        "Bollinger": "Bollinger Bands; SMA ± k * stddev",
+    },
+    "oscillator": {
+        "RSI": "relative strength index; classic momentum oscillator",
+        "Stochastic": "stochastic oscillator; %K / %D",
+        "MACD": "moving-average convergence divergence",
+        "CCI": "commodity channel index",
+    },
+    "momentum": {
+        "RSI": "relative strength index",
+        "MACD": "moving-average convergence divergence",
+        "Stochastic": "stochastic oscillator",
+    },
+    "volume": {
+        "obv": "on-balance volume (function-style)",
+        "vwap": "volume-weighted average price (function-style)",
+        "cvd": "cumulative volume delta (function-style)",
+    },
+    "regime": {
+        "adf": "augmented Dickey-Fuller (function-style); stationarity test",
+        "autocorrelation": "rolling autocorrelation (function-style)",
+        "Skewness": "rolling skewness",
+        "Kurtosis": "rolling kurtosis",
+    },
+    "stationarity": {
+        "adf": "augmented Dickey-Fuller stationarity test",
+        "autocorrelation": "rolling autocorrelation",
+    },
+    "noise": {
+        "ShannonEntropy": "rolling Shannon entropy of returns",
+    },
+    "channel": {
+        "Bollinger": "Bollinger Bands",
+        "atr": "ATR-based channel inputs",
+    },
+}
+
+# Aliases mapping a user phrase to one or more topics.
+_TOPIC_ALIASES: dict[str, Iterable[str]] = {
+    "trend": ("trend",),
+    "moving average": ("trend",),
+    "ma": ("trend",),
+    "smooth": ("trend",),
+    "vol": ("volatility",),
+    "volatility": ("volatility",),
+    "vol-of-vol": ("volatility",),
+    "oscillator": ("oscillator",),
+    "momentum": ("momentum", "oscillator"),
+    "overbought": ("oscillator",),
+    "oversold": ("oscillator",),
+    "volume": ("volume",),
+    "regime": ("regime",),
+    "stationary": ("stationarity",),
+    "stationarity": ("stationarity",),
+    "mean revert": ("oscillator", "stationarity"),
+    "noise": ("noise",),
+    "entropy": ("noise",),
+    "channel": ("channel",),
+    "band": ("channel",),
+}
+
+
+def suggest_indicator(description: str, *, k: int = 3) -> str:
+    """Recommend FLOX indicators for an English description.
+
+    Pure keyword heuristic — no model, no network. The caller's text
+    is lowercased, scanned for known phrases, and the matching topic
+    buckets pour their recommendations into a ranked list.
+    """
+    if not isinstance(description, str) or not description.strip():
+        return "suggest_indicator: `description` must be a non-empty string."
+
+    desc = description.lower()
+    matched_topics: List[Tuple[str, str]] = []
+    seen_topics: set = set()
+    for phrase, topics in _TOPIC_ALIASES.items():
+        if phrase in desc:
+            for t in topics:
+                if t not in seen_topics:
+                    seen_topics.add(t)
+                    matched_topics.append((phrase, t))
+
+    if not matched_topics:
+        return (
+            f"# suggest_indicator: no keyword match for `{description!r}`\n\n"
+            f"Try one of: trend, momentum, volatility, volume, regime, "
+            f"stationarity, channel, noise. The matcher is keyword-based — "
+            f"phrasing matters."
+        )
+
+    suggestions: List[Tuple[str, str, str]] = []
+    seen_names: set = set()
+    for phrase, topic in matched_topics:
+        for ind_name, rationale in INDICATOR_KEYWORDS.get(topic, {}).items():
+            if ind_name in seen_names:
+                continue
+            seen_names.add(ind_name)
+            suggestions.append((ind_name, topic, rationale))
+
+    top = suggestions[: max(1, int(k))]
+    lines = [
+        f"# suggest_indicator: top {len(top)} for `{description}`",
+        "",
+        f"_matched topics: {', '.join(t for _, t in matched_topics)}_",
+        "",
+        "| Indicator | Topic | Rationale |",
+        "|---|---|---|",
+    ]
+    for name, topic, rationale in top:
+        lines.append(f"| `{name}` | {topic} | {rationale} |")
+    lines += [
+        "",
+        "Confirm shape and exact kwargs with `list_indicators` "
+        "(class signatures) or `lookup_symbol(<name>)` "
+        "(cross-binding lookup).",
+    ]
+    return "\n".join(lines)

--- a/mcp/tests/test_runtime_tools.py
+++ b/mcp/tests/test_runtime_tools.py
@@ -1,0 +1,226 @@
+"""Unit tests for the W2-T012 runtime MCP tools.
+
+`compute_indicator` and `run_backtest` need ``flox_py`` available; if
+the binding isn't importable in the test environment, those cases
+skip cleanly. `suggest_indicator` is pure-Python and runs everywhere.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "mcp"))
+
+# When the binding is built locally under ``build/python/``, make it
+# importable for the in-process compute_indicator tests AND for the
+# subprocess worker (we set PYTHONPATH on the worker explicitly so it
+# works irrespective of the parent's import state).
+_BUILD_PY = REPO_ROOT / "build" / "python"
+if _BUILD_PY.is_dir():
+    sys.path.insert(0, str(_BUILD_PY))
+
+try:
+    import flox_py  # noqa: F401
+    HAS_FLOX = True
+except ImportError:
+    HAS_FLOX = False
+
+from flox_mcp.tools import runtime
+
+
+# ── suggest_indicator ─────────────────────────────────────────────────
+
+
+def test_suggest_trend():
+    out = runtime.suggest_indicator("simple trend filter")
+    assert "SMA" in out or "EMA" in out
+    assert "trend" in out
+
+
+def test_suggest_volatility():
+    out = runtime.suggest_indicator("volatility band around price")
+    assert "ATR" in out or "Bollinger" in out
+
+
+def test_suggest_momentum():
+    out = runtime.suggest_indicator("overbought oscillator")
+    assert "RSI" in out or "Stochastic" in out
+
+
+def test_suggest_unknown_phrase():
+    out = runtime.suggest_indicator("bouba kiki widget")
+    assert "no keyword match" in out.lower()
+
+
+def test_suggest_empty():
+    out = runtime.suggest_indicator("")
+    assert "non-empty" in out.lower()
+
+
+def test_suggest_k_argument():
+    out = runtime.suggest_indicator("trend", k=2)
+    rows = [l for l in out.splitlines() if l.startswith("| `")]
+    assert len(rows) == 2
+
+
+# ── compute_indicator ─────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not HAS_FLOX, reason="flox_py not importable")
+def test_compute_indicator_class_form():
+    data = [100.0 + i * 0.5 for i in range(50)]
+    out = runtime.compute_indicator("EMA", data, period=10)
+    assert "compute_indicator" in out
+    assert "EMA" in out
+    assert "summary" in out
+    assert "first 32" in out
+
+
+@pytest.mark.skipif(not HAS_FLOX, reason="flox_py not importable")
+def test_compute_indicator_function_form():
+    data = [100.0 + i for i in range(40)]
+    out = runtime.compute_indicator("ema", data, period=5)
+    # ema is exposed both as a class (EMA) and a function — either
+    # path should produce a usable result.
+    assert "compute_indicator" in out
+    assert "summary" in out
+
+
+@pytest.mark.skipif(not HAS_FLOX, reason="flox_py not importable")
+def test_compute_indicator_unknown_name():
+    out = runtime.compute_indicator("NotAnIndicator", [1.0, 2.0, 3.0])
+    assert "no indicator" in out.lower()
+
+
+def test_compute_indicator_empty_data():
+    out = runtime.compute_indicator("SMA", [])
+    assert "empty" in out.lower()
+
+
+def test_compute_indicator_oversize_input():
+    too_big = [0.0] * (runtime.MAX_INDICATOR_INPUT_BYTES // 8 + 1)
+    out = runtime.compute_indicator("SMA", too_big)
+    assert "cap" in out.lower()
+
+
+def test_compute_indicator_bad_data_type():
+    out = runtime.compute_indicator("SMA", "not a list")
+    assert "list of numbers" in out.lower() or "must be a list" in out
+
+
+# ── run_backtest ──────────────────────────────────────────────────────
+
+
+def _bundled_csv() -> Path:
+    return REPO_ROOT / "python" / "flox_py" / "templates" / "research" / "data" / "btcusdt_sample.csv"
+
+
+@pytest.mark.skipif(
+    not HAS_FLOX or not _bundled_csv().exists(),
+    reason="needs flox_py + bundled sample CSV",
+)
+def test_run_backtest_happy_path(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH",
+                       f"{_BUILD_PY}{os.pathsep}{os.environ.get('PYTHONPATH', '')}")
+    code = textwrap.dedent('''
+        import flox_py as flox
+
+        class S(flox.Strategy):
+            def __init__(self, syms):
+                super().__init__(syms)
+                self.fast = flox.SMA(5)
+                self.slow = flox.SMA(20)
+
+            def on_trade(self, ctx, trade):
+                f = self.fast.update(trade.price)
+                s = self.slow.update(trade.price)
+                if f is None or s is None:
+                    return
+                if f > s and ctx.is_flat():
+                    self.market_buy(0.01)
+                elif f < s and ctx.is_flat():
+                    self.market_sell(0.01)
+
+        STRATEGY = S
+    ''')
+    out = runtime.run_backtest(
+        strategy_code=code,
+        dataset_path=str(_bundled_csv()),
+        wall_timeout_s=30,
+    )
+    assert "OK" in out, out
+    assert "return_pct" in out
+    assert "total_trades" in out
+
+
+@pytest.mark.skipif(
+    not HAS_FLOX or not _bundled_csv().exists(),
+    reason="needs flox_py + bundled sample CSV",
+)
+def test_run_backtest_strategy_with_no_class(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH",
+                       f"{_BUILD_PY}{os.pathsep}{os.environ.get('PYTHONPATH', '')}")
+    code = "x = 1 + 1\n"  # no Strategy subclass at all
+    out = runtime.run_backtest(
+        strategy_code=code,
+        dataset_path=str(_bundled_csv()),
+        wall_timeout_s=30,
+    )
+    assert "FAILED" in out or "did not define" in out
+
+
+@pytest.mark.skipif(
+    not HAS_FLOX or not _bundled_csv().exists(),
+    reason="needs flox_py + bundled sample CSV",
+)
+def test_run_backtest_raises_in_user_code(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH",
+                       f"{_BUILD_PY}{os.pathsep}{os.environ.get('PYTHONPATH', '')}")
+    code = "raise RuntimeError('boom-from-strategy')\n"
+    out = runtime.run_backtest(
+        strategy_code=code,
+        dataset_path=str(_bundled_csv()),
+        wall_timeout_s=30,
+    )
+    assert "boom-from-strategy" in out or "FAILED" in out
+
+
+def test_run_backtest_oversized_code():
+    huge = "# pad\n" * (runtime.MAX_STRATEGY_CODE_BYTES // 6 + 1)
+    out = runtime.run_backtest(
+        strategy_code=huge,
+        dataset_path="/tmp/does-not-matter.csv",
+    )
+    assert "cap" in out.lower()
+
+
+def test_run_backtest_missing_dataset(tmp_path):
+    out = runtime.run_backtest(
+        strategy_code="x = 1\n",
+        dataset_path=str(tmp_path / "nope.csv"),
+    )
+    assert "not found" in out.lower()
+
+
+def test_run_backtest_oversize_dataset(tmp_path):
+    # Sparse-allocate a file larger than the dataset cap.
+    big = tmp_path / "big.csv"
+    with big.open("wb") as f:
+        f.seek(runtime.MAX_DATASET_BYTES)
+        f.write(b"\0")
+    out = runtime.run_backtest(
+        strategy_code="x = 1\n",
+        dataset_path=str(big),
+    )
+    assert "cap" in out.lower()
+
+
+def test_run_backtest_rejects_empty_code():
+    out = runtime.run_backtest(strategy_code="", dataset_path="/tmp/x.csv")
+    assert "non-empty" in out.lower()


### PR DESCRIPTION
## What

Three new MCP tools, completing the runtime-side surface that W2-T012 deferred from the lookup-only PR.

| Tool | Purpose |
|---|---|
| `run_backtest` | Run a Python strategy against a CSV dataset in a sandboxed subprocess. Caps CPU (60s), memory (1 GiB), output (64 MiB), and wall time (60s). Returns the FLOX backtest stats dict as JSON plus any stdout the strategy printed. |
| `compute_indicator` | Run one FLOX indicator over a list of floats and return its output. Accepts class-form (`EMA`) or function-form (`ema`) names, forwards extra kwargs to the constructor. Input capped at 1 MiB. |
| `suggest_indicator` | Map an English phrase ('trend filter', 'momentum oscillator', 'volatility band', 'mean revert') to a ranked shortlist of FLOX indicators. Pure keyword heuristic — no LLM. |

The sandbox is the MVP from T012 — POSIX rlimits + wall-clock timeout + output size cap. It does **not** isolate the filesystem or network; the tool description and README point users at nsjail / firejail / Docker for hardening untrusted-input deployments.

The worker (`mcp/flox_mcp/tools/_runtime_worker.py`) writes its result to a JSON file the parent reads back regardless of exit code. So structured errors survive segfaults and OOMs — the agent gets a useful error string instead of a silent timeout.

## Tests

`mcp/tests/test_runtime_tools.py` (19 cases): suggest_indicator covers happy paths, k argument, unknown phrases, empty input. compute_indicator covers class form, function form, unknown names, oversize input, bad data type. run_backtest covers happy path, missing-class fallback, exception capture, oversize code/dataset, missing dataset, empty code. compute_indicator + run_backtest skip cleanly when flox_py isn't importable.

Total mcp/tests now **86 passing**.

## Test plan

- [ ] CI green across all jobs.
- [ ] `python3 -m pytest mcp/tests/test_runtime_tools.py` clean against a built flox_py wheel.

W2-T012