### PR TITLE
mcp: tier-4 read tools fail-graceful when no runtime snapshot

### DIFF
--- a/mcp/flox_mcp/server.py
+++ b/mcp/flox_mcp/server.py
@@ -611,7 +611,12 @@ def build_server() -> Server:
                     "symbol_name, qty, avg_price, unrealized_pnl}, ...]}. "
                     "Snapshot path is FLOX_RUNTIME_STATE env var or the "
                     "passed `state_path`; the user app is responsible for "
-                    "writing the snapshot. Read-only — never modifies state."
+                    "writing the snapshot. When no engine has written a "
+                    "snapshot yet, returns "
+                    "{engine: 'not_running', data: [], hint: ...} instead "
+                    "of an error — that's a normal pre-engine state, not "
+                    "a problem to surface to the user. Read-only — never "
+                    "modifies state."
                 ),
                 inputSchema={
                     "type": "object",
@@ -640,7 +645,9 @@ def build_server() -> Server:
                     "Read in-flight orders from the runtime state snapshot. "
                     "Use this for 'what orders are pending' / 'do I have "
                     "anything sitting on Bybit'. Optional substring filter "
-                    "matches against symbol_name or strategy. Read-only."
+                    "matches against symbol_name or strategy. Returns the "
+                    "engine_not_running idle response when no snapshot is "
+                    "present yet (no error). Read-only."
                 ),
                 inputSchema={
                     "type": "object",
@@ -665,7 +672,9 @@ def build_server() -> Server:
                     "Read PnL totals plus per-strategy breakdown from the "
                     "runtime state snapshot. Use this for 'what's my PnL' / "
                     "'how is strategy X doing today'. Returns realized + "
-                    "unrealized + fees per strategy. Read-only."
+                    "unrealized + fees per strategy. Returns the "
+                    "engine_not_running idle response when no snapshot is "
+                    "present yet (no error). Read-only."
                 ),
                 inputSchema={
                     "type": "object",
@@ -691,7 +700,10 @@ def build_server() -> Server:
                     "Read kill-switch state from the runtime state snapshot. "
                     "Returns {active, reason, since_ns}. Use this for 'is "
                     "trading halted' / 'why was the kill switch tripped'. "
-                    "Read-only — to flip the switch use set_kill_switch."
+                    "When no engine has written a snapshot, returns the "
+                    "idle response with active=false (there is no live "
+                    "trading to halt). Read-only — to flip the switch "
+                    "use set_kill_switch."
                 ),
                 inputSchema={
                     "type": "object",

--- a/mcp/flox_mcp/tools/positions.py
+++ b/mcp/flox_mcp/tools/positions.py
@@ -23,6 +23,15 @@ _DEFAULT_STATE_PATH = "/tmp/flox-runtime-state.json"
 _SUPPORTED_SCHEMA_VERSIONS = {1}
 
 
+class _NoSnapshot(Exception):
+    """Raised when the runtime snapshot file is absent or empty.
+
+    Distinct from the corrupt-snapshot case: this is a normal state
+    ('no engine attached yet') and the read-only tools translate it
+    into an idle response instead of an error.
+    """
+
+
 def _resolve_path(state_path: Optional[str]) -> Path:
     if state_path:
         return Path(state_path).expanduser()
@@ -35,13 +44,16 @@ def _resolve_path(state_path: Optional[str]) -> Path:
 def _load_state(state_path: Optional[str]) -> Dict[str, Any]:
     p = _resolve_path(state_path)
     if not p.exists():
-        raise FileNotFoundError(
-            f"runtime state snapshot not found at {p}. "
-            f"Set FLOX_RUNTIME_STATE or have your app write a snapshot. "
-            f"See docs/reference/runtime-state-schema.md."
-        )
-    with p.open("r") as fh:
-        data = json.load(fh)
+        raise _NoSnapshot(str(p))
+    raw = p.read_text()
+    if not raw.strip():
+        # Empty file is the same shape of "engine hasn't written yet"
+        # as a missing file — treat it the same way.
+        raise _NoSnapshot(str(p))
+    # Past this point any failure is a real bug — corrupt JSON or a
+    # schema mismatch is something the user wants to see, not have
+    # silently masked.
+    data = json.loads(raw)
     if not isinstance(data, dict):
         raise ValueError(f"runtime state at {p} is not a JSON object")
     version = data.get("schema_version")
@@ -52,6 +64,26 @@ def _load_state(state_path: Optional[str]) -> Dict[str, Any]:
             f"{sorted(_SUPPORTED_SCHEMA_VERSIONS)})"
         )
     return data
