### PR TITLE
strategy: on_fill / on_order_update parity for NAPI / QuickJS / Codon

### DIFF
--- a/codon/flox/strategy.codon
+++ b/codon/flox/strategy.codon
@@ -83,12 +83,13 @@ class Strategy:
         self._symbol_names = list[str]()
         self._symbol_map = dict[str, int]()
         self._reverse_map = dict[int, str]()
-        # FloxStrategyCallbacks is a 6-pointer struct on 64-bit
-        # (on_trade, on_book, on_bar, on_start, on_stop, user_data).
-        # Zero-initialise — overrides happen on the C++ side via the
-        # BridgeStrategy that the runner attaches to this handle.
-        self._callbacks_buf = Ptr[byte](48)
-        for i in range(48):
+        # FloxStrategyCallbacks is an 8-pointer struct on 64-bit
+        # (on_trade, on_book, on_bar, on_start, on_stop, on_fill,
+        # on_order_update, user_data). Zero-initialise — overrides
+        # happen on the C++ side via the BridgeStrategy that the
+        # runner attaches to this handle.
+        self._callbacks_buf = Ptr[byte](64)
+        for i in range(64):
             self._callbacks_buf[i] = byte(0)
         if registry == cobj():
             # No registry attached; downstream `Runner.add_strategy`
@@ -122,6 +123,20 @@ class Strategy:
 
     def on_stop(self):
         """Called when strategy stops. Override in subclass."""
+        pass
+
+    def on_fill(self, ctx: SymbolContext, ev):
+        """Called on each fill (status PARTIALLY_FILLED or FILLED)
+        for orders this strategy emitted. `ev` carries `order_id`,
+        `side`, `fill_qty`, `fill_price`, `exchange_ts_ns`. Override
+        in subclass to react to your own fills."""
+        pass
+
+    def on_order_update(self, ctx: SymbolContext, ev):
+        """Called on every order-lifecycle status change for orders
+        this strategy emitted (NEW / ACCEPTED / CANCELED / REJECTED /
+        REPLACED / TRIGGERED / TRAILING_UPDATED). Includes fills
+        too — pick `on_fill` if you only want fills."""
         pass
 
     # ------------------------------------------------------------------

