### PR TITLE
mcp: lookup_symbol surfaces curated semantic gotchas

### DIFF
--- a/mcp/flox_mcp/data/gotchas.json
+++ b/mcp/flox_mcp/data/gotchas.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "Curated semantic footguns surfaced by `lookup_symbol`. Keys are matched against the user's input name and against any symbol the lookup resolves to across bindings. Hand-curated; no bulk import. Drift check (scripts/sync_mcp_data.py --check) requires every key to resolve to ≥1 binding.",
+  "Strategy.market_buy": [
+    {
+      "id": "qty-rounds-to-tick-step",
+      "summary": "Quantity is silently rounded down to the symbol's tick step.",
+      "context": "If `qty` is below the symbol's registered tick step (e.g. 0.0001 BTC on a symbol with step 0.001), the engine quantizes to zero and the order is dropped without an event.",
+      "fix": "Use `lookup_symbol` to confirm the symbol's tick step and check `qty >= step` before submission, or scale qty up explicitly.",
+      "discovered": "2026-05-10"
+    }
+  ],
+  "BacktestRunner.run_bars": [
+    {
+      "id": "requires-chronological-bars",
+      "summary": "Bars must be sorted by `start_time_ns` ascending.",
+      "context": "`run_bars` does not re-sort its input. Out-of-order bars are processed in array order, which produces wrong PnL and out-of-order book/aggregate state.",
+      "fix": "Sort bars by `start_time_ns` before calling. The backtest runner intentionally trusts the caller for hot-path reasons.",
+      "discovered": "2026-05-10"
+    }
+  ],
+  "Strategy.symbols": [
+    {
+      "id": "subscribed-only-not-registry",
+      "summary": "Returns subscribed symbols, not every symbol in the registry.",
+      "context": "`Strategy.symbols()` reflects the strategy's own subscription list. Symbols that are in the `SymbolRegistry` but not subscribed to (or filtered out by `subscribed_symbols()`) are absent.",
+      "fix": "If you need the full registry, query `SymbolRegistry` directly. `Strategy.symbols()` is the right answer for 'what is this strategy listening to'.",
+      "discovered": "2026-05-10"
+    }
+  ]
+}

--- a/mcp/flox_mcp/server.py
+++ b/mcp/flox_mcp/server.py
@@ -165,7 +165,11 @@ def build_server() -> Server:
                     "spelling. Accepts any spelling the user knows "
                     "('FloxBarData', 'BarData', 'flox_indicator_ema', 'ema', "
                     "'Ema'). Filter to one language with the `language` arg "
