### PR TITLE
mcp: friendlier no-engine error for runtime tools

### DIFF
--- a/mcp/flox_mcp/tools/analytics.py
+++ b/mcp/flox_mcp/tools/analytics.py
@@ -37,8 +37,14 @@ def _post(path: str, body: Mapping[str, Any]) -> str:
     token = _env("FLOX_CONTROL_TOKEN")
     if not token:
         return json.dumps({
-            "error": "FLOX_CONTROL_TOKEN is not set; analytics tools "
-                     "cannot reach the control plane.",
+            "error": ("No flox engine detected. Runtime tools "
+                      "(list_strategies, get_positions, get_pnl, "
+                      "get_event_log, get_strategy_state, get_kill_switch) "
+                      "need a running engine reachable via "
+                      "FLOX_CONTROL_URL + FLOX_CONTROL_TOKEN. If you are "
+                      "exploring the framework without an engine, use "
+                      "docs_search / lookup_symbol / scaffold_strategy / "
+                      "run_backtest instead — those work standalone."),
         }, indent=2)
     headers = {
         "Content-Type": "application/json",

--- a/mcp/flox_mcp/tools/control.py
+++ b/mcp/flox_mcp/tools/control.py
@@ -36,8 +36,13 @@ def _post(path: str, body: Mapping[str, Any]) -> str:
     token = _env("FLOX_CONTROL_TOKEN")
     if not token:
         return json.dumps({
-            "error": "FLOX_CONTROL_TOKEN is not set; flox-mcp cannot "
-                     "reach the control plane without a bearer token.",
+            "error": ("No flox engine detected. Mutating control tools "
+                      "(place_order, cancel_order, cancel_all, "
+                      "flatten_positions, set_kill_switch) need a running "
+                      "engine reachable via FLOX_CONTROL_URL + "
+                      "FLOX_CONTROL_TOKEN. If you are exploring without "
+                      "an engine, use docs_search / lookup_symbol / "
+                      "scaffold_strategy / run_backtest instead."),
         }, indent=2)
 
     headers = {

--- a/mcp/tests/test_no_engine_messages.py
+++ b/mcp/tests/test_no_engine_messages.py
@@ -1,0 +1,35 @@
+"""Tests for the no-engine fallback message in runtime / control tools.
+
+A fresh sandbox without an engine returned a config-error message
+('FLOX_CONTROL_TOKEN is not set'), which made the agent waste turns
+trying to set the env var. The actual situation is "no engine to
+talk to". The new message names the standalone alternatives the
+agent can use.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "mcp"))
+
+from flox_mcp.tools import analytics, control
+
+
+def test_analytics_no_engine_message(monkeypatch):
+    monkeypatch.delenv("FLOX_CONTROL_TOKEN", raising=False)
+    out = analytics.list_strategies()
+    assert "No flox engine detected" in out
+    assert "docs_search" in out
+    assert "scaffold_strategy" in out
+
+
+def test_control_no_engine_message(monkeypatch):
+    monkeypatch.delenv("FLOX_CONTROL_TOKEN", raising=False)
+    out = control.place_order(
+        account="any", symbol=1, side="buy", qty=0.1, dry_run=True,
+    )
+    assert "No flox engine detected" in out
+    # Mutating-tool variant lists the mutating tools, not the read-only ones.
+    assert "place_order" in out


### PR DESCRIPTION
## Summary

Previous message ('FLOX_CONTROL_TOKEN is not set; ... cannot reach the control plane') implied a config issue. The actual situation is "no engine to talk to" — agents wasted turns trying to set the env var, which doesn't help because there is no engine.

The new message names the standalone tools an agent can use without an engine (\`docs_search\`, \`lookup_symbol\`, \`scaffold_strategy\`, \`run_backtest\`).

Applied to both \`analytics._post\` (read tools: list_strategies, get_positions, get_pnl, get_event_log, get_strategy_state, get_kill_switch) and \`control._post\` (mutating tools: place_order, cancel_order, cancel_all, flatten_positions, set_kill_switch).

## Test plan
- [x] \`pytest mcp/tests/test_no_engine_messages.py\` — 2 new tests
- [x] \`pytest mcp/tests/\` — 114 passed
- [x] check-format — green

## MCP impact
- analytics + control tools' no-token error message text changed.
- No tool description / schema change.

T025.