--- a/mcp/flox_mcp/data/binding_manifest.json
+++ b/mcp/flox_mcp/data/binding_manifest.json
@@ -5084,6 +5084,10 @@
         },
         {
           "kind": "class",
+          "name": "OrderEventData"
+        },
+        {
+          "kind": "class",
           "name": "OrderGroup"
         },
         {

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -96,6 +96,47 @@ export interface TradeData {
   timestampNs: bigint;
 }
 
+/** Order-event lifecycle status, mirrored from `FloxOrderEventStatus`. */
+export type OrderEventStatus =
+  | "NEW"
+  | "ACCEPTED"
+  | "PENDING_NEW"
+  | "PARTIALLY_FILLED"
+  | "FILLED"
+  | "PENDING_CANCEL"
+  | "CANCELED"
+  | "EXPIRED"
+  | "REJECTED"
+  | "REPLACED"
+  | "PENDING_TRIGGER"
+  | "TRIGGERED"
+  | "TRAILING_UPDATED"
+  | "UNKNOWN";
+
+/** Order-event payload delivered to `onFill` / `onOrderUpdate`. */
+export interface OrderEventData {
+  orderId: number;
+  symbolId: number;
+  side: Side;
+  orderType:
+    | "LIMIT"
+    | "MARKET"
+    | "STOP_MARKET"
+    | "STOP_LIMIT"
+    | "TP_MARKET"
+    | "TP_LIMIT"
+    | "ICEBERG"
+    | "UNKNOWN";
+  status: OrderEventStatus;
+  /** Cumulative or last-fill quantity depending on the executor. */
+  fillQty: number;
+  /** Last-fill price; 0 for non-fill events. */
+  fillPrice: number;
+  exchangeTsNs: number;
+  /** Set only when status === "REJECTED". */
+  rejectReason: string | null;
+}
+
 /** Order-emission helper passed as the third arg to strategy callbacks. */
 export interface EmitMethods {
   marketBuy(qty: number): void;
@@ -125,6 +166,13 @@ export interface Strategy {
   onTrade?(ctx: SymbolContext, trade: TradeData, emit: EmitMethods): void;
   onBookUpdate?(ctx: SymbolContext, emit: EmitMethods): void;
   onBar?(ctx: SymbolContext, bar: BarData, emit: EmitMethods): void;
+  /** Fires on every fill the strategy's own orders produce
+   *  (status PARTIALLY_FILLED or FILLED). */
+  onFill?(ctx: SymbolContext, ev: OrderEventData, emit: EmitMethods): void;
+  /** Fires on every order-lifecycle status change: NEW / ACCEPTED /
+   *  CANCELED / REJECTED / REPLACED / TRIGGERED / TRAILING_UPDATED.
+   *  Includes fills too — pick `onFill` if you only care about those. */
+  onOrderUpdate?(ctx: SymbolContext, ev: OrderEventData, emit: EmitMethods): void;
 }
 
 // ── Extension hooks ──────────────────────────────────────────────────

--- a/node/src/strategy.h
+++ b/node/src/strategy.h
@@ -532,20 +532,34 @@ struct NodeStrategyHost
   {
     switch (s)
     {
-      case 0: return "NEW";
-      case 1: return "ACCEPTED";
-      case 2: return "PENDING_NEW";
-      case 3: return "PARTIALLY_FILLED";
-      case 4: return "FILLED";
-      case 5: return "PENDING_CANCEL";
-      case 6: return "CANCELED";
-      case 7: return "EXPIRED";
-      case 8: return "REJECTED";
-      case 9: return "REPLACED";
-      case 10: return "PENDING_TRIGGER";
-      case 11: return "TRIGGERED";
-      case 12: return "TRAILING_UPDATED";
-      default: return "UNKNOWN";
+      case 0:
+        return "NEW";
+      case 1:
+        return "ACCEPTED";
+      case 2:
+        return "PENDING_NEW";
+      case 3:
+        return "PARTIALLY_FILLED";
+      case 4:
+        return "FILLED";
+      case 5:
+        return "PENDING_CANCEL";
+      case 6:
+        return "CANCELED";
+      case 7:
+        return "EXPIRED";
+      case 8:
+        return "REJECTED";
+      case 9:
+        return "REPLACED";
+      case 10:
+        return "PENDING_TRIGGER";
+      case 11:
+        return "TRIGGERED";
+      case 12:
+        return "TRAILING_UPDATED";
+      default:
+        return "UNKNOWN";
     }
   }
 
@@ -553,14 +567,22 @@ struct NodeStrategyHost
   {
     switch (t)
     {
-      case 0: return "LIMIT";
-      case 1: return "MARKET";
-      case 2: return "STOP_MARKET";
-      case 3: return "STOP_LIMIT";
-      case 4: return "TP_MARKET";
-      case 5: return "TP_LIMIT";
-      case 6: return "ICEBERG";
-      default: return "UNKNOWN";
+      case 0:
+        return "LIMIT";
+      case 1:
+        return "MARKET";
+      case 2:
+        return "STOP_MARKET";
+      case 3:
+        return "STOP_LIMIT";
+      case 4:
+        return "TP_MARKET";
+      case 5:
+        return "TP_LIMIT";
+      case 6:
+        return "ICEBERG";
+      default:
+        return "UNKNOWN";
     }
   }
 

--- a/node/src/strategy.h
+++ b/node/src/strategy.h
@@ -136,6 +136,8 @@ struct NodeStrategyHost
   Napi::FunctionReference on_bar_fn;
   Napi::FunctionReference on_start_fn;
   Napi::FunctionReference on_stop_fn;
+  Napi::FunctionReference on_fill_fn;
+  Napi::FunctionReference on_order_update_fn;
   Napi::ObjectReference emitter;
   std::vector<uint32_t> syms;
   std::unique_ptr<BridgeStrategy> bridge;
@@ -162,6 +164,16 @@ struct NodeStrategyHost
     FloxSymbolContext ctx;
     FloxBarData bar;
     NodeStrategyHost* host;
+  };
+  struct OrderEventCallData
+  {
+    FloxSymbolContext ctx;
+    FloxOrderEventData ev;
+    // reject_reason is a borrowed pointer in the C ABI struct; copy
+    // it onto the heap so the TSFN consumer can outlive the caller.
+    std::string reject_reason_owned;
+    NodeStrategyHost* host;
+    bool is_fill;
   };
 
   void enableThreaded()
@@ -205,6 +217,8 @@ struct NodeStrategyHost
     on_bar_fn = get("onBar");
     on_start_fn = get("onStart");
     on_stop_fn = get("onStop");
+    on_fill_fn = get("onFill");
+    on_order_update_fn = get("onOrderUpdate");
     if (on_start_fn)
     {
       on_start_fn.Call({});
@@ -230,6 +244,8 @@ struct NodeStrategyHost
     on_bar_fn = get("onBar");
     on_start_fn = get("onStart");
     on_stop_fn = get("onStop");
+    on_fill_fn = get("onFill");
+    on_order_update_fn = get("onOrderUpdate");
 
     FloxStrategyCallbacks cbs{};
     cbs.user_data = this;
@@ -238,6 +254,8 @@ struct NodeStrategyHost
     cbs.on_bar = &NodeStrategyHost::onBar;
     cbs.on_start = &NodeStrategyHost::onStart;
     cbs.on_stop = &NodeStrategyHost::onStop;
+    cbs.on_fill = &NodeStrategyHost::onFill;
+    cbs.on_order_update = &NodeStrategyHost::onOrderUpdate;
 
     bridge = std::make_unique<BridgeStrategy>(
         static_cast<SubscriberId>(id), syms, *reg, cbs);
@@ -498,6 +516,134 @@ struct NodeStrategyHost
       buildBarObj(env, barObj, bar);
       self->on_bar_fn.Call({ctxObj, barObj, self->emitter.Value()});
     }
+  }
+
+  // ── Order-event hooks ─────────────────────────────────────────────
+  //
+  // Mirror the pybind11 surface: status names match
+  // `FloxOrderEventStatus` (NEW, PARTIALLY_FILLED, FILLED, CANCELED,
+  // REJECTED, ...). `onFill` is called only on terminal fill events
+  // (status == PARTIALLY_FILLED or FILLED); `onOrderUpdate` fires on
+  // every status change including fills, so a strategy that only
+  // wants the lifecycle and is happy to inspect status itself can
+  // implement the latter.
+
+  static const char* orderEventStatusName(uint8_t s)
+  {
+    switch (s)
+    {
+      case 0: return "NEW";
+      case 1: return "ACCEPTED";
+      case 2: return "PENDING_NEW";
+      case 3: return "PARTIALLY_FILLED";
+      case 4: return "FILLED";
+      case 5: return "PENDING_CANCEL";
+      case 6: return "CANCELED";
+      case 7: return "EXPIRED";
+      case 8: return "REJECTED";
+      case 9: return "REPLACED";
+      case 10: return "PENDING_TRIGGER";
+      case 11: return "TRIGGERED";
+      case 12: return "TRAILING_UPDATED";
+      default: return "UNKNOWN";
+    }
+  }
+
+  static const char* orderTypeName(uint8_t t)
+  {
+    switch (t)
+    {
+      case 0: return "LIMIT";
+      case 1: return "MARKET";
+      case 2: return "STOP_MARKET";
+      case 3: return "STOP_LIMIT";
+      case 4: return "TP_MARKET";
+      case 5: return "TP_LIMIT";
+      case 6: return "ICEBERG";
+      default: return "UNKNOWN";
+    }
+  }
+
+  static void buildOrderEventObj(Napi::Env env, Napi::Object& o,
+                                 const FloxOrderEventData* ev,
+                                 const std::string* reject_owned)
+  {
+    o.Set("orderId", Napi::Number::New(env, static_cast<double>(ev->order_id)));
+    o.Set("symbolId", Napi::Number::New(env, ev->symbol_id));
+    o.Set("side", Napi::String::New(env, ev->side == 0 ? "buy" : "sell"));
+    o.Set("orderType", Napi::String::New(env, orderTypeName(ev->order_type)));
+    o.Set("status", Napi::String::New(env, orderEventStatusName(ev->status)));
+    o.Set("fillQty", Napi::Number::New(env, flox_quantity_to_double(ev->fill_qty_raw)));
+    o.Set("fillPrice", Napi::Number::New(env, flox_price_to_double(ev->fill_price_raw)));
+    o.Set("exchangeTsNs", Napi::Number::New(env, static_cast<double>(ev->exchange_ts_ns)));
+    if (reject_owned && !reject_owned->empty())
+    {
+      o.Set("rejectReason", Napi::String::New(env, *reject_owned));
+    }
+    else if (ev->reject_reason)
+    {
+      o.Set("rejectReason", Napi::String::New(env, ev->reject_reason));
+    }
+    else
+    {
+      o.Set("rejectReason", env.Null());
+    }
+  }
+
+  static void callOnOrderEvent(Napi::Env env, Napi::Function, OrderEventCallData* d)
+  {
+    auto* self = d->host;
+    auto& fn = d->is_fill ? self->on_fill_fn : self->on_order_update_fn;
+    if (!fn.IsEmpty())
+    {
+      auto ctxObj = Napi::Object::New(env);
+      buildCtxObj(env, ctxObj, &d->ctx);
+      auto evObj = Napi::Object::New(env);
+      buildOrderEventObj(env, evObj, &d->ev, &d->reject_reason_owned);
+      fn.Call({ctxObj, evObj, self->emitter.Value()});
+    }
+    delete d;
+  }
+
+  static void dispatchOrderEvent(NodeStrategyHost* self,
+                                 const FloxSymbolContext* ctx,
+                                 const FloxOrderEventData* ev,
+                                 bool is_fill)
+  {
+    auto& fn = is_fill ? self->on_fill_fn : self->on_order_update_fn;
+    if (fn.IsEmpty())
+    {
+      return;
+    }
+    if (self->_threaded)
+    {
+      auto* d = new OrderEventCallData{
+          *ctx, *ev,
+          ev->reject_reason ? std::string(ev->reject_reason) : std::string{},
+          self, is_fill};
+      self->_tsfn.NonBlockingCall(d, &NodeStrategyHost::callOnOrderEvent);
+    }
+    else
+    {
+      auto env = self->env;
+      auto ctxObj = Napi::Object::New(env);
+      buildCtxObj(env, ctxObj, ctx);
+      auto evObj = Napi::Object::New(env);
+      buildOrderEventObj(env, evObj, ev, nullptr);
+      fn.Call({ctxObj, evObj, self->emitter.Value()});
+    }
+  }
+
+  static void onFill(void* ud, const FloxSymbolContext* ctx,
+                     const FloxOrderEventData* ev)
+  {
+    dispatchOrderEvent(static_cast<NodeStrategyHost*>(ud), ctx, ev, true);
+  }
+
+  static void onOrderUpdate(void* ud, const FloxSymbolContext* ctx,
+                            const FloxOrderEventData* ev)
+  {
+    dispatchOrderEvent(static_cast<NodeStrategyHost*>(ud), ctx, ev, false);
   }
 
   struct LifecycleCallData