+
+
+def _idle_payload(reason: str, data: Any) -> str:
+    """Idle response shape for the 'no snapshot yet' state.
+
+    The agent gets a structured 'engine not running' marker plus an
+    actionable hint, rather than a stack trace. Read-only tools all
+    funnel through this so the response shape is consistent.
+    """
+    return json.dumps({
+        "engine": "not_running",
+        "reason": reason,
+        "snapshot_age_ms": None,
+        "data": data,
+        "hint": (
+            "No engine has written a runtime snapshot yet. Start one "
+            "with `flox engine sim --strategy s.py` (W2-T035), or "
+            "point FLOX_RUNTIME_STATE at an existing snapshot file."
+        ),
+    }, indent=2, sort_keys=True)
 
 
 def _snapshot_age_ms(state: Dict[str, Any]) -> Optional[int]:
@@ -87,11 +119,17 @@ def get_positions(
     """Return positions matching account / strategy filters.
 
     Filters are AND-ed. Both default to None (no filter). Returns a
-    JSON object ``{"snapshot_age_ms": int|None, "data": [{...}, ...]}``.
+    JSON object ``{"snapshot_age_ms": int|None, "data": [{...}, ...]}``
+    when an engine snapshot is present, or an
+    ``{"engine": "not_running", "data": [], "hint": ...}`` shape when
+    no snapshot has been written yet (no error — this is a normal
+    pre-engine state).
     """
     try:
         state = _load_state(state_path)
-    except (FileNotFoundError, ValueError) as exc:
+    except _NoSnapshot as exc:
+        return _idle_payload(f"no runtime snapshot at {exc}", [])
+    except ValueError as exc:
         return _format_error(str(exc))
     rows = state.get("positions") or []
     if account is not None:
@@ -109,7 +147,9 @@ def get_open_orders(
     match against ``symbol_name`` or ``strategy``."""
     try:
         state = _load_state(state_path)
-    except (FileNotFoundError, ValueError) as exc:
+    except _NoSnapshot as exc:
+        return _idle_payload(f"no runtime snapshot at {exc}", [])
+    except ValueError as exc:
         return _format_error(str(exc))
     rows: List[Dict[str, Any]] = state.get("open_orders") or []
     if filter:
@@ -135,7 +175,12 @@ def get_pnl(
     or a separate read path."""
     try:
         state = _load_state(state_path)
-    except (FileNotFoundError, ValueError) as exc:
+    except _NoSnapshot as exc:
+        return _idle_payload(
+            f"no runtime snapshot at {exc}",
+            {"by_strategy": [], "total": {}},
+        )
+    except ValueError as exc:
         return _format_error(str(exc))
     pnl = state.get("pnl") or {}
     by_strategy = pnl.get("by_strategy") or []
@@ -152,7 +197,12 @@ def get_kill_switch(state_path: Optional[str] = None) -> str:
     str|None, "since_ns": int|None}``."""
     try:
         state = _load_state(state_path)
-    except (FileNotFoundError, ValueError) as exc:
+    except _NoSnapshot as exc:
+        return _idle_payload(
+            f"no runtime snapshot at {exc}",
+            {"active": False, "reason": None, "since_ns": None},
+        )
+    except ValueError as exc:
         return _format_error(str(exc))
     ks = state.get("kill_switch") or {"active": False, "reason": None, "since_ns": None}
     return _format_payload(state, ks)

--- a/mcp/tests/test_positions.py
+++ b/mcp/tests/test_positions.py
@@ -118,25 +118,53 @@ class GetPositionsTests(_SnapshotTestCase):
             account="bybit-prod", strategy="kijun", state_path=self.path))
         self.assertEqual(out["data"], [])
 
-    def test_missing_snapshot_returns_error(self) -> None:
+    def test_missing_snapshot_returns_idle_response(self) -> None:
+        """No snapshot is a normal state — return an
+        engine_not_running marker, not an error. This is what makes
+        the state_daemon.py workaround unnecessary."""
         out = json.loads(positions.get_positions(
             state_path="/no/such/file.json"))
-        self.assertIn("error", out)
-        self.assertIn("not found", out["error"])
+        self.assertEqual(out["engine"], "not_running")
+        self.assertEqual(out["data"], [])
+        self.assertNotIn("error", out)
+        self.assertIn("flox engine sim", out["hint"])
+
+    def test_empty_snapshot_file_returns_idle_response(self) -> None:
+        """An empty file is the same shape of 'engine hasn't written
+        yet' as a missing file."""
+        with tempfile.NamedTemporaryFile(
+                "w", suffix=".json", delete=False) as f:
+            empty = f.name
+        try:
+            out = json.loads(positions.get_positions(state_path=empty))
+            self.assertEqual(out["engine"], "not_running")
+            self.assertEqual(out["data"], [])
+        finally:
+            os.unlink(empty)
 
     def test_unsupported_schema_version_returns_error(self) -> None:
+        """Corrupt-snapshot signals must keep failing loud — masking
+        them would hide engine corruption."""
         bad = _sample_state()
         bad["schema_version"] = 999
         self._write(bad)
         out = json.loads(positions.get_positions(state_path=self.path))
         self.assertIn("error", out)
         self.assertIn("schema_version", out["error"])
+        # Definitely not the idle path.
+        self.assertNotIn("engine", out)
 
 
 class GetOpenOrdersTests(_SnapshotTestCase):
     def test_no_filter_returns_all(self) -> None:
         out = json.loads(positions.get_open_orders(state_path=self.path))
         self.assertEqual(len(out["data"]), 1)
+
+    def test_missing_snapshot_returns_idle(self) -> None:
+        out = json.loads(positions.get_open_orders(
+            state_path="/no/such/file.json"))
+        self.assertEqual(out["engine"], "not_running")
+        self.assertEqual(out["data"], [])
 
     def test_filter_substring_on_symbol(self) -> None:
         out = json.loads(positions.get_open_orders(
@@ -158,6 +186,11 @@ class GetPnlTests(_SnapshotTestCase):
         self.assertEqual(out["data"]["total"]["realized"], 1184.56)
         self.assertEqual(len(out["data"]["by_strategy"]), 2)
 
+    def test_missing_snapshot_returns_idle(self) -> None:
+        out = json.loads(positions.get_pnl(state_path="/no/such/file.json"))
+        self.assertEqual(out["engine"], "not_running")
+        self.assertEqual(out["data"], {"by_strategy": [], "total": {}})
+
     def test_strategy_filter_narrows_breakdown(self) -> None:
         out = json.loads(positions.get_pnl(
             strategy="ema-trend", state_path=self.path))
@@ -171,6 +204,14 @@ class GetPnlTests(_SnapshotTestCase):
 class GetKillSwitchTests(_SnapshotTestCase):
     def test_inactive_returns_active_false(self) -> None:
         out = json.loads(positions.get_kill_switch(state_path=self.path))
+        self.assertFalse(out["data"]["active"])
+
+    def test_missing_snapshot_returns_idle_inactive(self) -> None:
+        """Defaulting to active=false when there is no engine is
+        the right answer: there is no live trading to halt."""
+        out = json.loads(positions.get_kill_switch(
+            state_path="/no/such/file.json"))
+        self.assertEqual(out["engine"], "not_running")
         self.assertFalse(out["data"]["active"])
 
     def test_active_returns_reason_and_since(self) -> None:


### PR DESCRIPTION
## Summary

Real-session feedback (#14): the position / pnl / orders / kill-switch family raised \`FileNotFoundError\` on a missing snapshot, so every fresh sandbox needed a separate \`state_daemon.py\` writing empty stubs just to make the read tools answerable. \"No engine attached yet\" is a normal first-second-of-the-session state, not an error.

## Approach

Distinguish \`no snapshot\` from \`snapshot is broken\`:

- Missing file OR empty file → structured idle response \`{engine: \"not_running\", data: <empty-shape>, hint: ...}\`.
- Valid JSON + supported schema → unchanged (data + \`snapshot_age_ms\`).
- Corrupt JSON OR schema mismatch → still error. Masking those would hide engine corruption.

Tool descriptions in \`server.py\` advertise the idle shape so the agent treats it as a normal pre-engine state, not a problem to surface.

## Why this matters

- Eliminates the \`state_daemon.py\` workaround for read-only tools.
- Read tools become useful from t=0 of any session. \"Is anything running?\" gets a real answer immediately.
- T035 (\`flox engine sim\`) will subsume the writer side cleanly because tier-4 no longer needs a placeholder file.

## Test plan

- [x] 137/137 mcp tests pass
- [x] New idle-response coverage for \`get_positions\`, \`get_open_orders\`, \`get_pnl\`, \`get_kill_switch\`
- [x] Empty-file case covered (same shape as missing file)
- [x] Schema-mismatch / corrupt-JSON path still asserts an error
- [x] \`scripts/sync_mcp_data.py --check\` green
- [ ] CI matrix green

W2-T033