### PR TITLE
backtest: wire MultiModePositionTracker into Strategy

### DIFF
--- a/include/flox/backtest/backtest_runner.h
+++ b/include/flox/backtest/backtest_runner.h
@@ -16,6 +16,7 @@
 #include "flox/backtest/simulated_executor.h"
 #include "flox/execution/abstract_execution_listener.h"
 #include "flox/execution/abstract_executor.h"
+#include "flox/position/multi_mode_position_tracker.h"
 #include "flox/replay/abstract_event_reader.h"
 #include "flox/strategy/abstract_signal_handler.h"
 #include "flox/strategy/strategy.h"
@@ -179,6 +180,12 @@ class BacktestRunner : public ISignalHandler
   // here instead of to the built-in SimulatedExecutor.
   IOrderExecutor* _customExecutor{nullptr};
   IStrategy* _strategy{nullptr};
+  // Built-in position tracker. Wired as an execution listener at
+  // construction and attached to the strategy in setStrategy() so
+  // `ctx.position` / `ctx.is_long()` / `ctx.is_flat()` reflect fills
+  // the simulator dispatches. Subscriber id is internal — does not
+  // collide with user-registered listeners.
+  MultiModePositionTracker _positionTracker{0xFEFEFEFEu};
   std::vector<IMarketDataSubscriber*> _marketDataSubscribers;
   std::vector<IOrderExecutionListener*> _executionListeners;
   OrderId _nextOrderId{1};

--- a/include/flox/strategy/abstract_strategy.h
+++ b/include/flox/strategy/abstract_strategy.h
@@ -16,6 +16,7 @@ namespace flox
 {
 
 class ISignalHandler;
+class IPositionManager;
 
 class IStrategy : public ISubsystem, public IMarketDataSubscriber
 {
@@ -23,6 +24,7 @@ class IStrategy : public ISubsystem, public IMarketDataSubscriber
   virtual ~IStrategy() = default;
 
   virtual void setSignalHandler(ISignalHandler*) {}
+  virtual void setPositionManager(IPositionManager*) {}
 };
 
 }  // namespace flox

--- a/include/flox/strategy/strategy.h
+++ b/include/flox/strategy/strategy.h
@@ -82,7 +82,7 @@ class Strategy : public IStrategy
 
   void setSignalHandler(ISignalHandler* handler) override { _signalHandler = handler; }
   void setOrderTracker(OrderTracker* tracker) noexcept { _orderTracker = tracker; }
-  void setPositionManager(IPositionManager* pm) noexcept { _positionManager = pm; }
+  void setPositionManager(IPositionManager* pm) noexcept override { _positionManager = pm; }
 
   void onTrade(const TradeEvent& ev) final
   {
@@ -95,6 +95,7 @@ class Strategy : public IStrategy
     auto& c = _contexts[sym];
     c.lastTradePrice = ev.trade.price;
     c.lastUpdateNs = ev.trade.exchangeTsNs;
+    refreshPosition(c, sym);
 
     onSymbolTrade(c, ev);
   }
@@ -110,6 +111,7 @@ class Strategy : public IStrategy
     auto& c = _contexts[sym];
     c.book.applyBookUpdate(ev);
     c.lastUpdateNs = ev.update.exchangeTsNs;
+    refreshPosition(c, sym);
 
     onSymbolBook(c, ev);
   }
@@ -125,6 +127,7 @@ class Strategy : public IStrategy
     auto& c = _contexts[sym];
     c.lastTradePrice = ev.bar.close;
     c.lastUpdateNs = ev.bar.endTime.time_since_epoch().count();
+    refreshPosition(c, sym);
 
     // Push into the per-(symbol, timeframe) ring so multi-TF strategies
     // can recall the last N closed bars without bookkeeping by hand.