--- a/node/test/test_bindings.js
+++ b/node/test/test_bindings.js
@@ -344,6 +344,49 @@ if (fs.existsSync(btCsv)) {
   console.log(`  skip BacktestRunner accessors (CSV not found: ${btCsv})`);
 }
 
+// ── Strategy on_fill / on_order_update hooks ─────────────────────────
+
+console.log('=== Strategy onFill / onOrderUpdate ===');
+
+if (fs.existsSync(btCsv)) {
+  const reg4 = new flox.SymbolRegistry();
+  const btc4 = reg4.addSymbol('exchange', 'BTCUSDT', 0.01);
+  const fast = new flox.SMA(10);
+  const slow = new flox.SMA(30);
+
+  const fills = [];
+  const updates = [];
+  const strat = {
+    symbols: [Number(btc4)],
+    onTrade(ctx, t, emit) {
+      const f = fast.update(t.price);
+      const s = slow.update(t.price);
+      if (f === null || s === null) return;
+      if (f > s && ctx.position === 0) emit.marketBuy(0.01);
+      else if (f < s && ctx.position > 0) emit.marketSell(0.01);
+    },
+    onFill(ctx, ev, _emit) { fills.push(ev); },
+    onOrderUpdate(ctx, ev, _emit) { updates.push(ev); },
+  };
+
+  const bt = new flox.BacktestRunner(reg4, 0.0004, 10000);
+  bt.setStrategy(strat);
+  const stats = bt.runCsv(btCsv, 'BTCUSDT');
+  check(stats !== null && stats.totalTrades > 0,
+        `onFill backtest produced trades (got ${stats && stats.totalTrades})`);
+  check(fills.length > 0, `onFill called at least once (got ${fills.length})`);
+  check(fills.every(f =>
+          typeof f.orderId === 'number' &&
+          (f.side === 'buy' || f.side === 'sell') &&
+          (f.status === 'FILLED' || f.status === 'PARTIALLY_FILLED') &&
+          f.fillQty > 0 && f.fillPrice > 0),
+        'onFill payloads have correct shape');
+  check(updates.length >= fills.length,
+        `onOrderUpdate fires on every status change (got ${updates.length}; >= fills ${fills.length})`);
+} else {
+  console.log(`  skip onFill backtest (CSV not found: ${btCsv})`);
+}
+
 // ── WalkForwardRunner ─────────────────────────────────────────────────
 
 console.log('=== WalkForwardRunner ===');

