### PR TITLE
backtest: BacktestRunner hooks cross-binding parity (NAPI / Codon)

### DIFF
--- a/codon/flox/runner.codon
+++ b/codon/flox/runner.codon
@@ -63,6 +63,10 @@ from C import flox_backtest_runner_set_strategy(cobj, cobj)
 from C import flox_backtest_runner_run_csv(cobj, cobj, cobj, Ptr[i64]) -> i32
 from C import flox_backtest_runner_run_ohlcv(cobj, Ptr[i64], Ptr[float], u32, cobj, Ptr[i64]) -> i32
 from C import flox_backtest_runner_run_tape(cobj, cobj, Ptr[i64]) -> i32
+from C import flox_backtest_runner_set_risk_manager(cobj, cobj)
+from C import flox_backtest_runner_set_kill_switch(cobj, cobj)
+from C import flox_backtest_runner_set_order_validator(cobj, cobj)
+from C import flox_backtest_runner_set_pnl_tracker(cobj, cobj)
 from C import flox_backtest_runner_run_bars(cobj, Ptr[i64], Ptr[i64],
                                               Ptr[float], Ptr[float], Ptr[float],
                                               Ptr[float], Ptr[float],
@@ -352,6 +356,29 @@ class BacktestRunner:
         if ok == i32(0):
             raise ValueError(f"BacktestRunner.run_tape failed: {path}")
         return self._parse_stats(buf)
+
+    # Pre-trade gate parity with the live Runner (W1-T036/T037).
+    # Each setter takes a FloxXxxHandle (opaque cobj) created via the
+    # corresponding `flox_xxx_create` C ABI helper. Pass `cobj()` to
+    # detach. Reduce-only orders bypass the gate by design.
+
+    def set_risk_manager(self, rm: cobj):
+        """Attach (or detach with `cobj()`) a pre-trade risk manager."""
+        flox_backtest_runner_set_risk_manager(self._handle, rm)
+
+    def set_kill_switch(self, ks: cobj):
+        """Attach (or detach with `cobj()`) a kill switch. Reduce-only
+        orders bypass so tightening caps does not strand a position."""
+        flox_backtest_runner_set_kill_switch(self._handle, ks)
+
+    def set_order_validator(self, ov: cobj):
+        """Attach (or detach with `cobj()`) an order validator."""
+        flox_backtest_runner_set_order_validator(self._handle, ov)
+
+    def set_pnl_tracker(self, tracker: cobj):
+        """Attach (or detach with `cobj()`) a PnL tracker. Fires on
+        every fill the simulator dispatches."""
+        flox_backtest_runner_set_pnl_tracker(self._handle, tracker)
 
     def run_ohlcv(self, timestamps: List[int], closes: List[float],
                   symbol: str) -> BacktestStats:

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -582,6 +582,13 @@ export class BacktestRunner {
   /** Attach a listener for order lifecycle events. Multiple listeners
    *  may be attached; each fires for every order event. */
   addExecutionListener(listener: ExecutionListener): void;
+  /** Pre-trade gate parity with the live `Runner`. Reduce-only orders
+   *  bypass the gate by design — when caps tighten you must still be
+   *  able to flatten. Pass `null` to detach. */
+  setRiskManager(rm: RiskManager | null): void;
+  setKillSwitch(ks: KillSwitch | null): void;
+  setOrderValidator(ov: OrderValidator | null): void;
+  setPnlTracker(tracker: PnLTracker | null): void;
   /** Equity curve from the most recent run. Throws FloxError(E_RUN_002)
    *  if no run has completed. */
   equityCurve(): EquityCurve;

--- a/node/src/strategy.h
+++ b/node/src/strategy.h
@@ -1119,6 +1119,12 @@ class BacktestRunnerNode : public Napi::ObjectWrap<BacktestRunnerNode>
             InstanceMethod("runTape", &BacktestRunnerNode::runTape),
             InstanceMethod("setExecutor", &BacktestRunnerNode::setExecutor),
             InstanceMethod("addExecutionListener", &BacktestRunnerNode::addExecutionListener),
+            // Pre-trade gate parity with live Runner (W1-T037 / T036).
+            // Reduce-only orders bypass the gate by design.
+            InstanceMethod("setRiskManager", &BacktestRunnerNode::setRiskManager),
+            InstanceMethod("setKillSwitch", &BacktestRunnerNode::setKillSwitch),
+            InstanceMethod("setOrderValidator", &BacktestRunnerNode::setOrderValidator),
+            InstanceMethod("setPnlTracker", &BacktestRunnerNode::setPnlTracker),
             InstanceMethod("equityCurve", &BacktestRunnerNode::equityCurve),
             InstanceMethod("trades", &BacktestRunnerNode::trades),
         });
@@ -1146,6 +1152,74 @@ class BacktestRunnerNode : public Napi::ObjectWrap<BacktestRunnerNode>
   FloxBacktestRunnerHandle _handle{nullptr};
   SymbolRegistry* _reg{nullptr};
   std::unique_ptr<NodeStrategyHost> _host;
