### PR TITLE
docs: mcp/README.md — `flox-mcp init` quickstart

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7560,43 +7560,67 @@ hosting; nothing leaves the machine.
 | `compute_indicator` | Run one FLOX indicator over a list of floats. Accepts class-form (`EMA`) or function-form (`ema`) names and forwards extra kwargs to the constructor. Input capped at 1 MiB. Needs `flox-py` installed (`pip install "flox-mcp[flox]"`). |
 | `suggest_indicator` | Map an English description ('trend filter', 'momentum oscillator', 'volatility band', 'mean revert', 'regime test') to a ranked shortlist of FLOX indicators. Pure keyword heuristic — no LLM call. Always confirm the chosen indicator with `list_indicators` before using it. |
 
-## Install
+## Quickstart
 
 ```bash
-pip install flox-mcp
-# or with the optional binding for indicator introspection:
-pip install "flox-mcp[flox]"
+pip install flox-mcp           # MCP server + flox-py (indicators, backtest, engine CLI)
+flox-mcp init                  # writes ./.mcp.json for the current project
+# restart your MCP client (Claude Code / Cursor / Cline) → done
 ```
 
-## Configure your AI client
+You get the whole surface in one install: docs / lookup tools,
+indicator introspection, backtest, and the engine CLI
+(`flox engine sim`, `flox tape record`). For tier-5/6 (live state,
+`place_order`, `flatten_positions`), also start a paper engine and
+rerun `init` with the printed token:
 
-### Claude Code
+```bash
+flox engine sim --strategy s.py --tape ./tape       # prints engine URL + token
+flox-mcp init --engine-url URL --token T            # appends env to ./.mcp.json
+```
 
-Edit `~/.claude.json` (or per-project `.claude/settings.json`):
+`flox engine sim` boots a `Runner` + `SimulatedExecutor` +
+`ControlServer` and writes a runtime snapshot the read tools poll.
+See [`python/flox_py/engine_cli.py`](../python/flox_py/engine_cli.py)
+for the full set of flags.
+
+`flox engine sim` boots a `Runner` + `SimulatedExecutor` + `ControlServer`
+and writes a runtime snapshot the read tools poll. See
+[`python/flox_py/engine_cli.py`](../python/flox_py/engine_cli.py)
+for the full set of flags.
+
+### `flox-mcp init` flags
+
+| Flag | What it does |
+|---|---|
+| *(default)* | Writes `./.mcp.json` in the current directory. Merges with an existing file. |
+| `--global` | Writes `~/.config/claude/.mcp.json` instead. |
+| `--overwrite` | Replace an existing `mcpServers.flox` entry instead of refusing. |
+| `--print` | Print the merged config to stdout, don't write. |
+| `--engine-url URL` | Sets `FLOX_CONTROL_URL` (tier-5/6 wiring). |
+| `--token T` | Sets `FLOX_CONTROL_TOKEN` (printed by `flox engine sim`). |
+
+### Manual override
+
+If you'd rather hand-edit, the resulting `.mcp.json` is shaped like:
 
 ```json
 {
   "mcpServers": {
     "flox": {
-      "command": "flox-mcp"
+      "command": "flox-mcp",
+      "args": ["serve"],
+      "env": {
+        "FLOX_RUNTIME_STATE": "$HOME/.flox/runtime.json"
+      }
     }
   }
 }
 ```
 
-### Cursor
-
-Settings → Features → MCP Servers → Add:
-
-```json
-{
-  "flox": { "command": "flox-mcp" }
-}
-```
-
-### Cline (VS Code)
-
-Cline's MCP settings panel; same shape.
+Same shape works for Claude Code, Cursor, and Cline — they all read
+`mcpServers.<name>` from a project-local `.mcp.json` (or the
+client-specific global path).
 
 ## Develop
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -26,43 +26,67 @@ hosting; nothing leaves the machine.
 | `compute_indicator` | Run one FLOX indicator over a list of floats. Accepts class-form (`EMA`) or function-form (`ema`) names and forwards extra kwargs to the constructor. Input capped at 1 MiB. Needs `flox-py` installed (`pip install "flox-mcp[flox]"`). |
 | `suggest_indicator` | Map an English description ('trend filter', 'momentum oscillator', 'volatility band', 'mean revert', 'regime test') to a ranked shortlist of FLOX indicators. Pure keyword heuristic — no LLM call. Always confirm the chosen indicator with `list_indicators` before using it. |
 