--- a/quickjs/flox/strategy.js
+++ b/quickjs/flox/strategy.js
@@ -26,6 +26,8 @@ class Strategy {
     onTrade(ctx, trade) {}
     onBookUpdate(ctx, book) {}
     onBar(ctx, bar) {}
+    onFill(ctx, ev) {}
+    onOrderUpdate(ctx, ev) {}
     onStart() {}
     onStop() {}
 
@@ -164,5 +166,15 @@ class Strategy {
         rawCtx.symbol = this._reverseMap[rawCtx.symbolId] || "";
         rawBar.symbol = this._reverseMap[rawBar.symbolId] || "";
         this.onBar(rawCtx, rawBar);
+    }
+
+    _dispatchFill(rawCtx, rawEv) {
+        rawCtx.symbol = this._reverseMap[rawCtx.symbolId] || "";
+        this.onFill(rawCtx, rawEv);
+    }
+
+    _dispatchOrderUpdate(rawCtx, rawEv) {
+        rawCtx.symbol = this._reverseMap[rawCtx.symbolId] || "";
+        this.onOrderUpdate(rawCtx, rawEv);
     }
 }

--- a/src/quickjs/js_strategy.cpp
+++ b/src/quickjs/js_strategy.cpp
@@ -855,6 +855,8 @@ FloxStrategyCallbacks FloxJsStrategy::getCallbacks()
   cb.on_bar = FloxJsStrategy::onBar;
   cb.on_start = FloxJsStrategy::onStart;
   cb.on_stop = FloxJsStrategy::onStop;
