### PR TITLE
mcp: `flox-mcp init` — bootstrap .mcp.json in one command

### DIFF
--- a/mcp/flox_mcp/cli.py
+++ b/mcp/flox_mcp/cli.py
@@ -1,0 +1,187 @@
+"""``flox-mcp`` console-script entry point with subcommands.
+
+Two verbs:
+
+* ``flox-mcp serve`` — start the MCP server over stdio. This is the
+  same behaviour the bare ``flox-mcp`` invocation has always had,
+  preserved for back-compat (and because that's what MCP clients
+  invoke directly).
+* ``flox-mcp init`` — write a working ``.mcp.json`` for the current
+  shell environment so users do not hand-craft the JSON.
+
+Bare ``flox-mcp`` (no args) keeps invoking ``serve`` for back-compat
+with existing MCP client configurations.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# ── init ──────────────────────────────────────────────────────────────
+
+
+_DEFAULT_RUNTIME_STATE = "$HOME/.flox/runtime.json"
+
+
+def _resolve_command() -> List[str]:
+    """Pick the most portable form of 'launch the flox-mcp server'.
+
+    Prefer the installed console script (`flox-mcp serve`) — it
+    works from any active Python regardless of which interpreter the
+    MCP client launches. Fall back to `python -m flox_mcp.server`
+    when the script is not yet on PATH (e.g. an editable install in
+    a venv whose ``bin/`` is not exported)."""
+    bin_path = shutil.which("flox-mcp")
+    if bin_path:
+        return [bin_path, "serve"]
+    return [sys.executable, "-m", "flox_mcp.server"]
+
+
+def _build_flox_entry(engine_url: Optional[str],
+                      token: Optional[str]) -> Dict[str, Any]:
+    cmd = _resolve_command()
+    env: Dict[str, str] = {
+        "FLOX_RUNTIME_STATE": _DEFAULT_RUNTIME_STATE,
+    }
+    if engine_url:
+        env["FLOX_CONTROL_URL"] = engine_url
+    if token:
+        env["FLOX_CONTROL_TOKEN"] = token
+    return {
+        "command": cmd[0],
+        "args": cmd[1:],
+        "env": env,
+    }
+
+
+def _global_config_path() -> Path:
+    """Where MCP clients look for a global server config.
+
+    Claude Code reads ``~/.config/claude/.mcp.json`` on POSIX and
+    Claude Desktop reads a platform-specific path. We standardise on
+    the POSIX location; users with the Desktop client can pass an
+    explicit path via the upcoming ``--out`` flag (out of scope for
+    the v1 init).
+    """
+    return Path(os.environ.get("XDG_CONFIG_HOME", "~/.config")).expanduser() \
+        / "claude" / ".mcp.json"
+
+
+def _local_config_path() -> Path:
+    return Path.cwd() / ".mcp.json"
+
+
+def _read_existing(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"flox-mcp init: existing {path} is not valid JSON ({exc}). "
+            f"Fix or remove it before running init."
+        )
+
+
+def _render(config: Dict[str, Any]) -> str:
+    return json.dumps(config, indent=2, sort_keys=True) + "\n"
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    target = _global_config_path() if args.global_ else _local_config_path()
+
+    flox_entry = _build_flox_entry(args.engine_url, args.token)
+    new_config: Dict[str, Any] = _read_existing(target) if not args.print else {}
+    new_config.setdefault("mcpServers", {})
+
+    if "flox" in new_config["mcpServers"] and not args.overwrite \
+            and not args.print:
+        print(
+            f"flox-mcp init: {target} already has an `mcpServers.flox` "
+            f"entry. Re-run with --overwrite to replace it.",
+            file=sys.stderr,
+        )
+        return 2
+    new_config["mcpServers"]["flox"] = flox_entry
+
+    rendered = _render(new_config)
+    if args.print:
+        sys.stdout.write(rendered)
+        return 0
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(rendered)
+    print(f"wrote {target}")
+    print("restart your MCP client to pick up the flox server.")
+    return 0
+
+
+# ── dispatcher ────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """``flox-mcp`` console-script entry point.
+
+    Bare ``flox-mcp`` (no subcommand) still launches the server, so
+    existing MCP-client configurations keep working. ``init`` is the
+    new bootstrap path.
+    """
+    raw = sys.argv[1:] if argv is None else list(argv)
+
+    # Back-compat: bare invocation = serve. That's what every MCP
+    # client config in the wild does.
+    if not raw or raw[0] not in ("init", "serve"):
+        from flox_mcp.server import main as serve_main
+        return serve_main() or 0
+
+    p = argparse.ArgumentParser(prog="flox-mcp")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    init_p = sub.add_parser(
+        "init",
+        help="Write a working .mcp.json for the current environment.",
+    )
+    init_p.add_argument(
+        "--global", dest="global_", action="store_true",
+        help="Write to the user-global config (~/.config/claude/.mcp.json) "
+             "instead of ./.mcp.json.",
+    )
+    init_p.add_argument(
+        "--overwrite", action="store_true",
+        help="Replace an existing mcpServers.flox entry instead of "
+             "refusing.",
+    )
+    init_p.add_argument(
+        "--print", action="store_true",
+        help="Print the merged config to stdout, write nothing.",
+    )
+    init_p.add_argument(
+        "--engine-url",
+        help="Wire tier-5/6 control tools at this engine URL "
+             "(sets FLOX_CONTROL_URL). Pair with --token.",
+    )
+    init_p.add_argument(
+        "--token",
+        help="ControlServer token (sets FLOX_CONTROL_TOKEN). The "
+             "token is printed by `flox engine sim` (W2-T035).",
+    )
+
+    sub.add_parser("serve", help="Start the MCP server over stdio.")
+
+    args = p.parse_args(raw)
+    if args.cmd == "init":
+        return cmd_init(args)
+    if args.cmd == "serve":
+        from flox_mcp.server import main as serve_main
+        return serve_main() or 0
+    return 0  # pragma: no cover
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -32,7 +32,7 @@ flox = ["flox-py>=0.5"]
 dev = ["pytest>=7"]
 
 [project.scripts]
-flox-mcp = "flox_mcp.server:main"
+flox-mcp = "flox_mcp.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/FLOX-Foundation/flox"

--- a/mcp/tests/test_cli_init.py
+++ b/mcp/tests/test_cli_init.py
@@ -1,0 +1,173 @@
+"""Tests for ``flox-mcp init`` — the .mcp.json bootstrap path."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "mcp"))
+
+from flox_mcp import cli  # noqa: E402
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    """Build the argparse Namespace cli.cmd_init expects."""
+    defaults = dict(
+        global_=False, overwrite=False, print=False,
+        engine_url=None, token=None,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class CliInitTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="flox-mcp-init-")
+        self.cwd_before = os.getcwd()
+        os.chdir(self.tmp)
+
+    def tearDown(self) -> None:
+        os.chdir(self.cwd_before)
+        # Best-effort cleanup; tmp dirs from mkdtemp are not auto-removed.
+        for child in Path(self.tmp).rglob("*"):
+            if child.is_file():
+                child.unlink()
+        for child in sorted(Path(self.tmp).rglob("*"), reverse=True):
+            if child.is_dir():
+                child.rmdir()
+        Path(self.tmp).rmdir()
+
+    def test_writes_local_mcp_json(self) -> None:
+        rc = cli.cmd_init(_ns())
+        self.assertEqual(rc, 0)
+
+        path = Path(self.tmp) / ".mcp.json"
+        self.assertTrue(path.exists())
+        cfg = json.loads(path.read_text())
+        self.assertIn("flox", cfg["mcpServers"])
+        flox = cfg["mcpServers"]["flox"]
+        self.assertIn("command", flox)
+        self.assertIn("args", flox)
+        # Default env var so tier-4 read tools find a snapshot path.
+        self.assertEqual(
+            flox["env"]["FLOX_RUNTIME_STATE"],
+            "$HOME/.flox/runtime.json",
+        )
+        # No engine wiring unless explicitly requested.
+        self.assertNotIn("FLOX_CONTROL_URL", flox["env"])
+        self.assertNotIn("FLOX_CONTROL_TOKEN", flox["env"])
+
+    def test_engine_url_and_token_wire_tier56(self) -> None:
+        rc = cli.cmd_init(_ns(
+            engine_url="http://127.0.0.1:8765", token="secret"))
+        self.assertEqual(rc, 0)
+        flox = json.loads(
+            (Path(self.tmp) / ".mcp.json").read_text())["mcpServers"]["flox"]
+        self.assertEqual(flox["env"]["FLOX_CONTROL_URL"],
+                         "http://127.0.0.1:8765")
+        self.assertEqual(flox["env"]["FLOX_CONTROL_TOKEN"], "secret")
+
+    def test_merges_into_existing_other_servers(self) -> None:
+        existing = {
+            "mcpServers": {
+                "other": {"command": "/usr/bin/other", "args": []},
+            },
+        }
+        target = Path(self.tmp) / ".mcp.json"
+        target.write_text(json.dumps(existing))
+
+        rc = cli.cmd_init(_ns())
+        self.assertEqual(rc, 0)
+        merged = json.loads(target.read_text())["mcpServers"]
+        # Existing entry preserved untouched.
+        self.assertEqual(merged["other"], existing["mcpServers"]["other"])
+        # New flox entry added.
+        self.assertIn("flox", merged)
+
+    def test_refuses_to_overwrite_existing_flox_entry(self) -> None:
+        existing = {"mcpServers": {"flox": {"command": "old", "args": []}}}
+        target = Path(self.tmp) / ".mcp.json"
+        target.write_text(json.dumps(existing))
+
+        rc = cli.cmd_init(_ns())
+        self.assertEqual(rc, 2)
+        # File untouched.
+        self.assertEqual(json.loads(target.read_text()), existing)
+
+    def test_overwrite_flag_replaces_existing_entry(self) -> None:
+        existing = {"mcpServers": {"flox": {"command": "old", "args": []}}}
+        target = Path(self.tmp) / ".mcp.json"
+        target.write_text(json.dumps(existing))
+
+        rc = cli.cmd_init(_ns(overwrite=True))
+        self.assertEqual(rc, 0)
+        cfg = json.loads(target.read_text())
+        self.assertNotEqual(cfg["mcpServers"]["flox"]["command"], "old")
+
+    def test_print_does_not_write(self) -> None:
+        target = Path(self.tmp) / ".mcp.json"
+        # Capture stdout.
+        from io import StringIO
+        buf = StringIO()
+        with patch.object(sys, "stdout", buf):
+            rc = cli.cmd_init(_ns(print=True))
+        self.assertEqual(rc, 0)
+        self.assertFalse(target.exists())
+        cfg = json.loads(buf.getvalue())
+        self.assertIn("flox", cfg["mcpServers"])
+
+    def test_corrupt_existing_file_is_a_clear_error(self) -> None:
+        target = Path(self.tmp) / ".mcp.json"
+        target.write_text("{ this is not valid json }")
+        with self.assertRaises(SystemExit) as ctx:
+            cli.cmd_init(_ns())
+        self.assertIn("not valid JSON", str(ctx.exception))
+
+
+class DispatcherTests(unittest.TestCase):
+    """The `flox-mcp` entry point preserves back-compat: bare invocation
+    must still launch the server, because that's what every MCP-client
+    config in the wild calls.
+
+    These tests stub out the real ``flox_mcp.server`` module so they
+    don't require the optional ``mcp`` dependency to be installed.
+    """
+
+    def setUp(self) -> None:
+        import types
+        self._real_server = sys.modules.get("flox_mcp.server")
+        stub = types.ModuleType("flox_mcp.server")
+        stub.main = lambda: 0  # type: ignore[attr-defined]
+        sys.modules["flox_mcp.server"] = stub
+
+    def tearDown(self) -> None:
+        if self._real_server is None:
+            sys.modules.pop("flox_mcp.server", None)
+        else:
+            sys.modules["flox_mcp.server"] = self._real_server
+
+    def test_no_args_calls_server_main(self) -> None:
+        with patch.object(
+                sys.modules["flox_mcp.server"], "main",
+                return_value=0) as mock_serve:
+            rc = cli.main([])
+        self.assertEqual(rc, 0)
+        mock_serve.assert_called_once()
+
+    def test_serve_subcommand_calls_server_main(self) -> None:
+        with patch.object(
+                sys.modules["flox_mcp.server"], "main",
+                return_value=0) as mock_serve:
+            rc = cli.main(["serve"])
+        self.assertEqual(rc, 0)
+        mock_serve.assert_called_once()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Real-session feedback (#13): every user wrote \`.mcp.json\` by hand, remembering absolute venv paths, env vars (\`FLOX_RUNTIME_STATE\`, \`FLOX_CONTROL_URL\`, \`FLOX_CONTROL_TOKEN\`), and the right \`command\`/\`args\`. Trivially wrong if the venv path differs. Replaces the 7-step setup with \`pip install flox-mcp && flox-mcp init\`.

## Dispatcher

\`flox-mcp\` becomes a sub-command dispatcher:

| invocation | behaviour |
|---|---|
| \`flox-mcp\` | back-compat: launches server (every MCP-client config in the wild calls this) |
| \`flox-mcp serve\` | explicit form |
| \`flox-mcp init\` | write a working .mcp.json |

## \`init\` flags

| flag | purpose |
|---|---|
| \`--global\` | write to \`~/.config/claude/.mcp.json\` instead of \`./.mcp.json\` |
| \`--overwrite\` | replace an existing \`mcpServers.flox\` entry |
| \`--print\` | print merged config to stdout, write nothing |
| \`--engine-url URL\` | set \`FLOX_CONTROL_URL\` (tier-5/6 wiring) |
| \`--token TOKEN\` | set \`FLOX_CONTROL_TOKEN\` |

## Defaults

- **Merge mode** is the default. Existing entries on other servers are preserved untouched. Refuses to clobber an existing \`flox\` entry without \`--overwrite\` — loud failure beats silent loss of custom env.
- **Command resolution** prefers an installed \`flox-mcp\` console script (works from any active Python regardless of which interpreter the MCP client launches) and falls back to \`python -m flox_mcp.server\` in editable-install dev environments.
- **\`FLOX_RUNTIME_STATE\`** defaults to \`\$HOME/.flox/runtime.json\` so the T033 idle-response path picks up the configured location without the user touching the env var.

Bare \`flox-mcp\` invocation still launches the server, so existing MCP-client configs in the wild keep working without edits.

## Test plan

- [x] 9 new tests in \`test_cli_init.py\` cover merge / overwrite / print / engine-wiring / corrupt-existing-file / back-compat dispatcher
- [x] Full mcp suite: 142 pass
- [x] \`scripts/sync_mcp_data.py --check\` green
- [ ] CI matrix green

W2-T034