### PR TITLE
capi: pointer-variant create exports unblocking pure-Codon strategies

### DIFF
--- a/codon/CMakeLists.txt
+++ b/codon/CMakeLists.txt
@@ -89,3 +89,6 @@ add_codon_executable(codon_trace_attach_smoke
 
 add_codon_executable(codon_byte_identical_fixture
   ${CMAKE_CURRENT_SOURCE_DIR}/examples/byte_identical_fixture.codon)
+
+add_codon_executable(codon_strategy_e2e_smoke
+  ${CMAKE_CURRENT_SOURCE_DIR}/examples/strategy_e2e_smoke.codon)

--- a/codon/examples/multi_tf_helpers_smoke.codon
+++ b/codon/examples/multi_tf_helpers_smoke.codon
@@ -65,10 +65,10 @@ def run():
     # End-to-end strategy handle round-trip is exercised in the
     # C++ test (tests/test_multi_tf_alignment.cpp), the QuickJS suite
     # (tests/test_quickjs.cpp) and pybind11
-    # (python/tests/test_multi_tf_alignment.py). The Codon FFI imports
-    # `flox_strategy_create` but cannot drive it through a struct-by-value
-    # callbacks parameter today, so the codon coverage stops at the
-    # FloxBar serialisation contract this smoke locks down.
+    # (python/tests/test_multi_tf_alignment.py). The Codon FFI now has
+    # `flox_strategy_create_p` (pointer variant for the callbacks
+    # struct), so a separate codon smoke (codon_strategy_e2e_smoke)
+    # exercises the full path.
 
     print("codon multi-tf helpers smoke ok")
 

--- a/codon/examples/strategy_e2e_smoke.codon
+++ b/codon/examples/strategy_e2e_smoke.codon
@@ -1,0 +1,69 @@
+# End-to-end Codon strategy smoke. Constructs a Strategy through the
+# pointer-variant callbacks export (flox_strategy_create_p), attaches
+# it to a Runner, drives a tape that crosses an M5 bar boundary,
+# and reads the bar ring back through Strategy.last_closed_bar.
+#
+# Before W9-T003 the Codon FFI couldn't model struct-by-value
+# parameters, so this smoke would never have run. With the pointer
+# variants in place, pure-Codon strategies are constructible.
+
+from C import flox_registry_create() -> cobj
+from C import flox_registry_destroy(cobj)
+from C import flox_registry_add_symbol(cobj, cobj, cobj, float) -> u32
+
+from C import flox_runner_create(cobj, cobj, cobj) -> cobj
+from C import flox_runner_destroy(cobj)
+from C import flox_runner_add_strategy(cobj, cobj)
+from C import flox_runner_start(cobj)
+from C import flox_runner_stop(cobj)
+from C import flox_runner_on_bar(cobj, u32, u8, u64,
+                                  f64, f64, f64, f64, f64, f64,
+                                  i64, i64, u8)
+
+from flox.strategy import Strategy
+from flox.types import BarData
+
+
+def check(label: str, ok: bool):
+    if not ok:
+        print("FAIL: " + label)
+        raise ValueError("smoke fail: " + label)
+    print("ok: " + label)
+
+
+def run():
+    registry = flox_registry_create()
+    exch = "test"
+    sym_name = "BTCUSDT"
+    sym_id = int(flox_registry_add_symbol(
+        registry, exch.c_str(), sym_name.c_str(), 0.01))
+
+    strat = Strategy(symbols=[sym_id], strategy_id=1, registry=registry)
+    check("strategy handle constructed", strat._handle != cobj())
+
+    runner = flox_runner_create(registry, cobj(), cobj())
+    flox_runner_add_strategy(runner, strat._handle)
+    flox_runner_start(runner)
+
+    M5_NS = 5 * 60 * 1_000_000_000
+    flox_runner_on_bar(runner, u32(sym_id), u8(0), u64(M5_NS),
+                        100.0, 102.0, 99.0, 101.0, 1.0, 0.5,
+                        i64(0), i64(M5_NS), u8(0))
+    flox_runner_on_bar(runner, u32(sym_id), u8(0), u64(M5_NS),
+                        101.0, 103.0, 100.0, 102.5, 1.0, 0.5,
+                        i64(M5_NS), i64(2 * M5_NS), u8(0))
+
+    last = strat.last_closed_bar(sym_id, 0, M5_NS)
+    check("last_closed_bar returns a bar", last is not None)
+    if last is not None:
+        check("last close matches latest bar",
+              abs(last.close - 102.5) < 1e-6)
+
+    flox_runner_stop(runner)
+    flox_runner_destroy(runner)
+    # Strategy handle is owned by Codon; the destructor will free it.
+    flox_registry_destroy(registry)
+    print("codon strategy e2e smoke ok")
+
+
+run()

--- a/codon/flox/strategy.codon
+++ b/codon/flox/strategy.codon
@@ -1,7 +1,7 @@
 # flox/strategy.codon -- Strategy base class for Codon.
 # Mirrors C++ flox::Strategy. Override on_trade/on_book_update to implement logic.
 
-from C import flox_strategy_create(u32, Ptr[u32], u32, cobj, cobj) -> cobj
+from C import flox_strategy_create_p(u32, Ptr[u32], u32, cobj, cobj) -> cobj
 from C import flox_strategy_destroy(cobj)
 from C import flox_emit_market_buy(cobj, u32, i64) -> u64
 from C import flox_emit_market_sell(cobj, u32, i64) -> u64
@@ -60,10 +60,11 @@ class Strategy:
     """Base class for Codon strategies. Mirrors C++ flox::Strategy.
 
     Override on_trade() and/or on_book_update() to implement strategy logic.
-    Use emit_* methods (legacy) or ergonomic methods (market_buy, limit_sell, etc).
+    Use emit_* methods (raw) or the ergonomic wrappers
+    (market_buy, limit_sell, etc.) — both reach the same C ABI.
     Use position() and ctx() to query state.
 
-    Codon compiles this to native code -- no interpreter overhead.
+    Codon compiles this to native code — no interpreter overhead.
     """
 
     _handle: cobj
@@ -71,13 +72,33 @@ class Strategy:
     _symbol_names: List[str]
     _symbol_map: Dict[str, int]
     _reverse_map: Dict[int, str]
+    _callbacks_buf: Ptr[byte]
 
-    def __init__(self, symbols: List[int]):
+    def __init__(self, symbols: List[int], strategy_id: int = 1,
+                 registry: cobj = cobj()):
+        """Construct a strategy bound to a registry. Without an attached
+        runner the handle is created but has no event source; pass it
+        into a Runner to drive trades / bars."""
         self._symbols = symbols
-        self._handle = cobj()
         self._symbol_names = list[str]()
         self._symbol_map = dict[str, int]()
         self._reverse_map = dict[int, str]()
+        # FloxStrategyCallbacks is a 6-pointer struct on 64-bit
+        # (on_trade, on_book, on_bar, on_start, on_stop, user_data).
+        # Zero-initialise — overrides happen on the C++ side via the
+        # BridgeStrategy that the runner attaches to this handle.
+        self._callbacks_buf = Ptr[byte](48)
+        for i in range(48):
+            self._callbacks_buf[i] = byte(0)
+        if registry == cobj():
+            # No registry attached; downstream `Runner.add_strategy`
+            # will rebuild the handle once a registry is present.
+            self._handle = cobj()
+        else:
+            sym_buf = [u32(s) for s in symbols]
+            self._handle = flox_strategy_create_p(
+                u32(strategy_id), Ptr[u32](sym_buf.arr.ptr),
+                u32(len(symbols)), registry, cobj(self._callbacks_buf))
 
     # ------------------------------------------------------------------
     # Overridable callbacks

--- a/include/flox/capi/flox_capi.h
+++ b/include/flox/capi/flox_capi.h
@@ -147,6 +147,9 @@ extern "C"
   FloxStrategyHandle flox_strategy_create(uint32_t id, const uint32_t* symbols,
                                           uint32_t num_symbols, FloxRegistryHandle registry,
                                           FloxStrategyCallbacks callbacks);
+  FloxStrategyHandle flox_strategy_create_p(uint32_t id, const uint32_t* symbols,
+                                            uint32_t num_symbols, FloxRegistryHandle registry,
+                                            const FloxStrategyCallbacks* callbacks);
   void flox_strategy_destroy(FloxStrategyHandle strategy);
 
   // Atomically replace the strategy's callback set without dropping
@@ -156,6 +159,8 @@ extern "C"
   // user_data after.
   void flox_strategy_replace_callbacks(FloxStrategyHandle strategy,
                                        FloxStrategyCallbacks callbacks);
+  void flox_strategy_replace_callbacks_p(FloxStrategyHandle strategy,
+                                         const FloxStrategyCallbacks* callbacks);
 
   // ============================================================
   // Signal emission (returns OrderId, 0 on failure)
@@ -1280,6 +1285,7 @@ extern "C"
   typedef void* FloxRiskManagerHandle;
 
   FloxRiskManagerHandle flox_risk_manager_create(FloxRiskManagerCallbacks callbacks);
+  FloxRiskManagerHandle flox_risk_manager_create_p(const FloxRiskManagerCallbacks* callbacks);
   void flox_risk_manager_destroy(FloxRiskManagerHandle rm);
 
   // ============================================================
@@ -1300,6 +1306,7 @@ extern "C"
   typedef void* FloxKillSwitchHandle;
 
   FloxKillSwitchHandle flox_kill_switch_create(FloxKillSwitchCallbacks callbacks);
+  FloxKillSwitchHandle flox_kill_switch_create_p(const FloxKillSwitchCallbacks* callbacks);
   void flox_kill_switch_destroy(FloxKillSwitchHandle ks);
 
   // ============================================================
@@ -1320,6 +1327,7 @@ extern "C"
   typedef void* FloxOrderValidatorHandle;
 
   FloxOrderValidatorHandle flox_order_validator_create(FloxOrderValidatorCallbacks callbacks);
+  FloxOrderValidatorHandle flox_order_validator_create_p(const FloxOrderValidatorCallbacks* callbacks);
   void flox_order_validator_destroy(FloxOrderValidatorHandle ov);
 
   // ============================================================
@@ -1359,6 +1367,7 @@ extern "C"
   typedef void* FloxPnLTrackerHandle;
 
   FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks callbacks);
