### PR TITLE
order_group(quickjs): wrap C ABI instead of pure-JS reimpl

### DIFF
--- a/quickjs/flox/order_group.js
+++ b/quickjs/flox/order_group.js
@@ -1,8 +1,7 @@
 // Multi-leg order group state machine for QuickJS strategies.
-// Mirrors the NAPI / pybind11 / Codon surfaces — passive state machine
-// that records submit / fill / cancel events and reports the group
-// state + recommended actions. The strategy is responsible for wiring
-// actions into the executor.
+// Thin wrapper over the C ABI flox_order_group_* exports — same as
+// the pybind11 / NAPI / Codon bindings. The state machine lives in
+// the C++ engine; this class is a shim, not a reimplementation.
 //
 // Policy + state are exposed as string-named constants (BestEffort /
 // AllOrNothing / OneSided; Pending / Submitted / Filled / ...).
@@ -57,7 +56,11 @@ class OrderGroup {
         opts = opts || {};
         this._parent = opts.parentSignalId || 0;
         this._policy = _resolvePolicy(opts.policy);
-        this._legs = [];
+        this._h = __flox_order_group_create(this._parent, this._policy);
+    }
+
+    destroy() {
+        if (this._h) { __flox_order_group_destroy(this._h); this._h = null; }
     }
 
     parentSignalId() { return this._parent; }
@@ -70,110 +73,62 @@ class OrderGroup {
     }
 
     addMarketLeg(symbol, side, qty) {
-        var idx = this._legs.length;
-        this._legs.push({
-            symbol: symbol, side: side, targetQty: qty,
-            orderType: 1, limitPrice: 0,
-            orderId: 0, filledQty: 0, state: 0,
-        });
-        return idx;
+        return __flox_order_group_add_market_leg(this._h, symbol, side, qty);
     }
 
     addLimitLeg(symbol, side, price, qty) {
-        var idx = this._legs.length;
-        this._legs.push({
-            symbol: symbol, side: side, targetQty: qty,
-            orderType: 0, limitPrice: price,
-            orderId: 0, filledQty: 0, state: 0,
-        });
-        return idx;
+        return __flox_order_group_add_limit_leg(this._h, symbol, side, price, qty);
     }
 
-    legCount() { return this._legs.length; }
-    legState(i) { return _LEG_STATE_NAMES[this._legs[i].state]; }
-    legFilled(i) { return this._legs[i].filledQty; }
-    legOrderId(i) { return this._legs[i].orderId; }
+    legCount() { return __flox_order_group_leg_count(this._h); }
+    legState(i) { return _LEG_STATE_NAMES[__flox_order_group_leg_state(this._h, i)]; }
+    legFilled(i) { return __flox_order_group_leg_filled(this._h, i); }
+    legOrderId(i) { return __flox_order_group_leg_order_id(this._h, i); }
 
     recordSubmit(i, orderId) {
-        this._legs[i].orderId = orderId;
-        this._legs[i].state = 1;
+        __flox_order_group_record_submit(this._h, i, orderId);
     }
 
     recordFill(i, cumulativeQty) {
-        var leg = this._legs[i];
-        leg.filledQty = cumulativeQty;
-        leg.state = (cumulativeQty >= leg.targetQty) ? 3 : 2;
+        __flox_order_group_record_fill(this._h, i, cumulativeQty);
     }
 
