### PR TITLE
mcp(docs_search): AND-match multi-word queries

### DIFF
--- a/mcp/flox_mcp/server.py
+++ b/mcp/flox_mcp/server.py
@@ -423,6 +423,10 @@ def build_server() -> Server:
                     "do I X' / 'what does Y do' / 'where is Z documented'. "
                     "The index is built from a strict allowlist; private "
                     "tracker / strategy / author files are NEVER indexed."
+                    "\n\nQuery syntax: plain word lists are AND-matched "
+                    "(every token must appear). Wrap a phrase in double "
+                    "quotes for exact match: `\"walk forward\"`. FTS5 "
+                    "operators (OR, NEAR, *, parens) pass through."
                     "\n\nCanonical workflow queries (run these instead of "
                     "guessing the canonical path from training data):\n"
                     "  • User wants to record market data → "
@@ -444,10 +448,9 @@ def build_server() -> Server:
                         "query": {
                             "type": "string",
                             "description":
-                                "Free-text query. Phrases like \"walk "
-                                "forward\" are treated as one phrase. "
-                                "Plain word lists work too; the tool "
-                                "quotes them automatically.",
+                                "Free-text query. Plain word lists are "
+                                "AND-matched. Wrap a phrase in double "
+                                "quotes for exact match.",
                         },
                         "k": {
                             "type": "integer",

--- a/mcp/flox_mcp/tools/docs_search.py
+++ b/mcp/flox_mcp/tools/docs_search.py
@@ -6,10 +6,12 @@ allowlist of doc roots (``docs/bindings``, ``docs/how-to``,
 ``docs/errors``). Internal trackers (``.notes/``) and author-only
 files (``CLAUDE.md``) are NEVER indexed — verified by a CI test.
 
-Queries use FTS5 syntax. Dashes are tokenizer separators, so
-``walk-forward`` is parsed as two tokens; the tool quotes the user's
-input so phrases like ``walk forward`` work without the caller having
-to know FTS syntax.
+Plain word lists are AND-matched (every token must appear in a doc
+to count). To force exact-phrase ranking, wrap the phrase in double
+quotes: ``"walk forward"``. The previous default was to phrase-quote
+plain queries, but FTS5 phrase match is so strict that natural agent
+queries (``"ccxt fetch_ohlcv historical"``) returned zero hits even
+when every keyword appeared in a single doc.
 """
 from __future__ import annotations
 
@@ -19,32 +21,36 @@ from typing import Optional
 from . import _data
 
 
-_FTS_QUERY_QUOTE = re.compile(r'^[A-Za-z0-9_ ]+$')
+# FTS5 reserved chars / boolean-operator syntax. If the user query
+# contains any of these, we treat it as an explicit FTS5 expression
+# and pass through unchanged.
+_FTS_OPERATOR_HINTS = ('"', " OR ", " AND ", " NEAR(", " NOT ", "(", "*", ":")
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
 
 
 def _normalize_query(q: str) -> str:
     """Make a user query safe + reasonably useful for FTS5.
 
-    * If the query is already a valid FTS5 expression with operators
-      (``"phrase"``, ``OR``, ``AND``, ``NEAR``), pass through.
-    * Otherwise quote it so dashes / dots / colons don't trip the
-      parser. Multiple words become a phrase search.
+    * If the query already uses FTS5 operators (``"phrase"``, ``OR``,
+      ``AND``, ``NEAR``, ``NOT``, ``*``, parens, column-prefix), pass
+      through unchanged.
+    * Otherwise tokenize and AND the terms. ``ccxt fetch_ohlcv
+      historical`` becomes ``ccxt AND fetch_ohlcv AND historical`` —
+      every term must appear, but they can be in any order or
+      distance apart, which matches what an agent typing a multi-word
+      query actually wants.
     """
     q = q.strip()
     if not q:
         return q
-    if any(op in q for op in ('"', " OR ", " AND ", " NEAR(")):
+    if any(op in q for op in _FTS_OPERATOR_HINTS):
         return q
-    if _FTS_QUERY_QUOTE.match(q):
-        # Plain words — turn into a phrase so adjacent matches rank
-        # higher than scattered hits.
-        return f'"{q}"'
-    # Strip non-alphanumerics + collapse whitespace, then phrase-quote.
-    cleaned = re.sub(r"[^A-Za-z0-9_ ]+", " ", q)
-    cleaned = re.sub(r"\s+", " ", cleaned).strip()
-    if not cleaned:
+    tokens = _TOKEN_RE.findall(q)
+    if not tokens:
         return ""
-    return f'"{cleaned}"'
+    if len(tokens) == 1:
+        return tokens[0]
+    return " AND ".join(tokens)
 
 
 def _excerpt(body: str, query: str, *, span: int = 240) -> str:

--- a/mcp/tests/test_polyglot_tools.py
+++ b/mcp/tests/test_polyglot_tools.py
@@ -276,6 +276,25 @@ def test_docs_search_phrase_with_punctuation():
     assert "no matches" not in out.lower()
 
 
+def test_docs_search_multi_word_and_matches():
+    """Plain multi-word queries AND-match every token rather than
+    requiring an exact phrase. A query like `ccxt fetch_ohlcv historical`
+    has to find docs where every term appears, but they need not be
+    adjacent. The previous default phrase-quoted, returning zero hits
+    on natural agent queries.
+    """
+    out = docs_search_tool.docs_search("ccxt fetch_ohlcv historical", k=5)
+    assert "no matches" not in out.lower()
+    assert "docs/" in out
+
+
+def test_docs_search_explicit_phrase_still_works():
+    """Wrapping in double quotes preserves exact-phrase ranking."""
+    out = docs_search_tool.docs_search('"walk forward"', k=3)
+    assert "walk forward" in out.lower() or "walk-forward" in out.lower()
+    assert "docs/" in out
+
+
 def test_docs_search_unknown_query_is_friendly():
     out = docs_search_tool.docs_search("xyzpdq nonexistentterm zzzqqq")
     assert "no matches" in out.lower()


### PR DESCRIPTION
## Summary

\`docs_search\` previously phrase-quoted plain word lists by default. Five real-session agent queries returned zero hits on docs that clearly contained every term:

- \`BTCUSDT perp symbol\`
- \`on_bar timeframe 1m bar interval strategy config\`
- \`register strategy timeframe perpetual futures bar interval\`
- \`ccxt fetch_ohlcv historical backfill\`
- \`project layout strategy backtest\`

Switch the default to AND-matching: every token must appear, but they need not be adjacent or in order. Wrap a phrase in double quotes for exact-phrase ranking (\`"walk forward"\`).

## Test plan
- [x] \`pytest mcp/tests/\` (112 passed; +2 new tests for multi-word AND + explicit phrase)
- [x] Verified end-to-end: previously-failing queries now return real hits (\`ccxt fetch_ohlcv historical\` → 2 hits, \`project layout strategy backtest\` → 2 hits, etc.)
- [x] check-format / check-doc-snippets / sync_mcp_data --check — green

## MCP impact
- \`docs_search\` description + inputSchema updated to document AND-default with explicit-phrase fallback.
- No bundled-data shape change.

T022.