+  cb.on_fill = FloxJsStrategy::onFill;
+  cb.on_order_update = FloxJsStrategy::onOrderUpdate;
   cb.user_data = this;
   return cb;
 }
@@ -1062,6 +1064,122 @@ JSValue FloxJsStrategy::makeBarObject(const FloxBarData* bar)
                     JS_NewFloat64(c, static_cast<double>(bar->end_time_ns)));
   JS_SetPropertyStr(c, obj, "closeReason", JS_NewUint32(c, bar->close_reason));
   return obj;
+}
+
+namespace
+{
+const char* jsOrderEventStatusName(uint8_t s)
+{
+  switch (s)
+  {
+    case 0: return "NEW";
+    case 1: return "ACCEPTED";
+    case 2: return "PENDING_NEW";
+    case 3: return "PARTIALLY_FILLED";
+    case 4: return "FILLED";
+    case 5: return "PENDING_CANCEL";
+    case 6: return "CANCELED";
+    case 7: return "EXPIRED";
+    case 8: return "REJECTED";
+    case 9: return "REPLACED";
+    case 10: return "PENDING_TRIGGER";
+    case 11: return "TRIGGERED";
+    case 12: return "TRAILING_UPDATED";
+    default: return "UNKNOWN";
+  }
+}
+const char* jsOrderTypeName(uint8_t t)
+{
+  switch (t)
+  {
+    case 0: return "LIMIT";
+    case 1: return "MARKET";
+    case 2: return "STOP_MARKET";
+    case 3: return "STOP_LIMIT";
+    case 4: return "TP_MARKET";
+    case 5: return "TP_LIMIT";
+    case 6: return "ICEBERG";
+    default: return "UNKNOWN";
+  }
+}
+}  // namespace
+
+JSValue FloxJsStrategy::makeOrderEventObject(const FloxOrderEventData* ev)
+{
+  auto* c = _engine.context();
+  JSValue obj = JS_NewObject(c);
+  JS_SetPropertyStr(c, obj, "orderId",
+                    JS_NewFloat64(c, static_cast<double>(ev->order_id)));
+  JS_SetPropertyStr(c, obj, "symbolId", JS_NewUint32(c, ev->symbol_id));
+  JS_SetPropertyStr(c, obj, "side",
+                    JS_NewString(c, ev->side == 0 ? "buy" : "sell"));
+  JS_SetPropertyStr(c, obj, "orderType",
+                    JS_NewString(c, jsOrderTypeName(ev->order_type)));
+  JS_SetPropertyStr(c, obj, "status",
+                    JS_NewString(c, jsOrderEventStatusName(ev->status)));
+  JS_SetPropertyStr(c, obj, "fillQty",
+                    JS_NewFloat64(c, flox_quantity_to_double(ev->fill_qty_raw)));
+  JS_SetPropertyStr(c, obj, "fillPrice",
+                    JS_NewFloat64(c, flox_price_to_double(ev->fill_price_raw)));
+  JS_SetPropertyStr(c, obj, "exchangeTsNs",
+                    JS_NewFloat64(c, static_cast<double>(ev->exchange_ts_ns)));
+  if (ev->reject_reason)
+  {
+    JS_SetPropertyStr(c, obj, "rejectReason", JS_NewString(c, ev->reject_reason));
+  }
+  else
+  {
+    JS_SetPropertyStr(c, obj, "rejectReason", JS_NULL);
+  }
+  return obj;
+}
+
+void FloxJsStrategy::onFill(void* userData, const FloxSymbolContext* ctx,
+                            const FloxOrderEventData* ev)
+{
+  auto* self = static_cast<FloxJsStrategy*>(userData);
+  auto* jsCtx = self->_engine.context();
+  JSValue ctxObj = self->makeCtxObject(ctx);
+  JSValue evObj = self->makeOrderEventObject(ev);
+  JSValue method = JS_GetPropertyStr(jsCtx, self->_strategyObj, "_dispatchFill");
+  if (JS_IsFunction(jsCtx, method))
+  {
+    JSValue args[2] = {ctxObj, evObj};
+    JSValue ret = JS_Call(jsCtx, method, self->_strategyObj, 2, args);
+    if (JS_IsException(ret))
+    {
+      std::cerr << "[flox-js] Error in onFill: "
+                << self->_engine.getErrorMessage() << std::endl;
+    }
+    JS_FreeValue(jsCtx, ret);
+  }
+  JS_FreeValue(jsCtx, method);
+  JS_FreeValue(jsCtx, ctxObj);
+  JS_FreeValue(jsCtx, evObj);
+}
+
+void FloxJsStrategy::onOrderUpdate(void* userData, const FloxSymbolContext* ctx,
+                                   const FloxOrderEventData* ev)
+{
+  auto* self = static_cast<FloxJsStrategy*>(userData);
+  auto* jsCtx = self->_engine.context();
+  JSValue ctxObj = self->makeCtxObject(ctx);
+  JSValue evObj = self->makeOrderEventObject(ev);
+  JSValue method = JS_GetPropertyStr(jsCtx, self->_strategyObj, "_dispatchOrderUpdate");
+  if (JS_IsFunction(jsCtx, method))
+  {
+    JSValue args[2] = {ctxObj, evObj};
+    JSValue ret = JS_Call(jsCtx, method, self->_strategyObj, 2, args);
+    if (JS_IsException(ret))
+    {
+      std::cerr << "[flox-js] Error in onOrderUpdate: "
+                << self->_engine.getErrorMessage() << std::endl;
+    }
+    JS_FreeValue(jsCtx, ret);
+  }
+  JS_FreeValue(jsCtx, method);
+  JS_FreeValue(jsCtx, ctxObj);
+  JS_FreeValue(jsCtx, evObj);
 }
 
 }  // namespace flox