@@ -359,6 +362,21 @@ class Strategy : public IStrategy
   {
     static std::atomic<OrderId> s_globalOrderId{1};
     return s_globalOrderId++;
+  }
+
+  // Pull the latest position from the attached IPositionManager into
+  // the per-symbol context so `ctx.position` / `ctx.is_long()` /
+  // `ctx.is_flat()` reflect fills the executor has dispatched. Without
+  // this hook the SymbolContext.position field is dead — initialised
+  // to zero and never updated — which silently produces 0-trade
+  // backtests when a strategy guards entries on `ctx.is_flat()` and
+  // exits on `ctx.is_long()`.
+  void refreshPosition(SymbolContext& c, SymbolId sym) noexcept
+  {
+    if (_positionManager)
+    {
+      c.position = _positionManager->getPosition(sym);
+    }
   }
 
   SubscriberId _id;

--- a/node/test/test_bindings.js
+++ b/node/test/test_bindings.js
@@ -302,8 +302,11 @@ if (fs.existsSync(btCsv)) {
       const f = fast.update(t.price);
       const s = slow.update(t.price);
       if (f === null || s === null) return;
+      // Long-only crossover with a real exit side. `totalTrades`
+      // counts round-trip trades, so the strategy needs both
+      // entry (flat → long) and exit (long → flat) to surface.
       if (f > s && ctx.position === 0) emit.marketBuy(0.01);
-      else if (f < s && ctx.position === 0) emit.marketSell(0.01);
+      else if (f < s && ctx.position > 0) emit.marketSell(0.01);
     },
   };
 
@@ -364,7 +367,7 @@ if (fs.existsSync(wfCsv)) {
         const s = slow.update(t.price);
         if (f === null || s === null || !slow.ready) return;
         if (f > s && ctx.position === 0) emit.marketBuy(0.01);
-        else if (f < s && ctx.position === 0) emit.marketSell(0.01);
+        else if (f < s && ctx.position > 0) emit.marketSell(0.01);
       },
     };
   });
@@ -390,7 +393,7 @@ if (fs.existsSync(wfCsv)) {
         const f = fast.update(t.price), s = slow.update(t.price);
         if (f === null || s === null || !slow.ready) return;
         if (f > s && ctx.position === 0) emit.marketBuy(0.01);
-        else if (f < s && ctx.position === 0) emit.marketSell(0.01);
+        else if (f < s && ctx.position > 0) emit.marketSell(0.01);
       },
     };
   });

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -435,9 +435,13 @@ if os.path.exists(bt_csv):
             s = self.slow.update(t.price)
             if f is None or s is None:
                 return
+            # Long-only crossover with a real exit side. `totalTrades`
+            # counts round-trip trades (a buy is not a "trade" until
+            # it's closed by an opposing sell), so the strategy needs
+            # both branches to surface in stats.
             if f > s and ctx.is_flat():
                 self.market_buy(0.01)
-            elif f < s and ctx.is_flat():
+            elif f < s and ctx.is_long():
                 self.market_sell(0.01)
 
     bt = flox.BacktestRunner(reg2, fee_rate=0.0004, initial_capital=10_000)