+  FloxPnLTrackerHandle flox_pnl_tracker_create_p(const FloxPnLTrackerCallbacks* callbacks);
   void flox_pnl_tracker_destroy(FloxPnLTrackerHandle tracker);
 
   // ============================================================
@@ -1377,6 +1386,7 @@ extern "C"
   typedef void* FloxStorageSinkHandle;
 
   FloxStorageSinkHandle flox_storage_sink_create(FloxStorageSinkCallbacks callbacks);
+  FloxStorageSinkHandle flox_storage_sink_create_p(const FloxStorageSinkCallbacks* callbacks);
   void flox_storage_sink_destroy(FloxStorageSinkHandle sink);
 
   // ============================================================
@@ -1413,6 +1423,8 @@ extern "C"
 
   FloxMarketDataRecorderHandle flox_market_data_recorder_create(
       FloxMarketDataRecorderCallbacks callbacks);
+  FloxMarketDataRecorderHandle flox_market_data_recorder_create_p(
+      const FloxMarketDataRecorderCallbacks* callbacks);
   void flox_market_data_recorder_destroy(FloxMarketDataRecorderHandle recorder);
 
   // ============================================================
@@ -1464,6 +1476,7 @@ extern "C"
   typedef void* FloxReplaySourceHandle;
 
   FloxReplaySourceHandle flox_replay_source_create(FloxReplaySourceCallbacks callbacks);
+  FloxReplaySourceHandle flox_replay_source_create_p(const FloxReplaySourceCallbacks* callbacks);
   void flox_replay_source_destroy(FloxReplaySourceHandle source);
 
   // Convenience: forward a seek to the binding's seek_to callback.
@@ -1537,6 +1550,8 @@ extern "C"
 
   FloxExecutionListenerHandle
   flox_execution_listener_create(FloxExecutionListenerCallbacks callbacks);
+  FloxExecutionListenerHandle
+  flox_execution_listener_create_p(const FloxExecutionListenerCallbacks* callbacks);
   void flox_execution_listener_destroy(FloxExecutionListenerHandle listener);
 
   // ============================================================
@@ -1599,6 +1614,7 @@ extern "C"
   typedef void* FloxExecutorHandle;
 
   FloxExecutorHandle flox_executor_create(FloxExecutorCallbacks callbacks);
+  FloxExecutorHandle flox_executor_create_p(const FloxExecutorCallbacks* callbacks);
   void flox_executor_destroy(FloxExecutorHandle executor);
 
   // Query the executor's reported capabilities. Forwards to the binding's

--- a/include/flox/capi/flox_capi_spec.hpp
+++ b/include/flox/capi/flox_capi_spec.hpp
@@ -175,6 +175,20 @@ extern "C"
   void flox_strategy_replace_callbacks(FloxStrategyHandle strategy,
                                        FloxStrategyCallbacks callbacks);
 
+  // Pointer-variant constructors for FFIs that cannot pass a struct
+  // by value. The `_p` form takes a pointer to the same struct;
+  // calling `*p` to read is equivalent to passing the struct directly.
+  // These exist alongside the by-value variants so existing
+  // pybind11/NAPI/QuickJS callers keep working unchanged. (Used by
+  // Codon today.)
+  FLOX_EXPORT(group = "strategy_lifecycle")
+  FloxStrategyHandle flox_strategy_create_p(uint32_t id, const uint32_t* symbols,
+                                            uint32_t num_symbols, FloxRegistryHandle registry,
+                                            const FloxStrategyCallbacks* callbacks);
+  FLOX_EXPORT(group = "strategy_lifecycle")
+  void flox_strategy_replace_callbacks_p(FloxStrategyHandle strategy,
+                                         const FloxStrategyCallbacks* callbacks);
+
   // ============================================================
   // Signal emission (returns OrderId, 0 on failure)
   // ============================================================
@@ -1635,6 +1649,8 @@ extern "C"
   FLOX_EXPORT(group = "risk")
   FloxRiskManagerHandle flox_risk_manager_create(FloxRiskManagerCallbacks callbacks);
   FLOX_EXPORT(group = "risk")
