### PR TITLE
build(flox-py): glob all .py modules into the wheel + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,14 @@ jobs:
     - name: Verify .pyi stubs are in sync with the binding
       run: python3 scripts/gen_pyi_stubs.py --check
 
+    # Build the wheel from python/pyproject.toml, install it into a
+    # throwaway venv, and assert every documented pure-Python module is
+    # importable. Catches the regression where scikit-build-core only
+    # collects the install component contents and silently drops new
+    # `.py` files added under `python/flox_py/`.
+    - name: Verify wheel ships every pure-Python module
+      run: bash scripts/check_flox_py_wheel.sh
+
     - name: Type-check Python examples with mypy
       run: PYTHONPATH=build/python python3 -m mypy --ignore-missing-imports
         docs/examples/python_backtest_vs_live.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -32,22 +32,17 @@ set_target_properties(_flox_py PROPERTIES
 # type checkers resolve `flox_py._flox_py.X`. Stubs are copied only if
 # present so the very first build — which produces the .so that stubgen
 # needs as input — is not blocked on them existing.
+#
+# The .py file list is globbed from `flox_py/*.py` so a new module
+# automatically lands in the wheel without touching this file. CMake
+# re-runs the configure step when this CMakeLists.txt changes; if you
+# add a new .py module, run `cmake -B build -S .` once to pick it up.
+file(GLOB FLOX_PY_PURE_PYTHON_MODULES
+     CONFIGURE_DEPENDS
+     "${CMAKE_CURRENT_SOURCE_DIR}/flox_py/*.py")
 set(FLOX_PY_REQUIRED_FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/__init__.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/cli.py
+  ${FLOX_PY_PURE_PYTHON_MODULES}
   ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/py.typed
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/ccxt.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/report.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/tape.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/paper.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/bundle.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/control_server.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/event_log.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/lookahead.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/portfolio_risk.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/latency_models.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/execution_algos.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/rl_env.py
 )
 set(FLOX_PY_OPTIONAL_ROOT_STUBS
   ${CMAKE_CURRENT_SOURCE_DIR}/flox_py/__init__.pyi

--- a/scripts/check_flox_py_wheel.sh
+++ b/scripts/check_flox_py_wheel.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Build the flox_py wheel + install into a throwaway venv + assert
+# every pure-Python module under `python/flox_py/` is importable.
+#
+# Catches the regression where scikit-build-core only collects what
+# the CMake `python_module` install component declares — adding a new
+# `.py` file to `python/flox_py/` without updating CMakeLists used to
+# silently drop it from the wheel.
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root/python"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+py="${PYTHON:-python3}"
+echo "[wheel-gate] preparing build venv with $($py --version)..."
+"$py" -m venv "$work/build-venv"
+build_py="$work/build-venv/bin/python"
+"$build_py" -m pip install --quiet --upgrade build pybind11 scikit-build-core
+"$build_py" -m build --wheel --outdir "$work"
+
+whl=$(ls "$work"/flox_py-*.whl | head -1)
+if [[ -z "$whl" ]]; then
+  echo "::error::wheel build produced no .whl in $work" >&2
+  exit 1
+fi
+echo "[wheel-gate] built $(basename "$whl")"
+
+# Discover modules from source. The wheel must include every one.
+mapfile -t expected < <(find "$repo_root/python/flox_py" -maxdepth 1 -name '*.py' -not -name '__init__.py' -exec basename {} .py \; | sort)
+echo "[wheel-gate] expecting modules: ${expected[*]}"
+
+"$py" -m venv "$work/venv"
+"$work/venv/bin/pip" install --quiet "$whl"
+
+# Run the import smoke from /tmp so the source `python/flox_py/`
+# directory cannot shadow the installed wheel via cwd resolution.
+cd /tmp
+import_lines=""
+for mod in "${expected[@]}"; do
+  import_lines="${import_lines}import flox_py.${mod}"$'\n'
+done
+
+if ! "$work/venv/bin/python" -c "$import_lines
+print('[wheel-gate] all ${#expected[@]} modules imported OK')"; then
+  echo "::error::wheel-gate failed — flox_py wheel does not ship every pure-Python module" >&2
+  echo "Inspect with: unzip -l $whl | grep '\.py$'" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Critical packaging bug surfaced by the launch-readiness eval (Phase 1.3): the flox-py wheel shipped only \`__init__.py\` + the compiled extension. Fifteen sibling pure-Python modules (lookahead, control_server, paper, ccxt, event_log, execution_algos, latency_models, mlflow, bundle, composite, cli, portfolio_risk, report, rl_env, tape) were dropped because the CMake \`python_module\` install component had a hand-curated list that hadn't been kept in sync with the source directory.

First-time \`pip install flox-py\` users got a half-functional package — the MCP control plane, paper-trading harness, ccxt connector, and several other tools all rely on modules that were missing.

## Fix

- \`python/CMakeLists.txt\`: replace the hand-curated \`FLOX_PY_REQUIRED_FILES\` list with \`file(GLOB CONFIGURE_DEPENDS flox_py/*.py)\` so any new module lands in the wheel automatically.
- \`scripts/check_flox_py_wheel.sh\`: build wheel into a throwaway venv, install it, assert every discovered module is importable.
- \`.github/workflows/ci.yml\`: gate added under verify-docs-current so a future regression fails CI immediately.

## Test plan

- [x] Built wheel locally: \`unzip -l flox_py-0.5.6-cp312-cp312-macosx_15_0_arm64.whl | grep '\.py$'\` shows all 15 modules + \`__init__.py\`.
- [x] \`scripts/check_flox_py_wheel.sh\` — fresh venv, all 15 modules import OK from /tmp (no source-dir shadowing).