--- a/python/tests/test_ctx_position_in_backtest.py
+++ b/python/tests/test_ctx_position_in_backtest.py
@@ -1,0 +1,91 @@
+"""Pybind11 regression test for the BacktestRunner ↔ Strategy
+position-manager wire (mirror of tests/test_backtest_ctx_position.cpp).
+
+The C++ gtest pins the engine-level behavior. This test pins that
+the pybind11 binding inherits it through the C ABI — strategies in
+Python see `ctx.position` / `ctx.is_long()` / `ctx.is_flat()` track
+fills the simulator dispatches.
+"""
+from __future__ import annotations
+
+import flox_py as flox
+import numpy as np
+
+
+class TrackingStrategy(flox.Strategy):
+    def __init__(self, symbols):
+        super().__init__(symbols)
+        self.samples = []  # (idx, position, is_long, is_flat)
+        self.bar_count = 0
+
+    def on_bar(self, ctx, bar):
+        if self.bar_count == 1:
+            self.market_buy(0.5)
+        self.samples.append(
+            (self.bar_count, ctx.position, ctx.is_long(), ctx.is_flat())
+        )
+        self.bar_count += 1
+
+
+def _make_bars(n: int):
+    start_ns = np.array([i * 60_000_000_000 for i in range(n)], dtype=np.int64)
+    end_ns = start_ns + 60_000_000_000
+    open_ = np.array([100.0 + i for i in range(n)], dtype=np.float64)
+    high = open_ + 0.5
+    low = open_ - 0.5
+    close = open_ + 0.25
+    volume = np.full(n, 100.0)
+    return start_ns, end_ns, open_, high, low, close, volume
+
+
+def test_ctx_position_reflects_fills_after_market_buy() -> None:
+    registry = flox.SymbolRegistry()
+    sym = registry.add_symbol("backtest", "BTCUSDT", tick_size=0.01)
+    runner = flox.BacktestRunner(registry, initial_capital=100_000.0)
+    strat = TrackingStrategy([sym])
+    runner.set_strategy(strat)
+
+    bars = _make_bars(5)
+    runner.run_bars(*bars, symbol="BTCUSDT")
+
+    assert len(strat.samples) == 5
+    # Bar 0: nothing emitted yet → flat.
+    assert strat.samples[0] == (0, 0.0, False, True)
+    # Bar 1: ctx is snapshotted before the emit; sample still flat.
+    assert strat.samples[1][3] is True, "snapshot taken before market_buy fills"
+    # Bars 2–4: refreshPosition picks up the fill from bar 1.
+    for i in range(2, 5):
+        idx, pos, is_long, is_flat = strat.samples[i]
+        assert is_long is True, f"bar {i}: ctx.is_long() should be True"
+        assert is_flat is False, f"bar {i}: ctx.is_flat() should be False"
+        assert pos == 0.5, f"bar {i}: ctx.position should be 0.5, got {pos}"
+
+
+def test_flat_guard_prevents_re_entry_after_first_buy() -> None:
+    """Without the position-manager wire, ctx.is_flat() is always True
+    in backtest, so a flat-guarded entry buys on every bar. This test
+    pins that the guard works once a position is open."""
+
+    class GuardedStrategy(flox.Strategy):
+        def __init__(self, symbols):
+            super().__init__(symbols)
+            self.buys = 0
+
+        def on_bar(self, ctx, bar):
+            if ctx.is_flat():
+                self.market_buy(0.5)
+                self.buys += 1
+
+    registry = flox.SymbolRegistry()
+    sym = registry.add_symbol("backtest", "BTCUSDT", tick_size=0.01)
+    runner = flox.BacktestRunner(registry, initial_capital=100_000.0)
+    strat = GuardedStrategy([sym])
+    runner.set_strategy(strat)
+
+    bars = _make_bars(10)
+    runner.run_bars(*bars, symbol="BTCUSDT")
+
+    # With the fix: bar 0 flat → buy; from bar 1 onwards ctx is long
+    # so the guard prevents re-entry. Exactly one buy.
+    # Without the fix: ctx always reports flat → 10 buys.
+    assert strat.buys == 1, f"is_flat() guard failed: got {strat.buys} buys"

--- a/python/tests/test_grid_search.py
+++ b/python/tests/test_grid_search.py
@@ -99,7 +99,7 @@ class GridSearchTests(unittest.TestCase):
                         return
                     if f > s and ctx.is_flat():
                         self.market_buy(0.01)
-                    elif f < s and ctx.is_flat():
+                    elif f < s and ctx.is_long():
                         self.market_sell(0.01)
 
             bt = flox.BacktestRunner(reg, 0.0004, 10_000)

