### PR TITLE
mcp: record_data tool — wrap canonical recording paths

### DIFF
--- a/mcp/flox_mcp/server.py
+++ b/mcp/flox_mcp/server.py
@@ -22,6 +22,7 @@ from .tools import (
     lookahead as lookahead_tool,
     lookup,
     positions,
+    record_data as record_data_tool,
     runtime,
     scaffold,
     strategy,
@@ -339,6 +340,88 @@ def build_server() -> Server:
                             "description":
                                 "Parent directory the project is created "
                                 "under. Default: current working dir.",
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="record_data",
+                description=(
+                    "Capture market data into a `.floxlog` tape. Wraps "
+                    "the canonical recording paths — for `mode=live` "
+                    "shells out to the `flox tape record` CLI; for "
+                    "`mode=historical` shells out to "
+                    "`scripts/backfill_to_tape.py` which uses ccxt's "
+                    "`fetch_ohlcv` / `fetch_trades`. Use this when the "
+                    "user asks to 'record some BTC data' / 'pull a "
+                    "month of klines for backtest' / 'tape the last "
+                    "hour of trades'. The result is a `.floxlog` "
+                    "directory drivable by `BacktestRunner.run_tape`."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["mode", "exchange", "symbol", "out_path"],
+                    "properties": {
+                        "mode": {
+                            "type": "string",
+                            "enum": ["historical", "live"],
+                            "description":
+                                "`historical` = ccxt backfill of past "
+                                "data. `live` = capture from now onwards "
+                                "via `flox tape record`.",
+                        },
+                        "exchange": {
+                            "type": "string",
+                            "description":
+                                "ccxt exchange id (bitget, binance, "
+                                "bybit, ...).",
+                        },
+                        "symbol": {
+                            "type": "string",
+                            "description":
+                                "Symbol in the exchange's spelling "
+                                "(BTC/USDT, BTCUSDT — both accepted).",
+                        },
+                        "out_path": {
+                            "type": "string",
+                            "description":
+                                "Output `.floxlog` directory (will be "
+                                "created if missing).",
+                        },
+                        "data_type": {
+                            "type": "string",
+                            "enum": ["klines", "trades"],
+                            "description":
+                                "Historical mode only. `klines` (1m bars "
+                                "by default) or `trades` (per-print). "
+                                "Trades have higher fidelity but are "
+                                "limited by what each exchange exposes.",
+                        },
+                        "from_dt": {
+                            "type": "string",
+                            "description":
+                                "Historical mode. Start datetime — ISO "
+                                "(2026-04-01) or unix-ms.",
+                        },
+                        "to_dt": {
+                            "type": "string",
+                            "description":
+                                "Historical mode. End datetime — ISO or "
+                                "unix-ms.",
+                        },
+                        "duration": {
+                            "type": "string",
+                            "description":
+                                "Live mode. Recording duration "
+                                "(`1h`, `30m`, `2d`). Omit for an open-"
+                                "ended recording (Ctrl+C to stop).",
+                        },
+                        "max_records": {
+                            "type": "integer",
+                            "description":
+                                "Historical mode. Refuse to start if "
+                                "estimated row count exceeds this. "
+                                "Default 1_000_000.",
                         },
                     },
                 },
@@ -963,6 +1046,18 @@ def build_server() -> Server:
                     project_name=arguments["project_name"],
                     template=arguments["template"],
                     target_dir=arguments.get("target_dir", "."),
+                )
+            elif name == "record_data":
+                text = record_data_tool.record_data(
+                    mode=arguments["mode"],
+                    exchange=arguments["exchange"],
+                    symbol=arguments["symbol"],
+                    out_path=arguments["out_path"],
+                    data_type=arguments.get("data_type", "klines"),
+                    from_dt=arguments.get("from_dt"),
+                    to_dt=arguments.get("to_dt"),
+                    duration=arguments.get("duration"),
+                    max_records=arguments.get("max_records", 1_000_000),
                 )
             elif name == "docs_search":
                 text = docs_search_tool.docs_search(

--- a/mcp/flox_mcp/tools/record_data.py
+++ b/mcp/flox_mcp/tools/record_data.py
@@ -1,0 +1,173 @@
+"""record_data — MCP wrapper around the canonical recording paths.
+
+This is not a parallel recorder. It shells out to the existing
+canonical paths:
+
+- `mode="historical"` → `scripts/backfill_to_tape.py` (ccxt
+  `fetch_ohlcv` / `fetch_trades` writing into a `.floxlog`).
+- `mode="live"` → `flox tape record` CLI from `flox-py`.
+
+Decision was: keep ccxt out of the MCP server itself; only pull it
+in when the user actually invokes a recording. The `backfill_to_tape.py`
+script imports ccxt only when run.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_BACKFILL_SCRIPT = _REPO_ROOT / "scripts" / "backfill_to_tape.py"
+
+SUPPORTED_MODES = ("historical", "live")
+SUPPORTED_TYPES = ("trades", "klines")
+
+
+def record_data(
+    mode: str,
+    exchange: str,
+    symbol: str,
+    out_path: str,
+    *,
+    data_type: str = "klines",
+    from_dt: Optional[str] = None,
+    to_dt: Optional[str] = None,
+    duration: Optional[str] = None,
+    max_records: int = 1_000_000,
+) -> str:
+    if mode not in SUPPORTED_MODES:
+        return (
+            f"record_data: unsupported mode {mode!r}. "
+            f"Supported: {', '.join(SUPPORTED_MODES)}."
+        )
+    if data_type not in SUPPORTED_TYPES:
+        return (
+            f"record_data: unsupported data_type {data_type!r}. "
+            f"Supported: {', '.join(SUPPORTED_TYPES)}."
+        )
+    if not exchange or not symbol or not out_path:
+        return "record_data: `exchange`, `symbol`, and `out_path` are required."
+
+    if mode == "historical":
+        if not from_dt or not to_dt:
+            return ("record_data: historical mode requires both `from_dt` "
+                    "and `to_dt` (ISO date or unix-ms).")
+        return _run_historical(exchange, symbol, data_type, from_dt, to_dt,
+                               out_path, max_records)
+    return _run_live(exchange, symbol, out_path, duration)
+
+
+def _run_historical(exchange: str, symbol: str, data_type: str,
+                    from_dt: str, to_dt: str, out_path: str,
+                    max_records: int) -> str:
+    if not _BACKFILL_SCRIPT.is_file():
+        return (
+            f"record_data: backfill script missing at {_BACKFILL_SCRIPT}. "
+            f"This is a packaging bug — flox-mcp ships with the script."
+        )
+    cmd = [
+        sys.executable, str(_BACKFILL_SCRIPT),
+        "--exchange", exchange,
+        "--symbol", symbol,
+        "--type", data_type,
+        "--from", from_dt,
+        "--to", to_dt,
+        "--out", out_path,
+        "--max-records", str(int(max_records)),
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+    except subprocess.TimeoutExpired:
+        return ("record_data: backfill exceeded the 15-minute wall-clock "
+                "limit. Narrow the time range or split into multiple calls.")
+
+    out = (proc.stdout or "").strip()
+    err = (proc.stderr or "").strip()
+    payload: dict = {}
+    if out:
+        try:
+            payload = json.loads(out.splitlines()[-1])
+        except Exception:
+            payload = {"raw_stdout": out}
+
+    lines = [
+        f"# record_data: historical / {exchange} / {symbol} / {data_type}",
+        "",
+    ]
+    if proc.returncode != 0:
+        lines += [
+            f"`backfill_to_tape.py` exited {proc.returncode}.",
+            "",
+            "## Result",
+            "```json",
+            json.dumps(payload, indent=2)[:2000],
+            "```",
+        ]
+        if err:
+            lines += ["", "## stderr", "```", err[-1000:], "```"]
+        return "\n".join(lines)
+
+    lines += [
+        "## Result",
+        "```json",
+        json.dumps(payload, indent=2),
+        "```",
+        "",
+        "## Next steps",
+        "",
+        f'- `docs_search("backtest")` — drive a strategy off `{out_path}`',
+        f'- `docs_search("record tape")` — extend the tape with more data',
+    ]
+    return "\n".join(lines)
+
+
+def _run_live(exchange: str, symbol: str, out_path: str,
+              duration: Optional[str]) -> str:
+    flox_cli = shutil.which("flox")
+    if flox_cli is None:
+        return ("record_data: `flox` CLI is not on PATH. Install with "
+                "`pip install flox-py`.")
+
+    cmd = [flox_cli, "tape", "record", exchange, symbol, "--output", out_path]
+    if duration:
+        cmd += ["--duration", duration]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=86_400)
+    except subprocess.TimeoutExpired:
+        return ("record_data: live recording hit the 24-hour wall-clock "
+                "ceiling on the worker. Use --duration explicitly for "
+                "longer runs and supervise with the CLI directly.")
+
+    out = (proc.stdout or "").strip()
+    err = (proc.stderr or "").strip()
+    lines = [
+        f"# record_data: live / {exchange} / {symbol}",
+        "",
+    ]
+    if proc.returncode != 0:
+        lines += [
+            f"`flox tape record` exited {proc.returncode}.",
+            "",
+            "## stderr",
+            "```",
+            err[-1500:] or "(empty)",
+            "```",
+        ]
+        return "\n".join(lines)
+
+    lines += [
+        "## CLI output",
+        "```",
+        out[-1500:] or "(empty)",
+        "```",
+        "",
+        "## Next steps",
+        "",
+        f'- `docs_search("backtest")` — drive a strategy off `{out_path}`',
+    ]
+    return "\n".join(lines)

--- a/mcp/tests/test_record_data.py
+++ b/mcp/tests/test_record_data.py
@@ -1,0 +1,93 @@
+"""Tests for the record_data MCP tool — wrapper around the canonical
+recording paths (`flox tape record` / `scripts/backfill_to_tape.py`)."""
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "mcp"))
+
+from flox_mcp.tools import record_data as record_data_tool
+
+
+def test_record_data_rejects_unknown_mode():
+    out = record_data_tool.record_data(
+        mode="quantum", exchange="bitget", symbol="BTC/USDT",
+        out_path="/tmp/x",
+    )
+    assert "unsupported mode" in out
+
+
+def test_record_data_rejects_unknown_data_type():
+    out = record_data_tool.record_data(
+        mode="historical", exchange="bitget", symbol="BTC/USDT",
+        out_path="/tmp/x", data_type="ticks",
+        from_dt="2026-04-01", to_dt="2026-04-02",
+    )
+    assert "unsupported data_type" in out
+
+
+def test_record_data_requires_dates_for_historical():
+    out = record_data_tool.record_data(
+        mode="historical", exchange="bitget", symbol="BTC/USDT",
+        out_path="/tmp/x",
+    )
+    assert "from_dt" in out
+    assert "to_dt" in out
+
+
+def test_record_data_requires_core_args():
+    out = record_data_tool.record_data(
+        mode="historical", exchange="", symbol="BTC/USDT",
+        out_path="/tmp/x",
+    )
+    assert "required" in out
+
+
+def test_record_data_live_reports_missing_cli(monkeypatch):
+    """When `flox` CLI is not on PATH, the live path returns an
+    install hint instead of failing cryptically."""
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    out = record_data_tool.record_data(
+        mode="live", exchange="bitget", symbol="BTC/USDT",
+        out_path="/tmp/x", duration="10s",
+    )
+    assert "not on PATH" in out
+    assert "pip install flox-py" in out
+
+
+def test_record_data_historical_dispatches_to_backfill_script():
+    """Historical mode shells out to scripts/backfill_to_tape.py.
+    Mock subprocess.run to capture the command without actually
+    running ccxt."""
+    import subprocess
+    captured = {}
+
+    class FakeProc:
+        returncode = 3  # cap exceeded
+        stdout = '{"error": "estimated 50000000 records exceeds cap"}'
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    with patch.object(subprocess, "run", fake_run):
+        out = record_data_tool.record_data(
+            mode="historical", exchange="bitget", symbol="BTC/USDT",
+            out_path="/tmp/x", data_type="klines",
+            from_dt="2026-04-01", to_dt="2026-12-01",
+            max_records=1_000,
+        )
+    assert "cmd" in captured
+    cmd = captured["cmd"]
+    assert "scripts/backfill_to_tape.py" in " ".join(cmd)
+    assert "--exchange" in cmd
+    assert "bitget" in cmd
+    # Cap-exceeded surfaced from backfill script.
+    assert "exceeds cap" in out or "exited 3" in out

--- a/scripts/backfill_to_tape.py
+++ b/scripts/backfill_to_tape.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Historical-data backfill into a `.floxlog` tape.
+
+The canonical `flox tape record` CLI captures live data. For
+historical backfill (anything before the recorder was running)
+ccxt's `fetch_ohlcv` / `fetch_trades` paginates depending on the
+exchange. This script wraps that loop and feeds the rows through
+`flox_py.Runner` + `MarketDataRecorderHook` so the result is a
+plain `.floxlog` directory — same format as a live recording.
+
+Usage:
+  python3 scripts/backfill_to_tape.py \\
+      --exchange bitget --symbol BTC/USDT --type klines \\
+      --from 2026-04-01 --to 2026-04-08 \\
+      --out ./tapes/bitget-btc-apr-week-1
+
+Status code:
+  0 — success
+  1 — argument error
+  2 — exchange / network error
+  3 — quota cap exceeded (set --max-records to allow more)
+
+This script is the path the `record_data` MCP tool shells out to.
+Keeping it here (not bundled inside the MCP server) means CCXT is
+only a dependency when the user actually calls it.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime, timezone
+
+
+def _parse_dt(s: str) -> int:
+    """Accept either an ISO-ish date / datetime or a unix-ms integer."""
+    s = s.strip()
+    if s.isdigit():
+        return int(s)
+    fmts = ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d")
+    for fmt in fmts:
+        try:
+            dt = datetime.strptime(s, fmt).replace(tzinfo=timezone.utc)
+            return int(dt.timestamp() * 1000)
+        except ValueError:
+            continue
+    raise ValueError(f"cannot parse timestamp {s!r}")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--exchange", required=True,
+                   help="ccxt exchange id (bitget, binance, bybit, ...)")
+    p.add_argument("--symbol", required=True, help="symbol, e.g. BTC/USDT")
+    p.add_argument("--type", default="klines",
+                   choices=("klines", "trades"),
+                   help="what to fetch — `klines` (1m bars) or `trades`")
+    p.add_argument("--from", dest="from_", required=True,
+                   help="start date / time (ISO or unix-ms)")
+    p.add_argument("--to", required=True,
+                   help="end date / time (ISO or unix-ms)")
+    p.add_argument("--out", required=True,
+                   help="output `.floxlog` directory")
+    p.add_argument("--max-records", type=int, default=1_000_000,
+                   help="refuse to start if estimated records exceed cap")
+    p.add_argument("--timeframe", default="1m",
+                   help="kline timeframe (only used for --type=klines)")
+    args = p.parse_args()
+
+    try:
+        import ccxt  # type: ignore
+    except ImportError:
+        print(json.dumps({
+            "error": "ccxt is not installed. Install with `pip install ccxt`."
+        }))
+        return 2
+
+    try:
+        import flox_py as flox  # type: ignore
+        from flox_py.tape import make_recorder_hook  # type: ignore
+    except ImportError as exc:
+        print(json.dumps({
+            "error": f"flox_py import failed: {exc}. "
+                     f"Install with `pip install flox-py`."
+        }))
+        return 2
+
+    try:
+        from_ms = _parse_dt(args.from_)
+        to_ms = _parse_dt(args.to)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}))
+        return 1
+
+    if to_ms <= from_ms:
+        print(json.dumps({"error": "--to must be greater than --from"}))
+        return 1
+
+    # Cheap pre-flight estimate so the user doesn't burn quota by accident.
+    duration_minutes = (to_ms - from_ms) / 60_000
+    if args.type == "klines":
+        estimated = int(duration_minutes / _timeframe_minutes(args.timeframe))
+    else:
+        # Trades vary wildly; assume 1/sec average. The exchange's actual
+        # rate is whatever it is; this is just a sanity cap.
+        estimated = int((to_ms - from_ms) / 1000)
+    if estimated > args.max_records:
+        print(json.dumps({
+            "error": (f"estimated {estimated} records exceeds --max-records "
+                      f"{args.max_records}. Raise the cap explicitly to proceed.")
+        }))
+        return 3
+
+    ex_class = getattr(ccxt, args.exchange, None)
+    if ex_class is None:
+        print(json.dumps({"error": f"unknown ccxt exchange: {args.exchange}"}))
+        return 1
+    ex = ex_class({"enableRateLimit": True})
+
+    registry = flox.SymbolRegistry()
+    sym = registry.add_symbol(args.exchange,
+                               args.symbol.replace("/", ""), tick_size=0.01)
+    rec = make_recorder_hook(args.out, max_segment_mb=64)
+    runner = flox.Runner(registry, on_signal=lambda s: None)
+    runner.set_market_data_recorder(rec)
+
+    written = 0
+    http_calls = 0
+    cursor = from_ms
+
+    try:
+        if args.type == "klines":
+            while cursor < to_ms:
+                bars = ex.fetch_ohlcv(args.symbol, args.timeframe,
+                                       since=cursor, limit=1000)
+                http_calls += 1
+                if not bars:
+                    break
+                for ts_ms, _o, _h, _l, c, v in bars:
+                    if ts_ms >= to_ms:
+                        break
+                    runner.on_trade(sym, price=float(c), qty=float(v),
+                                    is_buy=True, ts_ns=ts_ms * 1_000_000)
+                    written += 1
+                last_ts = bars[-1][0]
+                if last_ts <= cursor:
+                    break
+                cursor = last_ts + 1
+                time.sleep(ex.rateLimit / 1000)
+        else:
+            while cursor < to_ms:
+                trades = ex.fetch_trades(args.symbol, since=cursor, limit=1000)
+                http_calls += 1
+                if not trades:
+                    break
+                for t in trades:
+                    if t.get("timestamp", 0) >= to_ms:
+                        break
+                    runner.on_trade(sym, price=float(t["price"]),
+                                    qty=float(t["amount"]),
+                                    is_buy=(t.get("side") == "buy"),
+                                    ts_ns=int(t["timestamp"]) * 1_000_000)
+                    written += 1
+                last_ts = trades[-1].get("timestamp", cursor)
+                if last_ts <= cursor:
+                    break
+                cursor = last_ts + 1
+                time.sleep(ex.rateLimit / 1000)
+    except Exception as exc:
+        rec.close()
+        print(json.dumps({
+            "error": f"{type(exc).__name__}: {exc}",
+            "written_records": written,
+            "http_calls_made": http_calls,
+        }))
+        return 2
+
+    rec.close()
+    stats = rec.stats if hasattr(rec, "stats") else {}
+    print(json.dumps({
+        "written_records": written,
+        "http_calls_made": http_calls,
+        "out_path": args.out,
+        "exchange": args.exchange,
+        "symbol": args.symbol,
+        "type": args.type,
+        "from_ms": from_ms,
+        "to_ms": to_ms,
+        "stats": dict(stats) if stats else {},
+    }))
+    return 0
+
+
+def _timeframe_minutes(tf: str) -> float:
+    units = {"m": 1, "h": 60, "d": 1440}
+    if not tf:
+        return 1
+    suffix = tf[-1]
+    n = int(tf[:-1]) if suffix in units else int(tf)
+    return n * units.get(suffix, 1)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

New \`record_data\` MCP tool that wraps the two canonical recording paths instead of inventing a third:

- \`mode=\"live\"\` → shells out to \`flox tape record <exchange> <symbol> --output <path> [--duration ...]\`. Fails with a clean install hint if \`flox\` CLI isn't on PATH.
- \`mode=\"historical\"\` → shells out to a new \`scripts/backfill_to_tape.py\` that wraps \`ccxt.fetch_ohlcv\` / \`fetch_trades\` and writes to a \`.floxlog\` via \`Runner\` + \`MarketDataRecorderHook\`.

ccxt stays out of the MCP server — it's only imported when the user actually invokes a backfill.

## Why this exists

Recording is step 1 of any flox project. Real-session feedback: agents skip the canonical path because the doc-only path costs more tokens than copy-pasting urllib + CSV from training data. T020 originally rejected \`record_data\` as a parallel path. The reconsideration: a tool that **shells out** to the existing CLI / script is not a parallel path — it's automation of the canonical path.

## Backfill cap

\`scripts/backfill_to_tape.py\` enforces \`--max-records\` (default 1M) computed pre-flight from \`(from, to, type, timeframe)\`. Exit code 3 if exceeded — agents can't accidentally burn exchange quota.

## Tests

\`mcp/tests/test_record_data.py\` (6 tests, all pass):
- unsupported mode / data_type rejected
- missing dates for historical rejected
- missing core args rejected
- live mode reports missing CLI cleanly
- historical mode dispatches to \`scripts/backfill_to_tape.py\` with correct argv

\`pytest mcp/tests\` → 129 passed.

## Test plan

- [x] All 6 record_data tests pass
- [x] Full mcp test suite green (129 tests)
- [x] format-check / sync-mcp-data / verify-docs-current locally green
- [ ] CI matrix green

W2-T029