### PR TITLE
mcp: init_project tool — thin wrapper around 

### DIFF
--- a/mcp/flox_mcp/server.py
+++ b/mcp/flox_mcp/server.py
@@ -18,6 +18,7 @@ from .tools import (
     events,
     examples,
     indicators,
+    init_project as init_project_tool,
     lookahead as lookahead_tool,
     lookup,
     positions,
@@ -297,6 +298,49 @@ def build_server() -> Server:
                         },
                     },
                     "required": ["language"],
+                },
+            ),
+            Tool(
+                name="init_project",
+                description=(
+                    "Create a new FLOX project from a bundled template. "
+                    "Thin wrapper around the canonical `flox new` CLI — "
+                    "the CLI stays the source of truth, this tool only "
+                    "makes it discoverable from MCP. Use when the user "
+                    "asks 'set up a new flox project' / 'I want to "
+                    "scaffold a research notebook' / 'start a live "
+                    "trading bot'. Three templates ship with flox-py: "
+                    "`research` (notebook + sample data + main.py), "
+                    "`live` (CCXT broker + dry-run safety harness), "
+                    "`indicator-library` (standalone indicator package "
+                    "with tests). Result includes the CLI output and a "
+                    "Next steps section with `docs_search` queries."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["project_name", "template"],
+                    "properties": {
+                        "project_name": {
+                            "type": "string",
+                            "description":
+                                "Directory name for the new project. "
+                                "Created under `target_dir`. Special "
+                                "characters in the name become snake_case "
+                                "in the bundled `__PROJECT_SLUG__`.",
+                        },
+                        "template": {
+                            "type": "string",
+                            "enum": ["research", "live", "indicator-library"],
+                            "description":
+                                "Template to scaffold from. Required.",
+                        },
+                        "target_dir": {
+                            "type": "string",
+                            "description":
+                                "Parent directory the project is created "
+                                "under. Default: current working dir.",
+                        },
+                    },
                 },
             ),
             Tool(
@@ -905,6 +949,12 @@ def build_server() -> Server:
                     language=arguments.get("language"),
                     kind=arguments.get("kind", "bar-driven"),
                     name=arguments.get("name", "MyStrategy"),
+                )
+            elif name == "init_project":
+                text = init_project_tool.init_project(
+                    project_name=arguments["project_name"],
+                    template=arguments["template"],
+                    target_dir=arguments.get("target_dir", "."),
                 )
             elif name == "docs_search":
                 text = docs_search_tool.docs_search(

--- a/mcp/flox_mcp/tools/init_project.py
+++ b/mcp/flox_mcp/tools/init_project.py
@@ -1,0 +1,98 @@
+"""init_project — thin MCP wrapper around the canonical `flox new` CLI.
+
+This is not a parallel scaffolder. It shells out to `flox new`
+(installed by `flox-py`) and surfaces the exact CLI output. The
+purpose is discoverability: an agent that wants to create a new
+project from MCP shouldn't have to read `flox-new.md` and replicate
+the layout by hand. The CLI stays the source of truth.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+SUPPORTED_TEMPLATES = ("research", "live", "indicator-library")
+
+_NEXT_STEPS = (
+    ('record tape', 'capture market data into a `.floxlog` for the project'),
+    ('project layout', 'where strategy / data / backtest live in the new project'),
+    ('backtest', 'drive a strategy off the recorded data'),
+)
+
+
+def init_project(
+    project_name: str,
+    template: str,
+    target_dir: str = ".",
+) -> str:
+    if not isinstance(project_name, str) or not project_name.strip():
+        return "init_project: `project_name` is required and must be a non-empty string."
+    if template not in SUPPORTED_TEMPLATES:
+        return (
+            f"init_project: unsupported template {template!r}. "
+            f"Supported: {', '.join(SUPPORTED_TEMPLATES)}."
+        )
+    target = Path(target_dir).expanduser()
+    if not target.is_dir():
+        return (
+            f"init_project: `target_dir` does not exist: {target}. "
+            f"Create the directory first or point at an existing one."
+        )
+
+    flox_cli = shutil.which("flox")
+    if flox_cli is None:
+        return (
+            "init_project: `flox` CLI is not on PATH. Install with "
+            "`pip install flox-py` (or `pip install \"flox-mcp[flox]\"`)."
+        )
+
+    # `flox new <name> --template=<t>` creates `<target>/<name>/` and
+    # populates it from the bundled template tree. `--here` is the
+    # in-place flavour but we always use the named-dir form here so
+    # the agent can explicitly control where output lands.
+    cmd = [flox_cli, "new", project_name, f"--template={template}"]
+    try:
+        proc = subprocess.run(
+            cmd, cwd=str(target), capture_output=True, text=True, timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return (
+            "init_project: `flox new` exceeded a 30s timeout. "
+            "This is unexpected for a scaffolder; check whether the "
+            "`flox` CLI is mis-installed."
+        )
+    except Exception as exc:
+        return f"init_project: failed to invoke `flox new`: {type(exc).__name__}: {exc}"
+
+    project_path = target / project_name
+    body_lines = [
+        f"# init_project: {template} / {project_name}",
+        "",
+    ]
+    if proc.returncode != 0:
+        body_lines += [
+            f"`flox new` exited {proc.returncode}.",
+            "",
+            "## stderr",
+            "```",
+            (proc.stderr or "(empty)").strip(),
+            "```",
+        ]
+        if proc.stdout.strip():
+            body_lines += ["", "## stdout", "```", proc.stdout.strip(), "```"]
+        return "\n".join(body_lines)
+
+    if proc.stdout.strip():
+        body_lines += ["## CLI output", "```", proc.stdout.strip(), "```", ""]
+    body_lines += [
+        f"Project created at: `{project_path}`.",
+        "",
+        "## Next steps",
+        "",
+    ]
+    for query, desc in _NEXT_STEPS:
+        body_lines.append(f"- `docs_search(\"{query}\")` — {desc}")
+    return "\n".join(body_lines)

--- a/mcp/tests/test_init_project.py
+++ b/mcp/tests/test_init_project.py
@@ -1,0 +1,58 @@
+"""Tests for the init_project MCP tool — thin wrapper around `flox new`."""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "mcp"))
+
+from flox_mcp.tools import init_project as init_project_tool
+
+
+def test_init_project_rejects_unsupported_template():
+    out = init_project_tool.init_project("my_proj", template="quantum",
+                                          target_dir="/tmp")
+    assert "unsupported template" in out
+
+
+def test_init_project_rejects_empty_name():
+    out = init_project_tool.init_project("", template="research",
+                                          target_dir="/tmp")
+    assert "required" in out
+
+
+def test_init_project_rejects_missing_target_dir(tmp_path):
+    nope = tmp_path / "does_not_exist"
+    out = init_project_tool.init_project("my_proj", template="research",
+                                          target_dir=str(nope))
+    assert "does not exist" in out
+
+
+def test_init_project_reports_missing_cli(monkeypatch, tmp_path):
+    """When `flox` CLI is not on PATH, the tool returns a helpful
+    install hint instead of trying to shell out and failing
+    cryptically."""
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    out = init_project_tool.init_project("my_proj", template="research",
+                                          target_dir=str(tmp_path))
+    assert "not on PATH" in out
+    assert "pip install flox-py" in out
+
+
+@pytest.mark.skipif(
+    shutil.which("flox") is None,
+    reason="needs the `flox` CLI on PATH (install flox-py)",
+)
+def test_init_project_happy_path(tmp_path):
+    out = init_project_tool.init_project("smoke_proj", template="research",
+                                          target_dir=str(tmp_path))
+    assert "init_project: research / smoke_proj" in out
+    assert "Next steps" in out
+    assert 'docs_search("record tape")' in out
+    # Project directory was actually created.
+    assert (tmp_path / "smoke_proj").is_dir()


### PR DESCRIPTION
## Summary

Agents reinvented the project layout from scratch or read flox-new.md and replicated by hand. Neither helps; the canonical scaffolder already exists. This tool surfaces it through MCP without inventing a parallel path.

\`init_project(project_name, template, target_dir=".")\` shells out to \`flox new <name> --template=<t>\` (installed by flox-py). Three templates: research / live / indicator-library. Refuses cleanly when the CLI is missing with an install hint. Result includes the CLI output and a Next steps section with \`docs_search\` queries (record tape / project layout / backtest).

## Test plan
- [x] \`pytest mcp/tests/test_init_project.py\` — 4 passed + 1 skipped (happy-path needs flox CLI on PATH)
- [x] \`pytest mcp/tests/\` — 116 passed
- [x] check-format / check-doc-snippets / sync_mcp_data --check — green

## MCP impact
- New tool \`init_project\` registered in server.py with full Tool() definition + dispatch.
- No bundled-data shape change.
- Description points at \`flox new\` as the underlying CLI so the agent knows the tool is automating the canonical path.

T026.