+  FloxRiskManagerHandle flox_risk_manager_create_p(const FloxRiskManagerCallbacks* callbacks);
+  FLOX_EXPORT(group = "risk")
   void flox_risk_manager_destroy(FloxRiskManagerHandle rm);
 
   // ============================================================
@@ -1661,6 +1677,8 @@ extern "C"
   FLOX_EXPORT(group = "risk")
   FloxKillSwitchHandle flox_kill_switch_create(FloxKillSwitchCallbacks callbacks);
   FLOX_EXPORT(group = "risk")
+  FloxKillSwitchHandle flox_kill_switch_create_p(const FloxKillSwitchCallbacks* callbacks);
+  FLOX_EXPORT(group = "risk")
   void flox_kill_switch_destroy(FloxKillSwitchHandle ks);
 
   // ============================================================
@@ -1686,6 +1704,8 @@ extern "C"
 
   FLOX_EXPORT(group = "risk")
   FloxOrderValidatorHandle flox_order_validator_create(FloxOrderValidatorCallbacks callbacks);
+  FLOX_EXPORT(group = "risk")
+  FloxOrderValidatorHandle flox_order_validator_create_p(const FloxOrderValidatorCallbacks* callbacks);
   FLOX_EXPORT(group = "risk")
   void flox_order_validator_destroy(FloxOrderValidatorHandle ov);
 
@@ -1747,6 +1767,8 @@ extern "C"
   FLOX_EXPORT(group = "metrics")
   FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks callbacks);
   FLOX_EXPORT(group = "metrics")
+  FloxPnLTrackerHandle flox_pnl_tracker_create_p(const FloxPnLTrackerCallbacks* callbacks);
+  FLOX_EXPORT(group = "metrics")
   void flox_pnl_tracker_destroy(FloxPnLTrackerHandle tracker);
 
   // ============================================================
@@ -1773,6 +1795,8 @@ extern "C"
 
   FLOX_EXPORT(group = "storage")
   FloxStorageSinkHandle flox_storage_sink_create(FloxStorageSinkCallbacks callbacks);
+  FLOX_EXPORT(group = "storage")
+  FloxStorageSinkHandle flox_storage_sink_create_p(const FloxStorageSinkCallbacks* callbacks);
   FLOX_EXPORT(group = "storage")
   void flox_storage_sink_destroy(FloxStorageSinkHandle sink);
 
@@ -1818,6 +1842,9 @@ extern "C"
   FLOX_EXPORT(group = "recorder")
   FloxMarketDataRecorderHandle
   flox_market_data_recorder_create(FloxMarketDataRecorderCallbacks callbacks);
+  FLOX_EXPORT(group = "recorder")
+  FloxMarketDataRecorderHandle
+  flox_market_data_recorder_create_p(const FloxMarketDataRecorderCallbacks* callbacks);
   FLOX_EXPORT(group = "recorder")
   void flox_market_data_recorder_destroy(FloxMarketDataRecorderHandle recorder);
 
@@ -1882,6 +1909,8 @@ extern "C"
 
   FLOX_EXPORT(group = "replay")
   FloxReplaySourceHandle flox_replay_source_create(FloxReplaySourceCallbacks callbacks);
+  FLOX_EXPORT(group = "replay")
+  FloxReplaySourceHandle flox_replay_source_create_p(const FloxReplaySourceCallbacks* callbacks);
   FLOX_EXPORT(group = "replay")
   void flox_replay_source_destroy(FloxReplaySourceHandle source);
 
@@ -1964,6 +1993,9 @@ extern "C"
   FloxExecutionListenerHandle
   flox_execution_listener_create(FloxExecutionListenerCallbacks callbacks);
   FLOX_EXPORT(group = "execution")
+  FloxExecutionListenerHandle
+  flox_execution_listener_create_p(const FloxExecutionListenerCallbacks* callbacks);
+  FLOX_EXPORT(group = "execution")
   void flox_execution_listener_destroy(FloxExecutionListenerHandle listener);
 
   // Attaching listeners to BacktestRunner is declared with the rest of
@@ -2037,6 +2069,8 @@ extern "C"
 
   FLOX_EXPORT(group = "execution")
   FloxExecutorHandle flox_executor_create(FloxExecutorCallbacks callbacks);
+  FLOX_EXPORT(group = "execution")
+  FloxExecutorHandle flox_executor_create_p(const FloxExecutorCallbacks* callbacks);
   FLOX_EXPORT(group = "execution")
   void flox_executor_destroy(FloxExecutorHandle executor);
 