-    recordCancel(i) { this._legs[i].state = 4; }
-    recordFailure(i) { this._legs[i].state = 5; }
+    recordCancel(i) { __flox_order_group_record_cancel(this._h, i); }
+    recordFailure(i) { __flox_order_group_record_failure(this._h, i); }
 
     markActionDispatched(legIndex, kind) {
-        var bit = (kind === 'cancel') ? 0x1 : 0x2;
-        this._legs[legIndex].dispatched = (this._legs[legIndex].dispatched || 0) | bit;
+        var k = (kind === 'cancel') ? 0 : 1;
+        __flox_order_group_mark_action_dispatched(this._h, legIndex, k);
     }
 
     setPairLatencyBudgetNs(budgetNs) {
-        this._pairBudgetNs = budgetNs;
+        __flox_order_group_set_pair_latency_budget_ns(this._h, budgetNs);
     }
 
     pairLatencyDecision(opts) {
         opts = opts || {};
-        var budget = this._pairBudgetNs || 0;
-        if (budget <= 0) return 'wait';
-        var submit = opts.leaderSubmitTsNs || 0;
-        var ack = opts.leaderAckTsNs || 0;
-        var ackReceived = opts.ackReceived === true;
-        if (ackReceived) {
-            return (ack - submit <= budget) ? 'submit_follower' : 'cancel_leader';
-        }
-        // No ack yet — caller passed current feed-time as ackTs.
-        if (ack - submit > budget) return 'cancel_leader';
-        return 'wait';
+        return __flox_order_group_pair_latency_decision(
+            this._h,
+            opts.leaderSubmitTsNs || 0,
+            opts.leaderAckTsNs || 0,
+            opts.ackReceived === true ? 1 : 0);
     }
 
     setRiskLimits(opts) {
         opts = opts || {};
-        this._limits = {
-            maxGrossNotional: opts.maxGrossNotional || 0,
-            maxConcentrationPct: opts.maxConcentrationPct || 0,
-            maxLegQty: opts.maxLegQty || 0,
-        };
+        __flox_order_group_set_risk_limits(
+            this._h,
+            opts.maxGrossNotional || 0,
+            opts.maxConcentrationPct || 0,
+            opts.maxLegQty || 0);
     }
 
     precheckSubmission(opts) {
         opts = opts || {};
-        var limits = this._limits || { maxGrossNotional: 0, maxConcentrationPct: 0, maxLegQty: 0 };
-        if (limits.maxGrossNotional === 0 && limits.maxConcentrationPct === 0
-            && limits.maxLegQty === 0) {
-            return { denied: false, rule: '', detail: '' };
-        }
-        var equity = opts.equity || 0;
-        var refPrices = opts.marketRefPrices || [];
-        var grossNotional = 0;
-        for (var i = 0; i < this._legs.length; i++) {
-            var l = this._legs[i];
-            if (limits.maxLegQty !== 0 && l.targetQty > limits.maxLegQty) {
-                return { denied: true, rule: 'maxLegQty',
-                         detail: 'leg ' + i + ' qty exceeds per-leg cap' };
-            }
-            var price = 0;
-            if (l.orderType === 0) price = l.limitPrice;
-            else if (i < refPrices.length) price = refPrices[i];
-            grossNotional += Math.abs(price * l.targetQty);
-        }
-        if (limits.maxGrossNotional !== 0 && grossNotional > limits.maxGrossNotional) {
-            return { denied: true, rule: 'maxGrossNotional',
-                     detail: 'basket gross notional exceeds cap' };
-        }
-        if (limits.maxConcentrationPct > 0 && equity > 0) {
-            var frac = grossNotional / equity;
-            if (frac > limits.maxConcentrationPct) {
-                return { denied: true, rule: 'maxConcentrationPct',
-                         detail: 'basket gross notional exceeds concentration limit vs equity' };
-            }
-        }
-        return { denied: false, rule: '', detail: '' };
+        return __flox_order_group_precheck_submission(
+            this._h,
+            opts.equity || 0,
+            opts.marketRefPrices || []);
     }
 
     autoDispatch(strategy) {
@@ -199,77 +154,9 @@ class OrderGroup {
         return fired;
     }
 
-    _stateRaw() {
-        if (this._legs.length === 0) return 0;
-        var anyPending = false, anyFilled = false, allFilled = true;
-        var anyFailed = false, anyCancelled = false, allTerminal = true;
-        var anyNonFilledTerminal = false;
-        for (var i = 0; i < this._legs.length; i++) {
-            var s = this._legs[i].state;
-            switch (s) {
-                case 0: anyPending = true; allTerminal = false; allFilled = false; break;
-                case 1:
-                case 2: allTerminal = false; allFilled = false; break;
-                case 3: anyFilled = true; break;
-                case 4: anyCancelled = true; allFilled = false; anyNonFilledTerminal = true; break;
-                case 5: anyFailed = true; allFilled = false; anyNonFilledTerminal = true; break;
-            }
-        }
-        if (anyPending) return 0;
-        if (allFilled) return 3;
-        if (this._policy === 1 && anyFailed) return 5;
-        if (this._policy === 2 && anyFilled && !allFilled) return 2;
-        if (allTerminal && !anyFilled) {
-            return anyCancelled ? 4 : 6;
-        }
-        if (anyFilled || anyNonFilledTerminal) return 2;
-        return 1;
-    }
-
-    state() { return _GROUP_STATE_NAMES[this._stateRaw()]; }
+    state() { return _GROUP_STATE_NAMES[__flox_order_group_state(this._h)]; }
 
     recommendedActions() {
-        var out = [];
-        if (this._policy === 0) return out;
-        if (this._policy === 2) {
-            var anyFill = false;
-            for (var i = 0; i < this._legs.length; i++) {
-                if (this._legs[i].state === 3 || this._legs[i].state === 2) { anyFill = true; break; }
-            }
-            if (!anyFill) return out;
-            for (var j = 0; j < this._legs.length; j++) {
-                var l = this._legs[j];
-                var dispatched = l.dispatched || 0;
-                if ((l.state === 0 || l.state === 1) && !(dispatched & 0x1)) {
-                    out.push({ kind: 'cancel', legIndex: j, orderId: l.orderId });
-                }
-            }
-            return out;
-        }
-        if (this._policy === 1) {
-            var anyFailureOrCancel = false;
-            for (var k = 0; k < this._legs.length; k++) {
-                var st = this._legs[k].state;
-                if (st === 5 || st === 4) { anyFailureOrCancel = true; break; }
-            }
-            if (!anyFailureOrCancel) return out;
-            for (var m = 0; m < this._legs.length; m++) {
-                var ll = this._legs[m];
-                var disp = ll.dispatched || 0;
-                if ((ll.state === 0 || ll.state === 1) && !(disp & 0x1)) {
-                    out.push({ kind: 'cancel', legIndex: m, orderId: ll.orderId });
-                } else if ((ll.state === 3 || ll.state === 2) && !(disp & 0x2)) {
-                    out.push({
-                        kind: 'revert',
-                        legIndex: m,
-                        symbol: ll.symbol,
-                        side: ll.side === 0 ? 1 : 0,
-                        qty: ll.filledQty,
-                    });
-                }
-            }
-            return out;
-        }
-        return out;
+        return __flox_order_group_recommended_actions(this._h);
     }
 }