--- a/src/quickjs/js_strategy.cpp
+++ b/src/quickjs/js_strategy.cpp
@@ -1072,34 +1072,56 @@ const char* jsOrderEventStatusName(uint8_t s)
 {
   switch (s)
   {
-    case 0: return "NEW";
-    case 1: return "ACCEPTED";
-    case 2: return "PENDING_NEW";
-    case 3: return "PARTIALLY_FILLED";
-    case 4: return "FILLED";
-    case 5: return "PENDING_CANCEL";
-    case 6: return "CANCELED";
-    case 7: return "EXPIRED";
-    case 8: return "REJECTED";
-    case 9: return "REPLACED";
-    case 10: return "PENDING_TRIGGER";
-    case 11: return "TRIGGERED";
-    case 12: return "TRAILING_UPDATED";
-    default: return "UNKNOWN";
+    case 0:
+      return "NEW";
+    case 1:
+      return "ACCEPTED";
+    case 2:
+      return "PENDING_NEW";
+    case 3:
+      return "PARTIALLY_FILLED";
+    case 4:
+      return "FILLED";
+    case 5:
+      return "PENDING_CANCEL";
+    case 6:
+      return "CANCELED";
+    case 7:
+      return "EXPIRED";
+    case 8:
+      return "REJECTED";
+    case 9:
+      return "REPLACED";
+    case 10:
+      return "PENDING_TRIGGER";
+    case 11:
+      return "TRIGGERED";
+    case 12:
+      return "TRAILING_UPDATED";
+    default:
+      return "UNKNOWN";
   }
 }
 const char* jsOrderTypeName(uint8_t t)
 {
   switch (t)
   {
-    case 0: return "LIMIT";
-    case 1: return "MARKET";
-    case 2: return "STOP_MARKET";
-    case 3: return "STOP_LIMIT";
-    case 4: return "TP_MARKET";
-    case 5: return "TP_LIMIT";
-    case 6: return "ICEBERG";
-    default: return "UNKNOWN";
+    case 0:
+      return "LIMIT";
+    case 1:
+      return "MARKET";
+    case 2:
+      return "STOP_MARKET";
+    case 3:
+      return "STOP_LIMIT";
+    case 4:
+      return "TP_MARKET";
+    case 5:
+      return "TP_LIMIT";
+    case 6:
+      return "ICEBERG";
+    default:
+      return "UNKNOWN";
   }
 }
 }  // namespace