--- a/mcp/flox_mcp/data/binding_manifest.json
+++ b/mcp/flox_mcp/data/binding_manifest.json
@@ -630,12 +630,22 @@
         {
           "group": "execution",
           "kind": "function",
+          "name": "flox_execution_listener_create_p"
+        },
+        {
+          "group": "execution",
+          "kind": "function",
           "name": "flox_execution_listener_destroy"
         },
         {
           "group": "execution",
           "kind": "function",
           "name": "flox_executor_create"
+        },
+        {
+          "group": "execution",
+          "kind": "function",
+          "name": "flox_executor_create_p"
         },
         {
           "group": "execution",
@@ -1000,6 +1010,11 @@
         {
           "group": "risk",
           "kind": "function",
+          "name": "flox_kill_switch_create_p"
+        },
+        {
+          "group": "risk",
+          "kind": "function",
           "name": "flox_kill_switch_destroy"
         },
         {
@@ -1181,6 +1196,11 @@
           "group": "recorder",
           "kind": "function",
           "name": "flox_market_data_recorder_create"
+        },
+        {
+          "group": "recorder",
+          "kind": "function",
+          "name": "flox_market_data_recorder_create_p"
         },
         {
           "group": "recorder",
@@ -1380,6 +1400,11 @@
         {
           "group": "risk",
           "kind": "function",
+          "name": "flox_order_validator_create_p"
+        },
+        {
+          "group": "risk",
+          "kind": "function",
           "name": "flox_order_validator_destroy"
         },
         {
@@ -1426,6 +1451,11 @@
           "group": "metrics",
           "kind": "function",
           "name": "flox_pnl_tracker_create"
+        },
+        {
+          "group": "metrics",
+          "kind": "function",
+          "name": "flox_pnl_tracker_create_p"
         },
         {
           "group": "metrics",
@@ -1655,6 +1685,11 @@
         {
           "group": "replay",
           "kind": "function",
+          "name": "flox_replay_source_create_p"
+        },
+        {
+          "group": "replay",
+          "kind": "function",
           "name": "flox_replay_source_destroy"
         },
         {
@@ -1666,6 +1701,11 @@
           "group": "risk",
           "kind": "function",
           "name": "flox_risk_manager_create"
+        },
+        {
+          "group": "risk",
+          "kind": "function",
+          "name": "flox_risk_manager_create_p"
         },
         {
           "group": "risk",
@@ -2095,12 +2135,22 @@
         {
           "group": "storage",
           "kind": "function",
+          "name": "flox_storage_sink_create_p"
+        },
+        {
+          "group": "storage",
+          "kind": "function",
           "name": "flox_storage_sink_destroy"
         },
         {
           "group": "strategy_lifecycle",
           "kind": "function",
           "name": "flox_strategy_create"
+        },
+        {
+          "group": "strategy_lifecycle",
+          "kind": "function",
+          "name": "flox_strategy_create_p"
         },
         {
           "group": "strategy_lifecycle",
@@ -2126,6 +2176,11 @@
           "group": "strategy_lifecycle",
           "kind": "function",
           "name": "flox_strategy_replace_callbacks"
+        },
+        {
+          "group": "strategy_lifecycle",
+          "kind": "function",
+          "name": "flox_strategy_replace_callbacks_p"
         },
         {
           "group": "multi_tf_helpers",
@@ -3235,11 +3290,19 @@
         },
         {
           "kind": "function",
+          "name": "flox_execution_listener_create_p"
+        },
+        {
+          "kind": "function",
           "name": "flox_execution_listener_destroy"
         },
         {
           "kind": "function",
           "name": "flox_executor_create"
+        },
+        {
+          "kind": "function",
+          "name": "flox_executor_create_p"
         },
         {
           "kind": "function",
@@ -3531,6 +3594,10 @@
         },
         {
           "kind": "function",
+          "name": "flox_kill_switch_create_p"
+        },
+        {
+          "kind": "function",
           "name": "flox_kill_switch_destroy"
         },
         {
@@ -3676,6 +3743,10 @@
         {
           "kind": "function",
           "name": "flox_market_data_recorder_create"
+        },
+        {
+          "kind": "function",
+          "name": "flox_market_data_recorder_create_p"
         },
         {
           "kind": "function",
@@ -3835,6 +3906,10 @@
         },
         {
           "kind": "function",
+          "name": "flox_order_validator_create_p"
+        },
+        {
+          "kind": "function",
           "name": "flox_order_validator_destroy"
         },
         {
@@ -3872,6 +3947,10 @@
         {
           "kind": "function",
           "name": "flox_pnl_tracker_create"
+        },
+        {
+          "kind": "function",
+          "name": "flox_pnl_tracker_create_p"
         },
         {
           "kind": "function",
@@ -4055,6 +4134,10 @@
         },
         {
           "kind": "function",
+          "name": "flox_replay_source_create_p"
+        },
+        {
+          "kind": "function",
           "name": "flox_replay_source_destroy"
         },
         {
@@ -4064,6 +4147,10 @@
         {
           "kind": "function",
           "name": "flox_risk_manager_create"
+        },
+        {
+          "kind": "function",
+          "name": "flox_risk_manager_create_p"
         },
         {
           "kind": "function",
@@ -4407,11 +4494,19 @@
         },
         {
           "kind": "function",
+          "name": "flox_storage_sink_create_p"
+        },
+        {
+          "kind": "function",
           "name": "flox_storage_sink_destroy"
         },
         {
           "kind": "function",
           "name": "flox_strategy_create"
+        },
+        {
+          "kind": "function",
+          "name": "flox_strategy_create_p"
         },
         {
           "kind": "function",
@@ -4432,6 +4527,10 @@
         {
           "kind": "function",
           "name": "flox_strategy_replace_callbacks"
+        },
+        {
+          "kind": "function",
+          "name": "flox_strategy_replace_callbacks_p"
         },
         {
           "kind": "function",
@@ -6341,8 +6440,10 @@
         "flox_backtest_runner_add_execution_listener",
         "flox_backtest_runner_set_executor",
         "flox_execution_listener_create",
+        "flox_execution_listener_create_p",
         "flox_execution_listener_destroy",
         "flox_executor_create",
+        "flox_executor_create_p",
         "flox_executor_destroy",
         "flox_executor_get_capabilities",
         "flox_live_engine_set_executor",
@@ -6903,6 +7004,7 @@
       "capi_functions": [
         "flox_live_engine_set_pnl_tracker",
         "flox_pnl_tracker_create",
+        "flox_pnl_tracker_create_p",
         "flox_pnl_tracker_destroy",
         "flox_runner_set_pnl_tracker"
       ],
@@ -7208,6 +7310,7 @@
       "capi_functions": [
         "flox_live_engine_set_market_data_recorder",
         "flox_market_data_recorder_create",
+        "flox_market_data_recorder_create_p",
         "flox_market_data_recorder_destroy",
         "flox_runner_set_market_data_recorder"
       ],
@@ -7233,6 +7336,7 @@
     "replay": {
       "capi_functions": [
         "flox_replay_source_create",
+        "flox_replay_source_create_p",
         "flox_replay_source_destroy",
         "flox_replay_source_seek_to"
       ],
@@ -7258,13 +7362,16 @@
     "risk": {
       "capi_functions": [
         "flox_kill_switch_create",
+        "flox_kill_switch_create_p",
         "flox_kill_switch_destroy",
         "flox_live_engine_set_kill_switch",
         "flox_live_engine_set_order_validator",
         "flox_live_engine_set_risk_manager",
         "flox_order_validator_create",
+        "flox_order_validator_create_p",
         "flox_order_validator_destroy",
         "flox_risk_manager_create",
+        "flox_risk_manager_create_p",
         "flox_risk_manager_destroy",
         "flox_runner_set_kill_switch",
         "flox_runner_set_order_validator",
@@ -7425,6 +7532,7 @@
         "flox_live_engine_set_storage_sink",
         "flox_runner_set_storage_sink",
         "flox_storage_sink_create",
+        "flox_storage_sink_create_p",
         "flox_storage_sink_destroy"
       ],
       "codon": {
@@ -7449,8 +7557,10 @@
     "strategy_lifecycle": {
       "capi_functions": [
         "flox_strategy_create",
+        "flox_strategy_create_p",
         "flox_strategy_destroy",
-        "flox_strategy_replace_callbacks"
+        "flox_strategy_replace_callbacks",
+        "flox_strategy_replace_callbacks_p"
       ],
       "codon": {
         "present": true,

--- a/mcp/flox_mcp/data/ir.snapshot.json
+++ b/mcp/flox_mcp/data/ir.snapshot.json
@@ -3043,6 +3043,17 @@
     },
     {
       "group": "execution",
+      "name": "flox_execution_listener_create_p",
+      "params": [
+        {
+          "name": "callbacks",
+          "type": "const FloxExecutionListenerCallbacks *"
+        }
+      ],
+      "return_type": "FloxExecutionListenerHandle"
+    },
+    {
+      "group": "execution",
       "name": "flox_execution_listener_destroy",
       "params": [
         {
@@ -3059,6 +3070,17 @@
         {
           "name": "callbacks",
           "type": "FloxExecutorCallbacks"
+        }
+      ],
+      "return_type": "FloxExecutorHandle"
+    },
+    {
+      "group": "execution",
+      "name": "flox_executor_create_p",
+      "params": [
+        {
+          "name": "callbacks",
+          "type": "const FloxExecutorCallbacks *"
         }
       ],
       "return_type": "FloxExecutorHandle"
@@ -4567,6 +4589,17 @@
     },
     {
       "group": "risk",
+      "name": "flox_kill_switch_create_p",
+      "params": [
+        {
+          "name": "callbacks",
+          "type": "const FloxKillSwitchCallbacks *"
+        }
+      ],
+      "return_type": "FloxKillSwitchHandle"
+    },
+    {
+      "group": "risk",
       "name": "flox_kill_switch_destroy",
       "params": [
         {
@@ -5233,6 +5266,17 @@
     },
     {
       "group": "recorder",
+      "name": "flox_market_data_recorder_create_p",
+      "params": [
+        {
+          "name": "callbacks",
+          "type": "const FloxMarketDataRecorderCallbacks *"
+        }
+      ],
+      "return_type": "FloxMarketDataRecorderHandle"
+    },
+    {
+      "group": "recorder",
       "name": "flox_market_data_recorder_destroy",
       "params": [
         {
@@ -5805,6 +5849,17 @@
     },
     {
       "group": "risk",
+      "name": "flox_order_validator_create_p",
+      "params": [
+        {
+          "name": "callbacks",
+          "type": "const FloxOrderValidatorCallbacks *"
+        }
+      ],
+      "return_type": "FloxOrderValidatorHandle"
+    },
+    {
+      "group": "risk",
       "name": "flox_order_validator_destroy",
       "params": [
         {
@@ -5989,6 +6044,17 @@
         {
           "name": "callbacks",
           "type": "FloxPnLTrackerCallbacks"
+        }
+      ],
+      "return_type": "FloxPnLTrackerHandle"
+    },
+    {
+      "group": "metrics",
+      "name": "flox_pnl_tracker_create_p",
+      "params": [
+        {
+          "name": "callbacks",
+          "type": "const FloxPnLTrackerCallbacks *"
         }
       ],
       "return_type": "FloxPnLTrackerHandle"
@@ -6660,6 +6726,17 @@
     },
     {
       "group": "replay",
+      "name": "flox_replay_source_create_p",
+      "params": [
+        {
+          "name": "callbacks",
+          "type": "const FloxReplaySourceCallbacks *"
+        }
+      ],
+      "return_type": "FloxReplaySourceHandle"
+    },
+    {
+      "group": "replay",
       "name": "flox_replay_source_destroy",
       "params": [
         {
@@ -6691,6 +6768,17 @@
         {
           "name": "callbacks",
           "type": "FloxRiskManagerCallbacks"
+        }
+      ],
+      "return_type": "FloxRiskManagerHandle"
+    },
+    {
+      "group": "risk",
+      "name": "flox_risk_manager_create_p",
+      "params": [
+        {
+          "name": "callbacks",
+          "type": "const FloxRiskManagerCallbacks *"
         }
       ],
       "return_type": "FloxRiskManagerHandle"
@@ -8679,6 +8767,17 @@
     },
     {
       "group": "storage",
+      "name": "flox_storage_sink_create_p",
+      "params": [
+        {
+          "name": "callbacks",
+          "type": "const FloxStorageSinkCallbacks *"
+        }
+      ],
+      "return_type": "FloxStorageSinkHandle"
+    },
+    {
+      "group": "storage",
       "name": "flox_storage_sink_destroy",
       "params": [
         {
@@ -8711,6 +8810,33 @@
         {
           "name": "callbacks",
           "type": "FloxStrategyCallbacks"
+        }
+      ],
+      "return_type": "FloxStrategyHandle"
+    },
+    {
+      "group": "strategy_lifecycle",
+      "name": "flox_strategy_create_p",
+      "params": [
+        {
+          "name": "id",
+          "type": "uint32_t"
+        },
+        {
+          "name": "symbols",
+          "type": "const uint32_t *"
+        },
+        {
+          "name": "num_symbols",
+          "type": "uint32_t"
+        },
+        {
+          "name": "registry",
+          "type": "FloxRegistryHandle"
+        },
+        {
+          "name": "callbacks",
+          "type": "const FloxStrategyCallbacks *"
         }
       ],
       "return_type": "FloxStrategyHandle"
@@ -8806,6 +8932,21 @@
         {
           "name": "callbacks",
           "type": "FloxStrategyCallbacks"
+        }
+      ],
+      "return_type": "void"
+    },
+    {
+      "group": "strategy_lifecycle",
+      "name": "flox_strategy_replace_callbacks_p",
+      "params": [
+        {
+          "name": "strategy",
+          "type": "FloxStrategyHandle"
+        },
+        {
+          "name": "callbacks",
+          "type": "const FloxStrategyCallbacks *"
         }
       ],
       "return_type": "void"

--- a/src/capi/flox_capi.cpp
+++ b/src/capi/flox_capi.cpp
@@ -203,6 +203,14 @@ FloxStrategyHandle flox_strategy_create(uint32_t id, const uint32_t* symbols,
   return static_cast<FloxStrategyHandle>(strat);
 }
 
+FloxStrategyHandle flox_strategy_create_p(uint32_t id, const uint32_t* symbols,
+                                          uint32_t num_symbols, FloxRegistryHandle registry,
+                                          const FloxStrategyCallbacks* callbacks)
+{
+  FloxStrategyCallbacks cbs = callbacks ? *callbacks : FloxStrategyCallbacks{};
+  return flox_strategy_create(id, symbols, num_symbols, registry, cbs);
+}
+
 void flox_strategy_destroy(FloxStrategyHandle strategy)
 {
   delete toStrategy(strategy);
@@ -215,6 +223,13 @@ void flox_strategy_replace_callbacks(FloxStrategyHandle strategy, FloxStrategyCa
     return;
   }
   toStrategy(strategy)->replaceCallbacks(callbacks);
+}
+
+void flox_strategy_replace_callbacks_p(FloxStrategyHandle strategy,
+                                       const FloxStrategyCallbacks* callbacks)
+{
+  FloxStrategyCallbacks cbs = callbacks ? *callbacks : FloxStrategyCallbacks{};
+  flox_strategy_replace_callbacks(strategy, cbs);
 }
 
 // ============================================================
@@ -4806,6 +4821,12 @@ FloxRiskManagerHandle flox_risk_manager_create(FloxRiskManagerCallbacks callback
   return static_cast<FloxRiskManagerHandle>(rm);
 }
 
+FloxRiskManagerHandle flox_risk_manager_create_p(const FloxRiskManagerCallbacks* callbacks)
+{
+  FloxRiskManagerCallbacks cbs = callbacks ? *callbacks : FloxRiskManagerCallbacks{};
+  return flox_risk_manager_create(cbs);
+}
+
 void flox_risk_manager_destroy(FloxRiskManagerHandle rm)
 {
   delete static_cast<FloxRiskManagerImpl*>(rm);
@@ -4815,6 +4836,12 @@ FloxKillSwitchHandle flox_kill_switch_create(FloxKillSwitchCallbacks callbacks)
 {
   auto* ks = new FloxKillSwitchImpl{callbacks};
   return static_cast<FloxKillSwitchHandle>(ks);
+}
+
+FloxKillSwitchHandle flox_kill_switch_create_p(const FloxKillSwitchCallbacks* callbacks)
+{
+  FloxKillSwitchCallbacks cbs = callbacks ? *callbacks : FloxKillSwitchCallbacks{};
+  return flox_kill_switch_create(cbs);
 }
 
 void flox_kill_switch_destroy(FloxKillSwitchHandle ks)
@@ -4828,6 +4855,12 @@ FloxOrderValidatorHandle flox_order_validator_create(FloxOrderValidatorCallbacks
   return static_cast<FloxOrderValidatorHandle>(ov);
 }
 
+FloxOrderValidatorHandle flox_order_validator_create_p(const FloxOrderValidatorCallbacks* callbacks)
+{
+  FloxOrderValidatorCallbacks cbs = callbacks ? *callbacks : FloxOrderValidatorCallbacks{};
+  return flox_order_validator_create(cbs);
+}
+
 void flox_order_validator_destroy(FloxOrderValidatorHandle ov)
 {
   delete static_cast<FloxOrderValidatorImpl*>(ov);
@@ -4838,6 +4871,12 @@ FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks callbacks)
   return static_cast<FloxPnLTrackerHandle>(new FloxPnLTrackerImpl{callbacks});
 }
 
+FloxPnLTrackerHandle flox_pnl_tracker_create_p(const FloxPnLTrackerCallbacks* callbacks)
+{
+  FloxPnLTrackerCallbacks cbs = callbacks ? *callbacks : FloxPnLTrackerCallbacks{};
+  return flox_pnl_tracker_create(cbs);
+}
+
 void flox_pnl_tracker_destroy(FloxPnLTrackerHandle tracker)
 {
   delete static_cast<FloxPnLTrackerImpl*>(tracker);
@@ -4846,6 +4885,12 @@ void flox_pnl_tracker_destroy(FloxPnLTrackerHandle tracker)
 FloxStorageSinkHandle flox_storage_sink_create(FloxStorageSinkCallbacks callbacks)
 {
   return static_cast<FloxStorageSinkHandle>(new FloxStorageSinkImpl{callbacks});
+}
+
+FloxStorageSinkHandle flox_storage_sink_create_p(const FloxStorageSinkCallbacks* callbacks)
+{
+  FloxStorageSinkCallbacks cbs = callbacks ? *callbacks : FloxStorageSinkCallbacks{};
+  return flox_storage_sink_create(cbs);
 }
 
 void flox_storage_sink_destroy(FloxStorageSinkHandle sink)
@@ -4860,6 +4905,13 @@ FloxMarketDataRecorderHandle flox_market_data_recorder_create(
       new FloxMarketDataRecorderImpl{callbacks});
 }
 
+FloxMarketDataRecorderHandle flox_market_data_recorder_create_p(
+    const FloxMarketDataRecorderCallbacks* callbacks)
+{
+  FloxMarketDataRecorderCallbacks cbs = callbacks ? *callbacks : FloxMarketDataRecorderCallbacks{};
+  return flox_market_data_recorder_create(cbs);
+}
+
 void flox_market_data_recorder_destroy(FloxMarketDataRecorderHandle recorder)
 {
   delete static_cast<FloxMarketDataRecorderImpl*>(recorder);
@@ -4869,6 +4921,12 @@ FloxReplaySourceHandle flox_replay_source_create(FloxReplaySourceCallbacks callb
 {
   return static_cast<FloxReplaySourceHandle>(
       new FloxReplaySourceImpl{callbacks});
+}
+
+FloxReplaySourceHandle flox_replay_source_create_p(const FloxReplaySourceCallbacks* callbacks)
+{
+  FloxReplaySourceCallbacks cbs = callbacks ? *callbacks : FloxReplaySourceCallbacks{};
+  return flox_replay_source_create(cbs);
 }
 
 void flox_replay_source_destroy(FloxReplaySourceHandle source)
@@ -4893,6 +4951,13 @@ flox_execution_listener_create(FloxExecutionListenerCallbacks callbacks)
       new FloxExecutionListenerImpl{callbacks});
 }
 
+FloxExecutionListenerHandle
+flox_execution_listener_create_p(const FloxExecutionListenerCallbacks* callbacks)
+{
+  FloxExecutionListenerCallbacks cbs = callbacks ? *callbacks : FloxExecutionListenerCallbacks{};
+  return flox_execution_listener_create(cbs);
+}
+
 void flox_execution_listener_destroy(FloxExecutionListenerHandle listener)
 {
   delete static_cast<FloxExecutionListenerImpl*>(listener);
@@ -4901,6 +4966,12 @@ void flox_execution_listener_destroy(FloxExecutionListenerHandle listener)
 FloxExecutorHandle flox_executor_create(FloxExecutorCallbacks callbacks)
 {
   return static_cast<FloxExecutorHandle>(new FloxExecutorImpl{callbacks});
+}
+
+FloxExecutorHandle flox_executor_create_p(const FloxExecutorCallbacks* callbacks)
+{
+  FloxExecutorCallbacks cbs = callbacks ? *callbacks : FloxExecutorCallbacks{};
+  return flox_executor_create(cbs);
 }
 
 void flox_executor_destroy(FloxExecutorHandle executor)

--- a/tools/codegen/golden/flox_capi.codon
+++ b/tools/codegen/golden/flox_capi.codon
@@ -118,8 +118,10 @@ from C import flox_delta_book_replayer_copy_asks(cobj, cobj, u64) -> u64
 
 # ── execution ──
 from C import flox_execution_listener_create(cobj) -> cobj
+from C import flox_execution_listener_create_p(cobj) -> cobj
 from C import flox_execution_listener_destroy(cobj)
 from C import flox_executor_create(cobj) -> cobj
+from C import flox_executor_create_p(cobj) -> cobj
 from C import flox_executor_destroy(cobj)
 from C import flox_executor_get_capabilities(cobj, cobj)
 from C import flox_live_engine_set_executor(cobj, cobj)
@@ -329,6 +331,7 @@ from C import flox_market_profile_clear(cobj)
 
 # ── metrics ──
 from C import flox_pnl_tracker_create(cobj) -> cobj
+from C import flox_pnl_tracker_create_p(cobj) -> cobj
 from C import flox_pnl_tracker_destroy(cobj)
 from C import flox_live_engine_set_pnl_tracker(cobj, cobj)
 from C import flox_runner_set_pnl_tracker(cobj, cobj)
@@ -443,21 +446,26 @@ from C import flox_position_group_prune(cobj)
 
 # ── recorder ──
 from C import flox_market_data_recorder_create(cobj) -> cobj
+from C import flox_market_data_recorder_create_p(cobj) -> cobj
 from C import flox_market_data_recorder_destroy(cobj)
 from C import flox_live_engine_set_market_data_recorder(cobj, cobj)
 from C import flox_runner_set_market_data_recorder(cobj, cobj)
 
 # ── replay ──
 from C import flox_replay_source_create(cobj) -> cobj
+from C import flox_replay_source_create_p(cobj) -> cobj
 from C import flox_replay_source_destroy(cobj)
 from C import flox_replay_source_seek_to(cobj, i64) -> u8
 
 # ── risk ──
 from C import flox_risk_manager_create(cobj) -> cobj
+from C import flox_risk_manager_create_p(cobj) -> cobj
 from C import flox_risk_manager_destroy(cobj)
 from C import flox_kill_switch_create(cobj) -> cobj
+from C import flox_kill_switch_create_p(cobj) -> cobj
 from C import flox_kill_switch_destroy(cobj)
 from C import flox_order_validator_create(cobj) -> cobj
+from C import flox_order_validator_create_p(cobj) -> cobj
 from C import flox_order_validator_destroy(cobj)
 from C import flox_live_engine_set_risk_manager(cobj, cobj)
 from C import flox_live_engine_set_kill_switch(cobj, cobj)
@@ -513,6 +521,7 @@ from C import flox_stat_win_rate(Ptr[float], int) -> float
 
 # ── storage ──
 from C import flox_storage_sink_create(cobj) -> cobj
+from C import flox_storage_sink_create_p(cobj) -> cobj
 from C import flox_storage_sink_destroy(cobj)
 from C import flox_live_engine_set_storage_sink(cobj, cobj)
 from C import flox_runner_set_storage_sink(cobj, cobj)
@@ -521,6 +530,8 @@ from C import flox_runner_set_storage_sink(cobj, cobj)
 from C import flox_strategy_create(u32, Ptr[u32], u32, cobj, cobj) -> cobj
 from C import flox_strategy_destroy(cobj)
 from C import flox_strategy_replace_callbacks(cobj, cobj)
+from C import flox_strategy_create_p(u32, Ptr[u32], u32, cobj, cobj) -> cobj
+from C import flox_strategy_replace_callbacks_p(cobj, cobj)
 
 # ── strategyrunner_synchronous ──
 from C import flox_runner_create(cobj, cobj, cobj) -> cobj

--- a/tools/codegen/golden/flox_capi.h
+++ b/tools/codegen/golden/flox_capi.h
@@ -907,8 +907,10 @@ extern "C"
   // ============================================================
 
   FloxExecutionListenerHandle flox_execution_listener_create(FloxExecutionListenerCallbacks callbacks);
+  FloxExecutionListenerHandle flox_execution_listener_create_p(const FloxExecutionListenerCallbacks* callbacks);
   void flox_execution_listener_destroy(FloxExecutionListenerHandle listener);
   FloxExecutorHandle flox_executor_create(FloxExecutorCallbacks callbacks);
+  FloxExecutorHandle flox_executor_create_p(const FloxExecutorCallbacks* callbacks);
   void flox_executor_destroy(FloxExecutorHandle executor);
   void flox_executor_get_capabilities(FloxExecutorHandle executor,
                                       FloxExchangeCapabilities* caps_out);
@@ -1276,6 +1278,7 @@ extern "C"
   // ============================================================
 
   FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks callbacks);
+  FloxPnLTrackerHandle flox_pnl_tracker_create_p(const FloxPnLTrackerCallbacks* callbacks);
   void flox_pnl_tracker_destroy(FloxPnLTrackerHandle tracker);
   void flox_live_engine_set_pnl_tracker(FloxLiveEngineHandle engine, FloxPnLTrackerHandle tracker);
   void flox_runner_set_pnl_tracker(FloxRunnerHandle runner, FloxPnLTrackerHandle tracker);
@@ -1457,6 +1460,7 @@ extern "C"
   // ============================================================
 
   FloxMarketDataRecorderHandle flox_market_data_recorder_create(FloxMarketDataRecorderCallbacks callbacks);
+  FloxMarketDataRecorderHandle flox_market_data_recorder_create_p(const FloxMarketDataRecorderCallbacks* callbacks);
   void flox_market_data_recorder_destroy(FloxMarketDataRecorderHandle recorder);
   void flox_live_engine_set_market_data_recorder(FloxLiveEngineHandle engine,
                                                  FloxMarketDataRecorderHandle recorder);
@@ -1468,6 +1472,7 @@ extern "C"
   // ============================================================
 
   FloxReplaySourceHandle flox_replay_source_create(FloxReplaySourceCallbacks callbacks);
+  FloxReplaySourceHandle flox_replay_source_create_p(const FloxReplaySourceCallbacks* callbacks);
   void flox_replay_source_destroy(FloxReplaySourceHandle source);
   uint8_t flox_replay_source_seek_to(FloxReplaySourceHandle source, int64_t timestamp_ns);
 
@@ -1476,10 +1481,13 @@ extern "C"
   // ============================================================
 
   FloxRiskManagerHandle flox_risk_manager_create(FloxRiskManagerCallbacks callbacks);
+  FloxRiskManagerHandle flox_risk_manager_create_p(const FloxRiskManagerCallbacks* callbacks);
   void flox_risk_manager_destroy(FloxRiskManagerHandle rm);
   FloxKillSwitchHandle flox_kill_switch_create(FloxKillSwitchCallbacks callbacks);
+  FloxKillSwitchHandle flox_kill_switch_create_p(const FloxKillSwitchCallbacks* callbacks);
   void flox_kill_switch_destroy(FloxKillSwitchHandle ks);
   FloxOrderValidatorHandle flox_order_validator_create(FloxOrderValidatorCallbacks callbacks);
+  FloxOrderValidatorHandle flox_order_validator_create_p(const FloxOrderValidatorCallbacks* callbacks);
   void flox_order_validator_destroy(FloxOrderValidatorHandle ov);
   void flox_live_engine_set_risk_manager(FloxLiveEngineHandle engine, FloxRiskManagerHandle rm);
   void flox_live_engine_set_kill_switch(FloxLiveEngineHandle engine, FloxKillSwitchHandle ks);
@@ -1574,6 +1582,7 @@ extern "C"
   // ============================================================
 
   FloxStorageSinkHandle flox_storage_sink_create(FloxStorageSinkCallbacks callbacks);
+  FloxStorageSinkHandle flox_storage_sink_create_p(const FloxStorageSinkCallbacks* callbacks);
   void flox_storage_sink_destroy(FloxStorageSinkHandle sink);
   void flox_live_engine_set_storage_sink(FloxLiveEngineHandle engine, FloxStorageSinkHandle sink);
   void flox_runner_set_storage_sink(FloxRunnerHandle runner, FloxStorageSinkHandle sink);
@@ -1587,6 +1596,11 @@ extern "C"
                                           FloxStrategyCallbacks callbacks);
   void flox_strategy_destroy(FloxStrategyHandle strategy);
   void flox_strategy_replace_callbacks(FloxStrategyHandle strategy, FloxStrategyCallbacks callbacks);
+  FloxStrategyHandle flox_strategy_create_p(uint32_t id, const uint32_t* symbols,
+                                            uint32_t num_symbols, FloxRegistryHandle registry,
+                                            const FloxStrategyCallbacks* callbacks);
+  void flox_strategy_replace_callbacks_p(FloxStrategyHandle strategy,
+                                         const FloxStrategyCallbacks* callbacks);
 
   // ============================================================
   // Strategyrunner Synchronous

--- a/tools/codegen/golden/flox_capi.md
+++ b/tools/codegen/golden/flox_capi.md
@@ -2,7 +2,7 @@
 
 Generated from `include/flox/capi/flox_capi_spec.hpp`. Source of truth for FFI consumers (Codon, QuickJS, Rust, Go cgo, Python ctypes). The pybind11 (Python) and NAPI (Node) bindings wrap this surface but expose richer language-native APIs that live in `python/` and `node/` respectively — see those for the Python/TS-flavored interfaces.
 
-**Surface:** 460 functions, 42 handles, 48 structs, 33 callback typedefs, 2 enums, 57 groups.
+**Surface:** 471 functions, 42 handles, 48 structs, 33 callback typedefs, 2 enums, 57 groups.
 
 ## Opaque handles
 
@@ -806,8 +806,10 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 ### execution
 
 - `FloxExecutionListenerHandle flox_execution_listener_create(FloxExecutionListenerCallbacks callbacks)`
+- `FloxExecutionListenerHandle flox_execution_listener_create_p(const FloxExecutionListenerCallbacks * callbacks)`
 - `void flox_execution_listener_destroy(FloxExecutionListenerHandle listener)`
 - `FloxExecutorHandle flox_executor_create(FloxExecutorCallbacks callbacks)`
+- `FloxExecutorHandle flox_executor_create_p(const FloxExecutorCallbacks * callbacks)`
 - `void flox_executor_destroy(FloxExecutorHandle executor)`
 - `void flox_executor_get_capabilities(FloxExecutorHandle executor, FloxExchangeCapabilities * caps_out)`
 - `void flox_live_engine_set_executor(FloxLiveEngineHandle engine, FloxExecutorHandle executor)`
@@ -1034,6 +1036,7 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 ### metrics
 
 - `FloxPnLTrackerHandle flox_pnl_tracker_create(FloxPnLTrackerCallbacks callbacks)`
+- `FloxPnLTrackerHandle flox_pnl_tracker_create_p(const FloxPnLTrackerCallbacks * callbacks)`
 - `void flox_pnl_tracker_destroy(FloxPnLTrackerHandle tracker)`
 - `void flox_live_engine_set_pnl_tracker(FloxLiveEngineHandle engine, FloxPnLTrackerHandle tracker)`
 - `void flox_runner_set_pnl_tracker(FloxRunnerHandle runner, FloxPnLTrackerHandle tracker)`
@@ -1158,6 +1161,7 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 ### recorder
 
 - `FloxMarketDataRecorderHandle flox_market_data_recorder_create(FloxMarketDataRecorderCallbacks callbacks)`
+- `FloxMarketDataRecorderHandle flox_market_data_recorder_create_p(const FloxMarketDataRecorderCallbacks * callbacks)`
 - `void flox_market_data_recorder_destroy(FloxMarketDataRecorderHandle recorder)`
 - `void flox_live_engine_set_market_data_recorder(FloxLiveEngineHandle engine, FloxMarketDataRecorderHandle recorder)`
 - `void flox_runner_set_market_data_recorder(FloxRunnerHandle runner, FloxMarketDataRecorderHandle recorder)`
@@ -1165,16 +1169,20 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 ### replay
 
 - `FloxReplaySourceHandle flox_replay_source_create(FloxReplaySourceCallbacks callbacks)`
+- `FloxReplaySourceHandle flox_replay_source_create_p(const FloxReplaySourceCallbacks * callbacks)`
 - `void flox_replay_source_destroy(FloxReplaySourceHandle source)`
 - `uint8_t flox_replay_source_seek_to(FloxReplaySourceHandle source, int64_t timestamp_ns)`
 
 ### risk
 
 - `FloxRiskManagerHandle flox_risk_manager_create(FloxRiskManagerCallbacks callbacks)`
+- `FloxRiskManagerHandle flox_risk_manager_create_p(const FloxRiskManagerCallbacks * callbacks)`
 - `void flox_risk_manager_destroy(FloxRiskManagerHandle rm)`
 - `FloxKillSwitchHandle flox_kill_switch_create(FloxKillSwitchCallbacks callbacks)`
+- `FloxKillSwitchHandle flox_kill_switch_create_p(const FloxKillSwitchCallbacks * callbacks)`
 - `void flox_kill_switch_destroy(FloxKillSwitchHandle ks)`
 - `FloxOrderValidatorHandle flox_order_validator_create(FloxOrderValidatorCallbacks callbacks)`
+- `FloxOrderValidatorHandle flox_order_validator_create_p(const FloxOrderValidatorCallbacks * callbacks)`
 - `void flox_order_validator_destroy(FloxOrderValidatorHandle ov)`
 - `void flox_live_engine_set_risk_manager(FloxLiveEngineHandle engine, FloxRiskManagerHandle rm)`
 - `void flox_live_engine_set_kill_switch(FloxLiveEngineHandle engine, FloxKillSwitchHandle ks)`
@@ -1235,6 +1243,7 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 ### storage
 
 - `FloxStorageSinkHandle flox_storage_sink_create(FloxStorageSinkCallbacks callbacks)`
+- `FloxStorageSinkHandle flox_storage_sink_create_p(const FloxStorageSinkCallbacks * callbacks)`
 - `void flox_storage_sink_destroy(FloxStorageSinkHandle sink)`
 - `void flox_live_engine_set_storage_sink(FloxLiveEngineHandle engine, FloxStorageSinkHandle sink)`
 - `void flox_runner_set_storage_sink(FloxRunnerHandle runner, FloxStorageSinkHandle sink)`
@@ -1244,6 +1253,8 @@ All handles are typedef'd `void*`. Treat them as opaque; manage lifetime via the
 - `FloxStrategyHandle flox_strategy_create(uint32_t id, const uint32_t * symbols, uint32_t num_symbols, FloxRegistryHandle registry, FloxStrategyCallbacks callbacks)`
 - `void flox_strategy_destroy(FloxStrategyHandle strategy)`
 - `void flox_strategy_replace_callbacks(FloxStrategyHandle strategy, FloxStrategyCallbacks callbacks)`
+- `FloxStrategyHandle flox_strategy_create_p(uint32_t id, const uint32_t * symbols, uint32_t num_symbols, FloxRegistryHandle registry, const FloxStrategyCallbacks * callbacks)`
+- `void flox_strategy_replace_callbacks_p(FloxStrategyHandle strategy, const FloxStrategyCallbacks * callbacks)`
 
 ### strategyrunner_synchronous
 


### PR DESCRIPTION
## Summary

Eleven C ABI exports take a callbacks struct **by value**. The Codon FFI does not currently model struct-by-value parameters — it imports them as a single `cobj` pointer, which is the wrong calling convention. As a result, pure-Codon strategy / executor / risk-gate construction was broken end-to-end; an earlier follow-up explicitly stopped at FloxBar bytes because it couldn't construct a Strategy.

This PR adds `_p`-suffix pointer variants for every affected export. Each `_p` variant accepts `const FooCallbacks*` and forwards to the by-value sibling. Existing pybind11 / NAPI / QuickJS callers keep working unchanged.

## Surface added (11 new exports)

`flox_strategy_create_p`, `flox_strategy_replace_callbacks_p`, `flox_risk_manager_create_p`, `flox_kill_switch_create_p`, `flox_order_validator_create_p`, `flox_pnl_tracker_create_p`, `flox_storage_sink_create_p`, `flox_market_data_recorder_create_p`, `flox_replay_source_create_p`, `flox_execution_listener_create_p`, `flox_executor_create_p`.

## Codon side

`codon/flox/strategy.codon` now constructs a real strategy handle through `flox_strategy_create_p` with a zero-initialised callbacks buffer. A new `codon/examples/strategy_e2e_smoke.codon` proof-of-life builds a Strategy + Runner end-to-end, drives an M5 bar, and reads it back via `Strategy.last_closed_bar` — the path that was blocked before this fix.

## MCP impact

Pure bundled-data refresh — `sync_mcp_data.py` regenerates the IR snapshot + binding manifest. No new MCP tools, no payload-shape changes; bundled-data readers (`lookup_symbol`, `capi`) surface the new symbols automatically.

## Test plan

- [x] `nm libflox_capi.dylib | grep flox_strategy_create_p` — symbol exported with C linkage
- [x] `codon_strategy_e2e_smoke` — strategy handle constructed; bar round-trips through the C++ ring
- [x] sync chain green locally