+  // Pre-trade gate hosts (W1-T037). Owned so they outlive the
+  // runner's non-owning use of the FloxXxxHandle each one wraps.
+  // The same Host classes used by RunnerNode/LiveEngineNode work
+  // here — only the C ABI setter target changes.
+  std::unique_ptr<flox_node::RiskManagerHost> _risk_host;
+  std::unique_ptr<flox_node::KillSwitchHost> _kill_host;
+  std::unique_ptr<flox_node::OrderValidatorHost> _validator_host;
+  std::unique_ptr<flox_node::PnLTrackerHost> _pnl_host;
+
+  Napi::Value setRiskManager(const Napi::CallbackInfo& info)
+  {
+    auto env = info.Env();
+    if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined())
+    {
+      _risk_host.reset();
+      flox_backtest_runner_set_risk_manager(_handle, nullptr);
+      return env.Undefined();
+    }
+    _risk_host = std::make_unique<flox_node::RiskManagerHost>(
+        env, info[0].As<Napi::Object>());
+    flox_backtest_runner_set_risk_manager(_handle, _risk_host->handle);
+    return env.Undefined();
+  }
+
+  Napi::Value setKillSwitch(const Napi::CallbackInfo& info)
+  {
+    auto env = info.Env();
+    if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined())
+    {
+      _kill_host.reset();
+      flox_backtest_runner_set_kill_switch(_handle, nullptr);
+      return env.Undefined();
+    }
+    _kill_host = std::make_unique<flox_node::KillSwitchHost>(
+        env, info[0].As<Napi::Object>());
+    flox_backtest_runner_set_kill_switch(_handle, _kill_host->handle);
+    return env.Undefined();
+  }
+
+  Napi::Value setOrderValidator(const Napi::CallbackInfo& info)
+  {
+    auto env = info.Env();
+    if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined())
+    {
+      _validator_host.reset();
+      flox_backtest_runner_set_order_validator(_handle, nullptr);
+      return env.Undefined();
+    }
+    _validator_host = std::make_unique<flox_node::OrderValidatorHost>(
+        env, info[0].As<Napi::Object>());
+    flox_backtest_runner_set_order_validator(_handle, _validator_host->handle);
+    return env.Undefined();
+  }
+
+  Napi::Value setPnlTracker(const Napi::CallbackInfo& info)
+  {
+    auto env = info.Env();
+    if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined())
+    {
+      _pnl_host.reset();
+      flox_backtest_runner_set_pnl_tracker(_handle, nullptr);
+      return env.Undefined();
+    }
+    _pnl_host = std::make_unique<flox_node::PnLTrackerHost>(
+        env, info[0].As<Napi::Object>());
+    flox_backtest_runner_set_pnl_tracker(_handle, _pnl_host->handle);
+    return env.Undefined();
+  }
 
   // runner.setStrategy(strategyObj) — plain JS object with callbacks
   Napi::Value setStrategy(const Napi::CallbackInfo& info)

--- a/node/test/test_bindings.js
+++ b/node/test/test_bindings.js
@@ -344,6 +344,27 @@ if (fs.existsSync(btCsv)) {
   console.log(`  skip BacktestRunner accessors (CSV not found: ${btCsv})`);
 }
 
+// ── BacktestRunner pre-trade gate hooks (parity proof) ───────────────
+
+console.log('=== BacktestRunner gate hooks ===');
+
+{
+  const reg = new flox.SymbolRegistry();
+  reg.addSymbol('exchange', 'BTCUSDT', 0.01);
+  const bt = new flox.BacktestRunner(reg, 0.0004, 10000);
+  bt.setStrategy({ symbols: [], onTrade(_c, _t, _e) {} });
+
+  for (const m of ['setRiskManager', 'setKillSwitch',
+                   'setOrderValidator', 'setPnlTracker']) {
+    check(typeof bt[m] === 'function',
+          `BacktestRunner.${m} is a function`);
+    // null detach must not throw on a fresh runner.
+    let threw = false;
+    try { bt[m](null); } catch (_) { threw = true; }
+    check(!threw, `BacktestRunner.${m}(null) detaches without throwing`);
+  }
+}
+
 // ── BacktestRunner.runTape (parity proof) ────────────────────────────
 
 console.log('=== BacktestRunner.runTape ===');


### PR DESCRIPTION
## Summary

Follow-up of W1-T036 — NAPI and Codon parity for the four pre-trade gate setters. Pattern matches T031 / T032 exactly.

**Stacked on #235 (T036)** so the new C ABI exports it adds (\`flox_backtest_runner_set_risk_manager\` / \`set_kill_switch\` / \`set_order_validator\` / \`set_pnl_tracker\`) are visible. Will rebase to main once #235 merges.

## NAPI

- \`BacktestRunnerNode\` gains \`setRiskManager\` / \`setKillSwitch\` / \`setOrderValidator\` / \`setPnlTracker\`.
- Reuses the same \`RiskManagerHost\` / \`KillSwitchHost\` / \`OrderValidatorHost\` / \`PnLTrackerHost\` helpers \`RunnerNode\` already uses — only the C ABI setter target changes.
- \`node/index.d.ts\` declarations.
- \`node/test/test_bindings.js\`: 8 smoke checks (each method exists + null-detach contract).

## Codon

- \`codon/flox/runner.codon\` \`BacktestRunner\` gains four setters importing the new C ABI exports. Detach via \`cobj()\`.

## QuickJS

Skipped — it doesn't currently expose a \`BacktestRunner\` class. When QuickJS gets one, the hooks come along automatically.

## Test plan

- [x] \`node test/test_bindings.js\` 122/122 pass (8 new gate-hook checks)
- [x] Codon module compiles (CI \`codon-only\` will gate)
- [ ] CI matrix green (after T036 merges and this rebases to main)

W1-T037