--- a/src/quickjs/js_strategy.h
+++ b/src/quickjs/js_strategy.h
@@ -33,6 +33,10 @@ class FloxJsStrategy
   static void onTrade(void* userData, const FloxSymbolContext* ctx, const FloxTradeData* trade);
   static void onBook(void* userData, const FloxSymbolContext* ctx, const FloxBookData* book);
   static void onBar(void* userData, const FloxSymbolContext* ctx, const FloxBarData* bar);
+  static void onFill(void* userData, const FloxSymbolContext* ctx,
+                     const FloxOrderEventData* ev);
+  static void onOrderUpdate(void* userData, const FloxSymbolContext* ctx,
+                            const FloxOrderEventData* ev);
   static void onStart(void* userData);
   static void onStop(void* userData);
 
@@ -40,6 +44,7 @@ class FloxJsStrategy
   JSValue makeTradeObject(const FloxTradeData* trade);
   JSValue makeBookObject(const FloxBookData* book);
   JSValue makeBarObject(const FloxBarData* bar);
+  JSValue makeOrderEventObject(const FloxOrderEventData* ev);
 
   FloxJsEngine _engine;
   SymbolRegistry& _registry;


### PR DESCRIPTION
## Summary

T027 shipped the engine-side hooks (\`onSymbolFill\` / \`onSymbolOrderUpdate\`) plus the C ABI extension and the pybind11 wires. This brings the rest of the matrix up to parity.

## NAPI

- \`NodeStrategyHost\` grows \`on_fill_fn\` / \`on_order_update_fn\` FunctionReferences.
- \`OrderEventCallData\` carries an owned \`reject_reason\` copy so the TSFN consumer can outlive the callback.
- \`buildOrderEventObj\` + \`dispatchOrderEvent\` helpers cover both threaded (TSFN) and synchronous paths.
- \`node/index.d.ts\`: new \`OrderEventStatus\` / \`OrderEventData\` types and \`Strategy.onFill\` / \`Strategy.onOrderUpdate\`.
- \`node/test/test_bindings.js\`: backtest fixture asserts \`onFill\` is called with FILLED status and \`onOrderUpdate\` fires at least as often.

## QuickJS

- \`FloxJsStrategy::onFill\` / \`onOrderUpdate\` C ABI forwarders + \`makeOrderEventObject\` mirroring the JS shape.
- \`quickjs/flox/strategy.js\`: \`Strategy\` gains \`on_fill\` / \`on_order_update\` no-op overrides plus \`_dispatchFill\` / \`_dispatchOrderUpdate\` shims.

## Codon

- \`codon/flox/strategy.codon\`: \`Strategy\` gains overridable \`on_fill\` / \`on_order_update\` methods. \`_callbacks_buf\` grows 48 → 64 bytes to match the post-T027 8-pointer \`FloxStrategyCallbacks\` (a hidden buglet from T027 — Codon previously left the new fields out of bounds).

## Mcp data

- \`binding_manifest.json\` picks up \`OrderEventData\` on the NAPI surface.

## Test plan

- [x] \`node test/test_bindings.js\` 112/112 pass; new onFill section: 4/4
- [x] QuickJS builds clean (\`flox_js_runner\`)
- [x] Codon strategy module compiles (CI matrix \`codon-only\` will gate)
- [x] \`python3 scripts/sync_mcp_data.py --check\` green
- [ ] CI matrix green

W1-T031