-## Install
+## Quickstart
 
 ```bash
-pip install flox-mcp
-# or with the optional binding for indicator introspection:
-pip install "flox-mcp[flox]"
+pip install flox-mcp           # MCP server + flox-py (indicators, backtest, engine CLI)
+flox-mcp init                  # writes ./.mcp.json for the current project
+# restart your MCP client (Claude Code / Cursor / Cline) → done
 ```
 
-## Configure your AI client
+You get the whole surface in one install: docs / lookup tools,
+indicator introspection, backtest, and the engine CLI
+(`flox engine sim`, `flox tape record`). For tier-5/6 (live state,
+`place_order`, `flatten_positions`), also start a paper engine and
+rerun `init` with the printed token:
 
-### Claude Code
+```bash
+flox engine sim --strategy s.py --tape ./tape       # prints engine URL + token
+flox-mcp init --engine-url URL --token T            # appends env to ./.mcp.json
+```
 
-Edit `~/.claude.json` (or per-project `.claude/settings.json`):
+`flox engine sim` boots a `Runner` + `SimulatedExecutor` +
+`ControlServer` and writes a runtime snapshot the read tools poll.
+See [`python/flox_py/engine_cli.py`](../python/flox_py/engine_cli.py)
+for the full set of flags.
+
+`flox engine sim` boots a `Runner` + `SimulatedExecutor` + `ControlServer`
+and writes a runtime snapshot the read tools poll. See
+[`python/flox_py/engine_cli.py`](../python/flox_py/engine_cli.py)
+for the full set of flags.
+
+### `flox-mcp init` flags
+
+| Flag | What it does |
+|---|---|
+| *(default)* | Writes `./.mcp.json` in the current directory. Merges with an existing file. |
+| `--global` | Writes `~/.config/claude/.mcp.json` instead. |
+| `--overwrite` | Replace an existing `mcpServers.flox` entry instead of refusing. |
+| `--print` | Print the merged config to stdout, don't write. |
+| `--engine-url URL` | Sets `FLOX_CONTROL_URL` (tier-5/6 wiring). |
+| `--token T` | Sets `FLOX_CONTROL_TOKEN` (printed by `flox engine sim`). |
+
+### Manual override
+
+If you'd rather hand-edit, the resulting `.mcp.json` is shaped like:
 
 ```json
 {
   "mcpServers": {
     "flox": {
-      "command": "flox-mcp"
+      "command": "flox-mcp",
+      "args": ["serve"],
+      "env": {
+        "FLOX_RUNTIME_STATE": "$HOME/.flox/runtime.json"
+      }
     }
   }
 }
 ```
 
-### Cursor
-
-Settings → Features → MCP Servers → Add:
-
-```json
-{
-  "flox": { "command": "flox-mcp" }
-}
-```
-
-### Cline (VS Code)
-
-Cline's MCP settings panel; same shape.
+Same shape works for Claude Code, Cursor, and Cline — they all read
+`mcpServers.<name>` from a project-local `.mcp.json` (or the
+client-specific global path).
 
 ## Develop
 

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -22,13 +22,10 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.0",
+    "flox-py>=0.5",
 ]
 
 [project.optional-dependencies]
-# Pulling in flox_py is optional: the C-API and error-code tools work
-# from bundled data alone. `list_indicators` and `compute_indicator`
-# need the actual bindings.
-flox = ["flox-py>=0.5"]
 dev = ["pytest>=7"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

The README still walked users through hand-editing \`~/.claude.json\` or per-client config panels — the seven-step path that motivated T034. With \`flox-mcp init\` shipped, the canonical setup is:

\`\`\`
pip install flox-mcp
flox-mcp init
\`\`\`

## Updates

- New **Quickstart** section leads with the two-line install + init flow.
- Mentions the engine path (\`flox engine sim\`) for tier-5/6 with the copy-pasteable \`flox-mcp init --engine-url ... --token ...\` follow-up.
- Init flag table covers \`--global / --overwrite / --print / --engine-url / --token\`.
- Manual override kept as a fallback for users who want to hand-edit; same JSON shape works across Claude Code / Cursor / Cline.

Small enough that a separate tracker entry is overkill — rolling it into the post-T034/T035 docs sweep.

## Test plan

- [x] README renders cleanly
- [x] Commands match what \`flox-mcp init --help\` actually accepts
- [ ] CI matrix green (only docs touch — fast checks only)