### PR TITLE
backtest: BacktestRunner.runTape — NAPI / Codon parity

### DIFF
--- a/codon/flox/runner.codon
+++ b/codon/flox/runner.codon
@@ -62,6 +62,7 @@ from C import flox_backtest_runner_destroy(cobj)
 from C import flox_backtest_runner_set_strategy(cobj, cobj)
 from C import flox_backtest_runner_run_csv(cobj, cobj, cobj, Ptr[i64]) -> i32
 from C import flox_backtest_runner_run_ohlcv(cobj, Ptr[i64], Ptr[float], u32, cobj, Ptr[i64]) -> i32
+from C import flox_backtest_runner_run_tape(cobj, cobj, Ptr[i64]) -> i32
 from C import flox_backtest_runner_run_bars(cobj, Ptr[i64], Ptr[i64],
                                               Ptr[float], Ptr[float], Ptr[float],
                                               Ptr[float], Ptr[float],
@@ -337,6 +338,19 @@ class BacktestRunner:
             self._handle, path.c_str(), symbol.c_str(), buf.arr.ptr)
         if ok == i32(0):
             raise ValueError(f"BacktestRunner.run_csv failed: {path}")
+        return self._parse_stats(buf)
+
+    def run_tape(self, path: str) -> BacktestStats:
+        """Replay a `.floxlog` tape directory through the backtest.
+        The tape is the canonical recording format written by
+        `flox tape record` (live) or `scripts/backfill_to_tape.py`
+        (historical). Strategy.on_trade fires for each recorded
+        event; on_bar does not."""
+        buf = [i64(0)] * 29
+        ok = flox_backtest_runner_run_tape(
+            self._handle, path.c_str(), buf.arr.ptr)
+        if ok == i32(0):
+            raise ValueError(f"BacktestRunner.run_tape failed: {path}")
         return self._parse_stats(buf)
 
     def run_ohlcv(self, timestamps: List[int], closes: List[float],

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -573,6 +573,10 @@ export class BacktestRunner {
   setStrategy(strategy: Strategy): void;
   runCsv(path: string, symbol: string): BacktestStats;
   runOhlcv(timestamps: Float64Array, closes: Float64Array, symbol: string): BacktestStats;
+  /** Replay a `.floxlog` tape directory through the backtest. The tape
+   *  is the canonical recording format written by `flox tape record`
+   *  (live) or `scripts/backfill_to_tape.py` (historical). */
+  runTape(path: string): BacktestStats;
   /** Replace the built-in SimulatedExecutor with a binding-supplied one. */
   setExecutor(executor: Executor | null): void;
   /** Attach a listener for order lifecycle events. Multiple listeners

--- a/node/src/strategy.h
+++ b/node/src/strategy.h
@@ -1116,6 +1116,7 @@ class BacktestRunnerNode : public Napi::ObjectWrap<BacktestRunnerNode>
             InstanceMethod("runCsv", &BacktestRunnerNode::runCsv),
             InstanceMethod("runOhlcv", &BacktestRunnerNode::runOhlcv),
             InstanceMethod("runBars", &BacktestRunnerNode::runBars),
+            InstanceMethod("runTape", &BacktestRunnerNode::runTape),
             InstanceMethod("setExecutor", &BacktestRunnerNode::setExecutor),
             InstanceMethod("addExecutionListener", &BacktestRunnerNode::addExecutionListener),
             InstanceMethod("equityCurve", &BacktestRunnerNode::equityCurve),
@@ -1165,6 +1166,24 @@ class BacktestRunnerNode : public Napi::ObjectWrap<BacktestRunnerNode>
     flox_backtest_runner_set_strategy(_handle,
                                       static_cast<FloxStrategyHandle>(_host->bridge.get()));
     return env.Undefined();
+  }
+
+  // runner.runTape(path) → stats object. `path` is a `.floxlog`
+  // directory written by `flox tape record` or `scripts/backfill_to_tape.py`.
+  Napi::Value runTape(const Napi::CallbackInfo& info)
+  {
+    return tryFlox(info.Env(),
+                   [&]() -> Napi::Value
+                   {
+                     std::string path = info[0].As<Napi::String>().Utf8Value();
+                     FloxBacktestStats s{};
+                     int ok = flox_backtest_runner_run_tape(_handle, path.c_str(), &s);
+                     if (!ok)
+                     {
+                       return info.Env().Null();
+                     }
+                     return statsToJs(info.Env(), s);
+                   });
   }
 
   // runner.runCsv(path, symbol) → stats object

--- a/node/test/test_bindings.js
+++ b/node/test/test_bindings.js
@@ -344,6 +344,31 @@ if (fs.existsSync(btCsv)) {
   console.log(`  skip BacktestRunner accessors (CSV not found: ${btCsv})`);
 }
 
+// ── BacktestRunner.runTape (parity proof) ────────────────────────────
+
+console.log('=== BacktestRunner.runTape ===');
+
+{
+  const reg = new flox.SymbolRegistry();
+  reg.addSymbol('exchange', 'BTCUSDT', 0.01);
+  const bt = new flox.BacktestRunner(reg, 0.0004, 10000);
+  bt.setStrategy({
+    symbols: [],
+    onTrade(_ctx, _t, _emit) {},
+  });
+  check(typeof bt.runTape === 'function',
+        'BacktestRunner.runTape is a function');
+
+  // Missing-path case: per the existing runCsv pattern, the C ABI
+  // returns null when the underlying call fails. (Some fail modes
+  // raise FloxError instead — accept either.)
+  let result = 'pending';
+  try { result = bt.runTape('/__nonexistent_tape_path__'); }
+  catch (_) { result = 'threw'; }
+  check(result === null || result === 'threw',
+        `runTape signals failure on missing tape (got ${JSON.stringify(result)})`);
+}
+
 // ── Strategy on_fill / on_order_update hooks ─────────────────────────
 
 console.log('=== Strategy onFill / onOrderUpdate ===');


### PR DESCRIPTION
## Summary

T028 shipped \`runTape\` on the C++ engine, the pybind11 binding, and the C ABI export. This brings NAPI and Codon up to parity.

## NAPI

- \`BacktestRunnerNode::runTape(path)\` — thin wrapper around \`flox_backtest_runner_run_tape\` via \`tryFlox\`.
- \`node/index.d.ts\`: \`BacktestRunner.runTape\` declaration.
- \`node/test/test_bindings.js\`: parity proof — \`runTape\` exists as a function and signals failure on a missing tape path (returns null per the \`runCsv\` convention; accepts FloxError fallback).

## Codon

- \`flox.BacktestRunner.run_tape(path)\` — imports the C ABI export and feeds the same \`_parse_stats\` buffer used by \`run_csv\` / \`run_ohlcv\`.

## QuickJS

Intentionally out of scope: the QuickJS surface uses \`Engine.run(SignalBuilder)\`, not \`BacktestRunner\`. Adding \`runTape\` there needs a separate task to wire the runner shape first.

## Test plan

- [x] \`node test/test_bindings.js\` 110/110 pass; new runTape section 2/2
- [x] Codon module compiles (CI matrix \`codon-only\` will gate)
- [ ] CI matrix green

W1-T032