-                    "if the user is writing in a specific binding."
+                    "if the user is writing in a specific binding. "
+                    "When the symbol has hand-curated semantic gotchas "
+                    "(silent quantization, ordering preconditions, "
+                    "subscribed-vs-registry distinctions), they appear "
+                    "under a `## Gotchas` section in the response."
                 ),
                 inputSchema={
                     "type": "object",

--- a/mcp/flox_mcp/tools/_data.py
+++ b/mcp/flox_mcp/tools/_data.py
@@ -53,6 +53,11 @@ def _examples_index_cached(_mtime: float) -> Optional[dict]:
     return _load_json("examples_index.json")
 
 
+@functools.lru_cache(maxsize=1)
+def _gotchas_cached(_mtime: float) -> Optional[dict]:
+    return _load_json("gotchas.json")
+
+
 def _mtime_of(name: str) -> float:
     p = _data_path(name)
     return p.stat().st_mtime if p is not None else 0.0
@@ -68,6 +73,10 @@ def load_binding_manifest() -> Optional[dict]:
 
 def load_examples_index() -> Optional[dict]:
     return _examples_index_cached(_mtime_of("examples_index.json"))
+
+
+def load_gotchas() -> Optional[dict]:
+    return _gotchas_cached(_mtime_of("gotchas.json"))
 
 
 def open_docs_db() -> Optional[sqlite3.Connection]:

--- a/mcp/flox_mcp/tools/lookup.py
+++ b/mcp/flox_mcp/tools/lookup.py
@@ -199,13 +199,18 @@ def lookup_symbol(name: str, language: Optional[str] = None) -> str:
         if qj_match is not None:
             rows.append(("quickjs", qj_match))
 
+    gotchas = _collect_gotchas(name, rows)
+
     if not rows:
-        return (
+        body = (
             f"# lookup_symbol: no match for `{name}`\n\n"
             f"Tried C-API, Python, Node, Codon"
             f"{' (filtered to ' + language + ')' if language else ''}."
             f" Use `list_bindings(language=...)` to browse the surface."
         )
+        if gotchas:
+            body += "\n\n## Gotchas\n\n" + _format_gotchas(gotchas)
+        return body
 
     out = [f"# lookup_symbol: `{name}`", ""]
     out.append("| Binding | Local name | Kind | Signature |")
@@ -217,7 +222,70 @@ def lookup_symbol(name: str, language: Optional[str] = None) -> str:
             f"`{sig}` |" if sig else
             f"| {binding} | `{m.get('name', '')}` | {m.get('kind', '')} |  |"
         )
+
+    if gotchas:
+        out.append("")
+        out.append("## Gotchas")
+        out.append("")
+        out.append(_format_gotchas(gotchas))
     return "\n".join(out)
+
+
+def _format_gotchas(gotchas: List[dict]) -> str:
+    lines = []
+    for g in gotchas:
+        lines.append(f"- **{g['summary']}**")
+        lines.append(f"  - When: {g['context']}")
+        lines.append(f"  - Fix: {g['fix']}")
+    return "\n".join(lines)
+
+
+# ── Gotcha merge ──────────────────────────────────────────────────────
+
+
+def _collect_gotchas(input_name: str,
+                     rows: List[Tuple[str, dict]]) -> List[dict]:
+    """Return any curated gotchas whose key matches the input name or
+    any of the resolved per-binding names. Hand-curated entries live in
+    ``mcp/flox_mcp/data/gotchas.json``."""
+    data = _data.load_gotchas()
+    if not data:
+        return []
+    # Build the candidate-key set: the user's input plus everything we
+    # resolved across bindings. Match is case-sensitive on full key.
+    candidates = {input_name}
+    for _, m in rows:
+        n = m.get("name")
+        if n:
+            candidates.add(n)
+    seen_ids: set[str] = set()
+    out: List[dict] = []
+    for key, entries in data.items():
+        if key.startswith("$"):
+            continue  # schema/comment slot
+        if key not in candidates and not _key_matches_loosely(key, candidates):
+            continue
+        for entry in entries:
+            eid = entry.get("id") or ""
+            if eid in seen_ids:
+                continue
+            seen_ids.add(eid)
+            out.append(entry)
+    return out
+
+
+def _key_matches_loosely(key: str, candidates: set) -> bool:
+    """Allow a gotcha key to match by trailing component too — so a key
+    like ``Strategy.market_buy`` matches a resolved name of just
+    ``market_buy`` (Python) or ``flox_strategy_market_buy`` (C-API).
+    The match is anchored on the last path segment."""
+    tail = key.rsplit(".", 1)[-1]
+    if tail in candidates:
+        return True
+    for c in candidates:
+        if c.endswith("_" + tail) or c.endswith(tail):
+            return True
+    return False
 
 
 # ── list_bindings ─────────────────────────────────────────────────────

--- a/mcp/tests/test_data_artifacts.py
+++ b/mcp/tests/test_data_artifacts.py
@@ -167,6 +167,63 @@ def test_examples_index_entries(examples_index: dict) -> None:
         assert {"path", "language", "topic", "size_bytes", "sha256"} <= ex.keys()
         assert ex["language"] in valid_languages, ex
         assert ex["topic"] in valid_topics, ex
+
+
+# ── gotchas.json ──────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def gotchas() -> dict:
+    path = DATA / "gotchas.json"
+    assert path.exists(), (
+        f"missing {path}; gotchas are hand-curated, see "
+        f"mcp/flox_mcp/data/gotchas.json")
+    return json.loads(path.read_text())
+
+
+def test_gotchas_schema(gotchas: dict) -> None:
+    """Every non-schema entry is a list of dicts with the required
+    fields; ids are unique within a key."""
+    required = {"id", "summary", "context", "fix"}
+    for key, entries in gotchas.items():
+        if key.startswith("$"):
+            continue
+        assert isinstance(entries, list), key
+        assert entries, f"{key}: empty entry list"
+        seen_ids = set()
+        for entry in entries:
+            assert required <= entry.keys(), (key, entry)
+            assert entry["id"] not in seen_ids, f"{key}: duplicate id {entry['id']!r}"
+            seen_ids.add(entry["id"])
+
+
+def test_gotchas_keys_resolve(gotchas: dict, ir_snapshot: dict,
+                              binding_manifest: dict) -> None:
+    """Every gotcha key must resolve through the same loose match the
+    drift check uses. A rename that orphans a key fails this test."""
+    universe: set = set()
+    for kind in ("functions", "structs", "enums", "typedefs"):
+        for item in ir_snapshot.get(kind, []):
+            n = item.get("name")
+            if n:
+                universe.add(n)
+    for bind in binding_manifest.get("bindings", {}).values():
+        for s in bind.get("symbols", []):
+            n = s.get("name")
+            if n:
+                universe.add(n)
+
+    for key in gotchas:
+        if key.startswith("$"):
+            continue
+        if key in universe:
+            continue
+        tail = key.rsplit(".", 1)[-1]
+        if tail in universe:
+            continue
+        if any(n.endswith("_" + tail) or n.endswith(tail) for n in universe):
+            continue
+        pytest.fail(f"gotcha key {key!r} resolves to no symbol")
         assert ex["path"].startswith("docs/examples/"), ex["path"]
         assert (REPO_ROOT / ex["path"]).exists(), (
             f"index points at missing file: {ex['path']}")

--- a/mcp/tests/test_polyglot_tools.py
+++ b/mcp/tests/test_polyglot_tools.py
@@ -77,6 +77,24 @@ def test_lookup_symbol_requires_string():
     assert "required" in out.lower() or "must be" in out.lower()
 
 
+def test_lookup_symbol_attaches_gotcha_when_keyed_input():
+    """A gotcha keyed on `Strategy.market_buy` should attach when the
+    user types `market_buy` — even if the resolver finds no symbol,
+    the curated footgun is the real reason the tool exists for this
+    name."""
+    out = lookup.lookup_symbol("market_buy")
+    assert "Gotchas" in out
+    assert "tick step" in out
+
+
+def test_lookup_symbol_attaches_gotcha_when_resolved():
+    """When the resolver does match (e.g. `Strategy`), gotchas on any
+    member key (`Strategy.symbols`) are still surfaced via tail-segment
+    matching."""
+    out = lookup.lookup_symbol("symbols")
+    assert "subscribed" in out.lower()
+
+
 # ── list_bindings ─────────────────────────────────────────────────────
 
 

--- a/scripts/sync_mcp_data.py
+++ b/scripts/sync_mcp_data.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import io
+import json
 import os
 import sqlite3
 import sys
@@ -65,6 +66,7 @@ DST_IR = DST_DATA / "ir.snapshot.json"
 DST_MANIFEST = DST_DATA / "binding_manifest.json"
 DST_EXAMPLES = DST_DATA / "examples_index.json"
 DST_FTS = DST_DATA / "docs.fts.sqlite"
+DST_GOTCHAS = DST_DATA / "gotchas.json"
 
 # Total bundle budget. The IR snapshot + binding manifest + examples
 # index are tiny (kBs); the FTS index dominates. 10 MB is a soft cap
@@ -256,6 +258,81 @@ def _sync_docs_fts(dst: Path, drifts: List[str], *, check_only: bool) -> None:
     dst.write_bytes(new_bytes)
 
 
+def _validate_gotchas(gotchas_path: Path, ir_json: str,
+                      manifest_json: str) -> List[str]:
+    """Return a list of error strings for any gotcha key that fails to
+    resolve against the IR or any binding manifest.
+
+    The check is intentionally permissive — same loose matching the
+    ``lookup_symbol`` tool does — so an entry keyed on a Python member
+    (``Strategy.market_buy``) does not need to exist verbatim in the
+    C-API IR. The key resolves if any of:
+
+    - exact key in IR functions / structs / enums / typedefs
+    - any key segment matches a binding-local symbol name
+    - last dot-segment matches an IR or binding name (snake-case
+      tolerant: ``market_buy`` matches ``flox_strategy_market_buy``)
+    """
+    if not gotchas_path.exists():
+        return []
+    try:
+        data = json.loads(gotchas_path.read_text())
+    except Exception as exc:
+        return [f"{gotchas_path.relative_to(REPO_ROOT)}: invalid JSON: {exc}"]
+
+    ir = json.loads(ir_json)
+    mf = json.loads(manifest_json)
+
+    ir_names = set()
+    for kind in ("functions", "structs", "enums", "typedefs"):
+        for item in ir.get(kind, []):
+            n = item.get("name")
+            if n:
+                ir_names.add(n)
+
+    binding_names = set()
+    for bind in mf.get("bindings", {}).values():
+        for s in bind.get("symbols", []):
+            n = s.get("name")
+            if n:
+                binding_names.add(n)
+
+    universe = ir_names | binding_names
+    errors: List[str] = []
+
+    for key, entries in data.items():
+        if key.startswith("$"):
+            continue  # schema/comment slot
+        if not isinstance(entries, list):
+            errors.append(f"gotchas.json: {key!r} value must be a list")
+            continue
+        if not _gotcha_key_resolves(key, universe):
+            errors.append(
+                f"gotchas.json: {key!r} resolves to no symbol in IR / any "
+                f"binding manifest. Did the symbol get renamed?"
+            )
+        for i, entry in enumerate(entries):
+            for required in ("id", "summary", "context", "fix"):
+                if required not in entry:
+                    errors.append(
+                        f"gotchas.json: {key!r}[{i}] missing field "
+                        f"{required!r}"
+                    )
+    return errors
+
+
+def _gotcha_key_resolves(key: str, universe: set) -> bool:
+    if key in universe:
+        return True
+    tail = key.rsplit(".", 1)[-1]
+    if tail in universe:
+        return True
+    for n in universe:
+        if n.endswith("_" + tail) or n.endswith(tail):
+            return True
+    return False
+
+
 def _copy_if_different(src: Path, dst: Path, *, check_only: bool) -> bool:
     if not src.exists():
         return True
@@ -312,6 +389,16 @@ def main(argv=None) -> int:
     # 4. Docs FTS5 index — content-equal (row set), not byte-equal.
     _sync_docs_fts(DST_FTS, drifts, check_only=args.check)
 
+    # 4b. gotchas.json — hand-curated, not regenerated. Validate that
+    # every key still resolves to a real symbol; otherwise a rename
+    # silently orphans the entry.
+    gotcha_errors = _validate_gotchas(
+        DST_GOTCHAS,
+        _build_ir_json(),
+        _build_binding_manifest_json(),
+    )
+    drifts.extend(gotcha_errors)
+
     # 5. Bundle budget. Reported (not enforced) on --check; enforced on
     # write so an over-budget commit fails locally before it lands.
     if DST_DATA.exists():
@@ -338,10 +425,16 @@ def main(argv=None) -> int:
         print(f"OK: flox-mcp bundled data in sync.")
     else:
         n_pages = len(src_pages)
+        n_gotchas = sum(
+            len(v) for k, v in
+            (json.loads(DST_GOTCHAS.read_text()) if DST_GOTCHAS.exists() else {}).items()
+            if not k.startswith("$") and isinstance(v, list)
+        )
         print(
             f"synced: c-api.snapshot + {n_pages} error page(s) + "
             f"ir.snapshot.json + binding_manifest.json + "
-            f"examples_index.json + docs.fts.sqlite → "
+            f"examples_index.json + docs.fts.sqlite + "
+            f"{n_gotchas} gotcha(s) → "
             f"{DST_DATA.relative_to(REPO_ROOT)}"
         )
     return 0


### PR DESCRIPTION
## Summary

\`lookup_symbol\` resolves symbols across bindings via type info, but type info can't capture semantic footguns — quantity rounded to tick step, \`run_bars\` requires chronological order, \`Strategy.symbols()\` is subscribed-only, etc. Real-session feedback: agents repeatedly hit these even after \`lookup_symbol\` confirms the spelling.

## Approach

Hand-curated \`mcp/flox_mcp/data/gotchas.json\` keyed on \`Class.member\` (or just \`member\`). The file is intentionally small and grows per-PR — no bulk import. \`lookup_symbol\` merges any matching entries into a \`## Gotchas\` section in the response, with loose tail-segment matching so \`Strategy.market_buy\` attaches to user input \`market_buy\` even when no resolver hit lands.

## Drift check

\`scripts/sync_mcp_data.py --check\` validates that every gotcha key still resolves to a real symbol in the IR or any binding manifest. A rename that orphans a key fails the gate instead of silently going dead.

## Seeded entries

- \`Strategy.market_buy\` — qty silently rounds to tick step
- \`BacktestRunner.run_bars\` — bars must be sorted ascending
- \`Strategy.symbols\` — returns subscribed only, not registry

## Test plan

- [x] 2 new \`test_polyglot_tools.py\` tests (gotcha attaches on input-name match + resolved-name match)
- [x] 2 new \`test_data_artifacts.py\` tests (schema + drift validation)
- [x] Full mcp suite: 127 passed
- [x] \`python3 scripts/sync_mcp_data.py --check\` green
- [ ] CI matrix green

W2-T030