--- a/src/quickjs/js_bindings.cpp
+++ b/src/quickjs/js_bindings.cpp
@@ -2168,6 +2168,248 @@ static JSValue js_run_reader_fills(JSContext* ctx, JSValueConst, int, JSValueCon
 }
 
 // ============================================================
+// Order group (multi-leg state machine + risk gate + pair-latency)
+// ============================================================
+//
+// Thin shim over the C ABI. The high-level OrderGroup class lives in
+// quickjs/flox/order_group.js and wraps these globals so the four
+// bindings (pybind11 / NAPI / QuickJS / Codon) all reach the same
+// C++ engine.
+
+static JSValue js_order_group_create(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  int64_t parent = 0;
+  uint32_t policy = 0;
+  if (argv)
+  {
+    JS_ToInt64(ctx, &parent, argv[0]);
+    JS_ToUint32(ctx, &policy, argv[1]);
+  }
+  auto h = flox_order_group_create(static_cast<uint64_t>(parent), static_cast<uint8_t>(policy));
+  return createHandleObject(ctx, h);
+}
+
+static JSValue js_order_group_destroy(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  flox_order_group_destroy(static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0])));
+  return JS_UNDEFINED;
+}
+
+static JSValue js_order_group_add_market_leg(JSContext* ctx, JSValueConst, int,
+                                             JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  uint32_t symbol = toUint32(ctx, argv[1]);
+  uint32_t side = toUint32(ctx, argv[2]);
+  double qty = toDouble(ctx, argv[3]);
+  int64_t qty_raw = static_cast<int64_t>(qty * 100'000'000LL);
+  return JS_NewUint32(ctx,
+                      flox_order_group_add_market_leg(h, symbol, static_cast<uint8_t>(side),
+                                                      qty_raw));
+}
+
+static JSValue js_order_group_add_limit_leg(JSContext* ctx, JSValueConst, int,
+                                            JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  uint32_t symbol = toUint32(ctx, argv[1]);
+  uint32_t side = toUint32(ctx, argv[2]);
+  double price = toDouble(ctx, argv[3]);
+  double qty = toDouble(ctx, argv[4]);
+  int64_t price_raw = static_cast<int64_t>(price * 100'000'000LL);
+  int64_t qty_raw = static_cast<int64_t>(qty * 100'000'000LL);
+  return JS_NewUint32(
+      ctx, flox_order_group_add_limit_leg(h, symbol, static_cast<uint8_t>(side), price_raw,
+                                          qty_raw));
+}
+
+static JSValue js_order_group_leg_count(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  return JS_NewUint32(ctx, flox_order_group_leg_count(h));
+}
+
+static JSValue js_order_group_leg_state(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  uint32_t i = toUint32(ctx, argv[1]);
+  return JS_NewUint32(ctx, flox_order_group_leg_state(h, i));
+}
+
+static JSValue js_order_group_leg_filled(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  uint32_t i = toUint32(ctx, argv[1]);
+  int64_t raw = flox_order_group_leg_filled_raw(h, i);
+  return JS_NewFloat64(ctx, static_cast<double>(raw) / 1e8);
+}
+
+static JSValue js_order_group_leg_order_id(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  uint32_t i = toUint32(ctx, argv[1]);
+  return JS_NewInt64(ctx, static_cast<int64_t>(flox_order_group_leg_order_id(h, i)));
+}
+
+static JSValue js_order_group_record_submit(JSContext* ctx, JSValueConst, int,
+                                            JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  uint32_t i = toUint32(ctx, argv[1]);
+  int64_t order_id = 0;
+  JS_ToInt64(ctx, &order_id, argv[2]);
+  flox_order_group_record_submit(h, i, static_cast<uint64_t>(order_id));
+  return JS_UNDEFINED;
+}
+
+static JSValue js_order_group_record_fill(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  uint32_t i = toUint32(ctx, argv[1]);
+  double qty = toDouble(ctx, argv[2]);
+  flox_order_group_record_fill(h, i, static_cast<int64_t>(qty * 100'000'000LL));
+  return JS_UNDEFINED;
+}
+
+static JSValue js_order_group_record_cancel(JSContext* ctx, JSValueConst, int,
+                                            JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  uint32_t i = toUint32(ctx, argv[1]);
+  flox_order_group_record_cancel(h, i);
+  return JS_UNDEFINED;
+}
+
+static JSValue js_order_group_record_failure(JSContext* ctx, JSValueConst, int,
+                                             JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  uint32_t i = toUint32(ctx, argv[1]);
+  flox_order_group_record_failure(h, i);
+  return JS_UNDEFINED;
+}
+
+static JSValue js_order_group_state(JSContext* ctx, JSValueConst, int, JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  return JS_NewUint32(ctx, flox_order_group_state(h));
+}
+
+static JSValue js_order_group_recommended_actions(JSContext* ctx, JSValueConst, int,
+                                                  JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  constexpr uint32_t kMax = 32;
+  int64_t buf[kMax * 5];
+  uint32_t n = flox_order_group_recommended_actions(h, buf, kMax);
+  JSValue out = JS_NewArray(ctx);
+  for (uint32_t i = 0; i < n; ++i)
+  {
+    int64_t* row = buf + i * 5;
+    JSValue rec = JS_NewObject(ctx);
+    JS_SetPropertyStr(ctx, rec, "kind",
+                      JS_NewString(ctx, row[0] == 0 ? "cancel" : "revert"));
+    JS_SetPropertyStr(ctx, rec, "legIndex", JS_NewInt32(ctx, static_cast<int32_t>(row[1])));
+    if (row[0] == 0)
+    {
+      JS_SetPropertyStr(ctx, rec, "orderId", JS_NewInt64(ctx, row[2]));
+    }
+    else
+    {
+      JS_SetPropertyStr(ctx, rec, "symbol", JS_NewInt32(ctx, static_cast<int32_t>(row[2])));
+      JS_SetPropertyStr(ctx, rec, "side", JS_NewInt32(ctx, static_cast<int32_t>(row[3])));
+      JS_SetPropertyStr(ctx, rec, "qty", JS_NewFloat64(ctx, static_cast<double>(row[4]) / 1e8));
+    }
+    JS_SetPropertyUint32(ctx, out, i, rec);
+  }
+  return out;
+}
+
+static JSValue js_order_group_mark_action_dispatched(JSContext* ctx, JSValueConst, int,
+                                                     JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  uint32_t leg = toUint32(ctx, argv[1]);
+  uint32_t kind = toUint32(ctx, argv[2]);
+  flox_order_group_mark_action_dispatched(h, leg, static_cast<uint8_t>(kind));
+  return JS_UNDEFINED;
+}
+
+static JSValue js_order_group_set_risk_limits(JSContext* ctx, JSValueConst, int,
+                                              JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  double max_gross = toDouble(ctx, argv[1]);
+  double max_conc = toDouble(ctx, argv[2]);
+  double max_leg = toDouble(ctx, argv[3]);
+  int64_t gross_raw = static_cast<int64_t>(max_gross * 100'000'000LL);
+  int64_t leg_raw = static_cast<int64_t>(max_leg * 100'000'000LL);
+  flox_order_group_set_risk_limits(h, gross_raw, max_conc, leg_raw);
+  return JS_UNDEFINED;
+}
+
+static JSValue js_order_group_precheck_submission(JSContext* ctx, JSValueConst, int,
+                                                  JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  double equity = toDouble(ctx, argv[1]);
+
+  std::vector<int64_t> prices_raw;
+  uint32_t plen = 0;
+  if (JS_IsArray(ctx, argv[2]))
+  {
+    JSValue lenVal = JS_GetPropertyStr(ctx, argv[2], "length");
+    JS_ToUint32(ctx, &plen, lenVal);
+    JS_FreeValue(ctx, lenVal);
+    prices_raw.reserve(plen);
+    for (uint32_t i = 0; i < plen; ++i)
+    {
+      JSValue v = JS_GetPropertyUint32(ctx, argv[2], i);
+      double p = 0;
+      JS_ToFloat64(ctx, &p, v);
+      JS_FreeValue(ctx, v);
+      prices_raw.push_back(static_cast<int64_t>(p * 100'000'000LL));
+    }
+  }
+
+  char rule[64] = {};
+  char detail[256] = {};
+  uint8_t denied = flox_order_group_precheck_submission(
+      h, equity, prices_raw.empty() ? nullptr : prices_raw.data(), plen, rule, sizeof(rule),
+      detail, sizeof(detail));
+
+  JSValue out = JS_NewObject(ctx);
+  JS_SetPropertyStr(ctx, out, "denied", JS_NewBool(ctx, denied != 0));
+  JS_SetPropertyStr(ctx, out, "rule", JS_NewString(ctx, rule));
+  JS_SetPropertyStr(ctx, out, "detail", JS_NewString(ctx, detail));
+  return out;
+}
+
+static JSValue js_order_group_set_pair_latency_budget_ns(JSContext* ctx, JSValueConst, int,
+                                                         JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  int64_t budget = 0;
+  JS_ToInt64(ctx, &budget, argv[1]);
+  flox_order_group_set_pair_latency_budget_ns(h, budget);
+  return JS_UNDEFINED;
+}
+
+static JSValue js_order_group_pair_latency_decision(JSContext* ctx, JSValueConst, int,
+                                                    JSValueConst* argv)
+{
+  auto h = static_cast<FloxOrderGroupHandle>(getHandle(ctx, argv[0]));
+  int64_t submit_ts = 0, ack_ts = 0;
+  JS_ToInt64(ctx, &submit_ts, argv[1]);
+  JS_ToInt64(ctx, &ack_ts, argv[2]);
+  uint32_t ack_received = toUint32(ctx, argv[3]);
+  uint8_t d = flox_order_group_pair_latency_decision(h, submit_ts, ack_ts,
+                                                     static_cast<uint8_t>(ack_received));
+  const char* name = d == 0 ? "wait" : (d == 1 ? "submit_follower" : "cancel_leader");
+  return JS_NewString(ctx, name);
+}
+
+// ============================================================
 // Bar dispatch recorder (cross-binding parity test fixture)
 // ============================================================
 