--- a/python/tests/test_walk_forward.py
+++ b/python/tests/test_walk_forward.py
@@ -32,7 +32,7 @@ class _SmaStrategy(flox.Strategy):
             return
         if f > s and ctx.is_flat():
             self.market_buy(0.01)
-        elif f < s and ctx.is_flat():
+        elif f < s and ctx.is_long():
             self.market_sell(0.01)
 
 

--- a/src/backtest/backtest_runner.cpp
+++ b/src/backtest/backtest_runner.cpp
@@ -25,6 +25,12 @@ BacktestRunner::BacktestRunner(const BacktestConfig& config)
   _executor.setOrderEventCallback(
       [this](const OrderEvent& ev)
       {
+        // The built-in position tracker has to receive fills before
+        // any user listener — strategies that read `ctx.position`
+        // inside an order-event handler need the tracker already
+        // updated when their listener fires. User listeners are
+        // appended after via addExecutionListener().
+        ev.dispatchTo(_positionTracker);
         for (auto* listener : _executionListeners)
         {
           ev.dispatchTo(*listener);
@@ -36,6 +42,11 @@ void BacktestRunner::setStrategy(IStrategy* strategy)
 {
   _strategy = strategy;
   strategy->setSignalHandler(this);
+  // Without this wire `ctx.position` / `ctx.is_long()` / `ctx.is_flat()`
+  // never reflect fills the executor dispatches. Strategy::onTrade /
+  // onBar / onBookUpdate refresh the per-symbol context from this
+  // tracker before each handler call.
+  strategy->setPositionManager(&_positionTracker);
 }
 
 void BacktestRunner::addMarketDataSubscriber(IMarketDataSubscriber* subscriber)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ if(FLOX_ENABLE_BACKTEST)
   add_flox_test(test_backtest_slippage)
   add_flox_test(test_backtest_queue)
   add_flox_test(test_backtest_metrics)
+  add_flox_test(test_backtest_ctx_position)
 endif()
 
 add_flox_test(test_indicators)

--- a/tests/test_backtest_ctx_position.cpp
+++ b/tests/test_backtest_ctx_position.cpp
@@ -1,0 +1,188 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+// Regression test for the BacktestRunner ↔ Strategy position-manager
+// wire. Two independent agent sessions reported `ctx.position` and
+// `ctx.is_long()` returning false-zero in `Strategy::onSymbolBar`
+// after a market_buy, producing 0-trade backtests with no error.
+// Root cause: `Strategy::_positionManager` was never attached in the
+// backtest path, so `position()` always returned `Quantity{}` and
+// `SymbolContext.position` (which the C ABI bridge reads from) was
+// dead-initialised to zero. Fix: BacktestRunner registers a
+// MultiModePositionTracker as an execution listener and attaches it
+// to the strategy in setStrategy(); Strategy refreshes
+// `c.position` from the manager before each handler call.
+
+#include "flox/aggregator/events/bar_event.h"
+#include "flox/backtest/backtest_runner.h"
+#include "flox/engine/symbol_registry.h"
+#include "flox/strategy/strategy.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <vector>
+
+using namespace flox;
+
+namespace
+{
+
+class TrackingStrategy : public Strategy
+{
+ public:
+  using Strategy::Strategy;
+
+  struct Sample
+  {
+    size_t idx;
+    double position;
+    bool is_long;
+    bool is_flat;
+  };
+
+  std::vector<Sample> samples;
+  size_t bar_count{0};
+  SymbolId target{0};
+
+ protected:
+  void onSymbolBar(SymbolContext& ctx, const BarEvent& /*ev*/) override
+  {
+    if (bar_count == 1)
+    {
+      emitMarketBuy(target, Quantity::fromDouble(0.5));
+    }
+    samples.push_back(Sample{
+        .idx = bar_count,
+        .position = ctx.position.toDouble(),
+        .is_long = ctx.position > Quantity{},
+        .is_flat = ctx.position.isZero(),
+    });
+    ++bar_count;
+  }
+};
+
+BarEvent makeBar(SymbolId sym, double close, int64_t ts_ns)
+{
+  BarEvent ev{};
+  ev.symbol = sym;
+  ev.barType = BarType::Time;
+  ev.barTypeParam = 60'000'000'000ull;
+  ev.bar.open = Price::fromDouble(close);
+  ev.bar.high = Price::fromDouble(close + 0.5);
+  ev.bar.low = Price::fromDouble(close - 0.5);
+  ev.bar.close = Price::fromDouble(close);
+  ev.bar.volume = Volume::fromDouble(100.0);
+  ev.bar.startTime = TimePoint{std::chrono::nanoseconds{ts_ns}};
+  ev.bar.endTime = TimePoint{std::chrono::nanoseconds{ts_ns + 60'000'000'000LL}};
+  ev.bar.reason = BarCloseReason::Threshold;
+  return ev;
+}
+
+SymbolId addSymbol(SymbolRegistry& reg, const std::string& spelling)
+{
+  SymbolInfo info;
+  info.exchange = "test";
+  info.symbol = spelling;
+  info.type = InstrumentType::Spot;
+  info.tickSize = Price::fromDouble(0.01);
+  return reg.registerSymbol(info);
+}
+
+}  // namespace
+
+TEST(BacktestCtxPosition, BarHandlerSeesFillAfterMarketBuy)
+{
+  SymbolRegistry reg;
+  SymbolId sym = addSymbol(reg, "BTCUSDT");
+
+  TrackingStrategy strat(1, std::vector<SymbolId>{sym}, reg);
+  strat.target = sym;
+
+  BacktestRunner runner;
+  runner.setStrategy(&strat);
+
+  std::vector<BarEvent> bars;
+  for (int i = 0; i < 5; ++i)
+  {
+    bars.push_back(makeBar(sym, 100.0 + i, i * 60'000'000'000LL));
+  }
+  runner.runBars(bars);
+
+  ASSERT_EQ(strat.samples.size(), 5u);
+  // Bar 0: nothing emitted yet → flat.
+  EXPECT_TRUE(strat.samples[0].is_flat);
+  EXPECT_FALSE(strat.samples[0].is_long);
+  EXPECT_DOUBLE_EQ(strat.samples[0].position, 0.0);
+  // Bar 1: ctx is snapshotted at the start of the handler (Strategy
+  // refreshes c.position from the position manager before calling
+  // onSymbolBar). The market_buy emitted *during* this handler lands
+  // on the position manager but the local ctx reference is already a
+  // copy — sample for bar 1 still reports flat. The fill is visible
+  // on the next handler call, when refreshPosition pulls in the new
+  // value.
+  EXPECT_TRUE(strat.samples[1].is_flat)
+      << "ctx is snapshotted at start of handler; fills land for the next call";
+  // Bars 2–4: refreshPosition picks up the fill from bar 1.
+  for (size_t i = 2; i < 5; ++i)
+  {
+    EXPECT_TRUE(strat.samples[i].is_long)
+        << "ctx.is_long() should be true on bar " << i << " (fill landed on bar 1)";
+    EXPECT_FALSE(strat.samples[i].is_flat);
+    EXPECT_DOUBLE_EQ(strat.samples[i].position, 0.5);
+  }
+}
+
+// Without the fix, the test above passes vacuously because bar 1 is
+// already flat. The crucial assertion is that bars 2-4 are long. This
+// negative case pins what the bug looked like before: a strategy that
+// only buys when flat keeps buying every bar because is_flat() never
+// flips to false.
+TEST(BacktestCtxPosition, FlatGuardedEntryFiresOncePerBuyCycle)
+{
+  SymbolRegistry reg;
+  SymbolId sym = addSymbol(reg, "BTCUSDT");
+
+  struct GuardedStrategy : public Strategy
+  {
+    using Strategy::Strategy;
+    SymbolId target{0};
+    int buys{0};
+
+   protected:
+    void onSymbolBar(SymbolContext& ctx, const BarEvent& /*ev*/) override
+    {
+      if (ctx.isFlat())
+      {
+        emitMarketBuy(target, Quantity::fromDouble(0.5));
+        ++buys;
+      }
+    }
+  };
+
+  GuardedStrategy strat(1, std::vector<SymbolId>{sym}, reg);
+  strat.target = sym;
+
+  BacktestRunner runner;
+  runner.setStrategy(&strat);
+
+  std::vector<BarEvent> bars;
+  for (int i = 0; i < 10; ++i)
+  {
+    bars.push_back(makeBar(sym, 100.0 + i, i * 60'000'000'000LL));
+  }
+  runner.runBars(bars);
+
+  // With the fix: bar 0 is flat → buy. From bar 1 onwards ctx reports
+  // long (fill from bar 0 landed via the position tracker), so the
+  // is_flat() guard prevents further buys. Exactly one buy.
+  // Without the fix: ctx is always flat → 10 buys.
+  EXPECT_EQ(strat.buys, 1)
+      << "is_flat() guard should prevent re-entry once a position is open";
+}


### PR DESCRIPTION
## Summary

Two independent agent sessions reported \`ctx.is_long()\` and \`ctx.position\` returning false-zero in \`Strategy.on_bar\` / \`on_trade\` after \`market_buy\`, producing 0-trade backtests with no error.

**Root cause:** \`Strategy::_positionManager\` was never attached in \`BacktestRunner\`. \`position()\` always returned \`Quantity{}\` and \`SymbolContext.position\` (which the C ABI bridge reads from) was dead-initialised to zero — there was no code anywhere that updated it.

**Fix:**

- \`BacktestRunner\` constructs a \`MultiModePositionTracker\` and registers it as the first execution listener so it receives fills before any user listener.
- \`setStrategy()\` calls \`strategy->setPositionManager(&tracker)\`.
- \`Strategy::onTrade\` / \`onBar\` / \`onBookUpdate\` refresh \`c.position\` from the manager before dispatching to the user override.
- \`IStrategy\` gains a virtual \`setPositionManager(IPositionManager*)\` defaulting to no-op so the backtest path can attach the tracker without coupling to the concrete \`Strategy\` class.

**Cross-binding parity:** automatic. pybind11 / NAPI / QuickJS / Codon all reach \`BacktestRunner\` through the unchanged C ABI.

**Symptom matrix before/after:**

| pattern | before fix | after fix |
|---|---|---|
| \`if ctx.is_flat(): buy\` (every bar) | buys on every bar (guard never fires) | buys once per cycle |
| \`elif ctx.is_long(): sell\` | never fires | fires once position is open |
| \`ctx.position\` after \`market_buy\` | always 0 | reflects fill on next handler call |

## Test plan
- [x] gtest \`tests/test_backtest_ctx_position.cpp\` (2 cases) — pins the wire at the engine level
- [x] pybind11 mirror \`python/tests/test_ctx_position_in_backtest.py\` (2 cases) — pins that the binding inherits the fix through the C ABI
- [x] All existing backtest tests still pass (test_backtest, test_backtest_metrics, test_backtest_queue, test_backtest_slippage, test_position_aggregator, test_multi_tf_alignment, test_multi_symbol_strategy — 158 tests total)
- [x] check-format / check-doc-snippets / check-binding-parity / check-dts-exports / check-error-codes — all green
- [x] sync chain: gen_pyi_stubs / gen_api_index / gen_llms_txt / sync_mcp_data — clean

## MCP impact
None — no IDL change, no new symbols, no new doc pages. Bundled-data readers stay current.

## Follow-up

T021's curated-gotchas infrastructure (originally Phase 3 of this task) is split into **T030**. That is general agent-DX work independent of this binding fix.

W2-T021