@@ -4286,6 +4528,33 @@ void registerFloxBindings(JSContext* ctx)
   addGlobalFunc(ctx, "__flox_run_reader_signals", js_run_reader_signals, 1);
   addGlobalFunc(ctx, "__flox_run_reader_orders", js_run_reader_orders, 1);
   addGlobalFunc(ctx, "__flox_run_reader_fills", js_run_reader_fills, 1);
+
+  // Order group (multi-leg state machine; QuickJS class wraps these in
+  // quickjs/flox/order_group.js so all four bindings share the engine).
+  addGlobalFunc(ctx, "__flox_order_group_create", js_order_group_create, 2);
+  addGlobalFunc(ctx, "__flox_order_group_destroy", js_order_group_destroy, 1);
+  addGlobalFunc(ctx, "__flox_order_group_add_market_leg", js_order_group_add_market_leg, 4);
+  addGlobalFunc(ctx, "__flox_order_group_add_limit_leg", js_order_group_add_limit_leg, 5);
+  addGlobalFunc(ctx, "__flox_order_group_leg_count", js_order_group_leg_count, 1);
+  addGlobalFunc(ctx, "__flox_order_group_leg_state", js_order_group_leg_state, 2);
+  addGlobalFunc(ctx, "__flox_order_group_leg_filled", js_order_group_leg_filled, 2);
+  addGlobalFunc(ctx, "__flox_order_group_leg_order_id", js_order_group_leg_order_id, 2);
+  addGlobalFunc(ctx, "__flox_order_group_record_submit", js_order_group_record_submit, 3);
+  addGlobalFunc(ctx, "__flox_order_group_record_fill", js_order_group_record_fill, 3);
+  addGlobalFunc(ctx, "__flox_order_group_record_cancel", js_order_group_record_cancel, 2);
+  addGlobalFunc(ctx, "__flox_order_group_record_failure", js_order_group_record_failure, 2);
+  addGlobalFunc(ctx, "__flox_order_group_state", js_order_group_state, 1);
+  addGlobalFunc(ctx, "__flox_order_group_recommended_actions",
+                js_order_group_recommended_actions, 1);
+  addGlobalFunc(ctx, "__flox_order_group_mark_action_dispatched",
+                js_order_group_mark_action_dispatched, 3);
+  addGlobalFunc(ctx, "__flox_order_group_set_risk_limits", js_order_group_set_risk_limits, 4);
+  addGlobalFunc(ctx, "__flox_order_group_precheck_submission",
+                js_order_group_precheck_submission, 3);
+  addGlobalFunc(ctx, "__flox_order_group_set_pair_latency_budget_ns",
+                js_order_group_set_pair_latency_budget_ns, 2);
+  addGlobalFunc(ctx, "__flox_order_group_pair_latency_decision",
+                js_order_group_pair_latency_decision, 4);
 
   // Bar dispatch recorder (cross-binding parity test fixture)
   addGlobalFunc(ctx, "__flox_bar_dispatch_recorder_create", js_bar_dispatch_recorder_create, 0);


### PR DESCRIPTION
## Summary
- The QuickJS OrderGroup binding shipped the state machine + risk gate + pair-latency logic as a pure-JS reimplementation. The other three bindings (pybind11 / NAPI / Codon) wrap the C++ engine through the C ABI.
- That divergence meant a bug fix or new feature in `OrderGroup::pairLatencyDecision` or `precheckSubmission` reached three of four bindings — and the QuickJS path could silently drift from the engine.
- This refactor exposes the full \`__flox_order_group_*\` C ABI as QuickJS globals and rewrites \`quickjs/flox/order_group.js\` to wrap them. The public class API stays identical.

## Test plan
- [x] \`flox_js_runner quickjs/examples/order_group_smoke.js\` (13/13 ok — same suite as before, now exercising the C++ engine)
- [x] \`flox_js_runner quickjs/examples/bar_close_ordering_parity_smoke.js\` (still green — sanity that the new C bindings don't collide)
- [x] \`flox_js_runner quickjs/examples/sma_crossover.js\` (still green)
- [x] check-format / binding-parity / codegen-check — all green
- [x] No IDL changes, so no sync chain regen needed

## MCP impact
None — no IDL change, no new symbols, no doc additions. Bundled-data readers stay current; live-engine tools unaffected.

W15-T007