### PR TITLE
build: portable arch baseline + LZ4 default ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,32 @@ if(WIN32)
   target_compile_definitions(${FLOX} PUBLIC NOMINMAX)
 endif()
 
+# FLOX_NATIVE controls whether Release builds target the build machine's
+# instruction set (`-march=native`) or a portable baseline. `native` is
+# fastest but ties the resulting binary to the build host — if the build
+# CPU has AVX-512 and the runtime CPU does not, the process dies with
+# SIGILL on the first vector instruction. Default ON preserves the
+# historical local-dev behaviour; wheel/binary distribution paths
+# (python/pyproject.toml) flip it OFF.
+option(FLOX_NATIVE
+  "Compile Release with -march=native. Disable for distributable artifacts."
+  ON)
+
+if(NOT MSVC)
+  if(FLOX_NATIVE)
+    set(FLOX_ARCH_OPT -march=native)
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
+    # x86-64-v3 = AVX2 + BMI2 + FMA, baseline for Haswell/Excavator
+    # (~2015) and up. Covers the vast majority of distribution targets
+    # without requiring AVX-512.
+    set(FLOX_ARCH_OPT -march=x86-64-v3)
+  else()
+    # arm64/aarch64 etc.: compiler default is portable enough; macOS
+    # arm64 wheels are arch-tagged anyway so native vs. baseline is moot.
+    set(FLOX_ARCH_OPT "")
+  endif()
+endif()
+
 if(MSVC)
   target_compile_options(${FLOX} PUBLIC
     $<$<CONFIG:Release>:/O2 /GL>
@@ -62,8 +88,12 @@ if(MSVC)
     $<$<CONFIG:Release>:/LTCG>
   )
 else()
+  set(FLOX_RELEASE_OPTS -O3 -flto -funroll-loops)
+  if(FLOX_ARCH_OPT)
+    list(APPEND FLOX_RELEASE_OPTS ${FLOX_ARCH_OPT})
+  endif()
   target_compile_options(${FLOX} PUBLIC
-    $<$<CONFIG:Release>:-O3 -march=native -flto -funroll-loops>
+    $<$<CONFIG:Release>:${FLOX_RELEASE_OPTS}>
   )
   # LTO requires -flto flag at link time as well
   target_link_options(${FLOX} PUBLIC
@@ -94,7 +124,7 @@ else()
   target_compile_definitions(${FLOX} PUBLIC FLOX_NUMA_LIBRARY_LINKED=0)
 endif()
 
-option(FLOX_ENABLE_LZ4 "Enable LZ4 compression for binary logs" OFF)
+option(FLOX_ENABLE_LZ4 "Enable LZ4 compression for binary logs" ON)
 if(FLOX_ENABLE_LZ4)
   # Try find_package first (works with vcpkg on Windows)
   find_package(lz4 CONFIG QUIET)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -13,8 +13,16 @@ target_include_directories(_flox_py PRIVATE
 )
 
 if(NOT MSVC)
+  # FLOX_ARCH_OPT is computed in the top-level CMakeLists.txt and
+  # honours the FLOX_NATIVE option. Wheel builds set FLOX_NATIVE=OFF via
+  # python/pyproject.toml so the shipped .so does not require AVX-512
+  # (or whatever ISA the build host happened to expose).
+  set(_FLOX_PY_OPTS -O3 -flto)
+  if(FLOX_ARCH_OPT)
+    list(APPEND _FLOX_PY_OPTS ${FLOX_ARCH_OPT})
+  endif()
   target_compile_options(_flox_py PRIVATE
-    $<$<CONFIG:Release>:-O3 -march=native -flto>
+    $<$<CONFIG:Release>:${_FLOX_PY_OPTS}>
   )
 endif()
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,7 +26,16 @@ Repository = "https://github.com/FLOX-Foundation/flox"
 flox = "flox_py.cli:main"
 
 [tool.scikit-build]
-cmake.args = ["-DFLOX_ENABLE_BACKTEST=ON", "-DFLOX_BUILD_PYTHON=ON", "-DFLOX_ENABLE_LZ4=ON"]
+cmake.args = [
+    "-DFLOX_ENABLE_BACKTEST=ON",
+    "-DFLOX_BUILD_PYTHON=ON",
+    "-DFLOX_ENABLE_LZ4=ON",
+    # Wheels run on machines the build host knows nothing about; pin to
+    # the portable x86-64-v3 baseline (or compiler-default on non-x86)
+    # so the shipped .so does not require AVX-512 or other build-host-
+    # specific instructions.
+    "-DFLOX_NATIVE=OFF",
+]
 cmake.source-dir = ".."
 # Ship the package directory (pure-Python wrapper, .pyi stubs, py.typed
 # marker). The compiled `_flox_py` extension is copied into this same

--- a/src/capi/CMakeLists.txt
+++ b/src/capi/CMakeLists.txt
@@ -12,8 +12,16 @@ set_target_properties(flox_capi PROPERTIES
 )
 
 if(NOT MSVC)
+  # FLOX_ARCH_OPT comes from the top-level CMakeLists.txt and honours
+  # the FLOX_NATIVE option; the shared CAPI lib is a distribution target
+  # (Codon/QuickJS/Node load it at runtime), so set FLOX_NATIVE=OFF when
+  # shipping it to heterogeneous CPUs.
+  set(_FLOX_CAPI_OPTS -O3 -flto)
+  if(FLOX_ARCH_OPT)
+    list(APPEND _FLOX_CAPI_OPTS ${FLOX_ARCH_OPT})
+  endif()
   target_compile_options(flox_capi PRIVATE
-    $<$<CONFIG:Release>:-O3 -march=native -flto>
+    $<$<CONFIG:Release>:${_FLOX_CAPI_OPTS}>
   )
 endif()
 


### PR DESCRIPTION
## Summary
- Add `FLOX_NATIVE` option (default `ON`) controlling `-march=native` across the three Release compile blocks (libflox, `_flox_py`, `flox_capi`). When `OFF` on x86_64 it falls back to `-march=x86-64-v3` (AVX2/BMI2/FMA, supported since ~2015); on arm64/other the compiler default is left alone.
- `python/pyproject.toml` pins `FLOX_NATIVE=OFF` for wheel builds so the shipped extension is not tied to the build host's ISA — previously a wheel built on a CPU with AVX-512 would `SIGILL` on consumer CPUs that lack it.
- Flip `FLOX_ENABLE_LZ4` default to `ON`. Binary-log compression is the expected production configuration, and the existing fallback chain (`find_package` → `find_library` → `pkg-config` → vendored source) keeps the dependency self-resolving on every supported platform.

Local-dev behaviour is unchanged: `cmake --build` still emits `-march=native` because `FLOX_NATIVE` defaults to `ON`. Only distributable artefacts (wheels) flip to the portable baseline.

## Test plan
- [ ] `linux-gcc` / sanitizers green
- [ ] `windows-*` green
- [ ] python wheel job confirms the shipped `.so` has no `-march=native` in its compile commands
- [ ] LZ4 enabled-by-default does not regress builds that previously ran with the flag implicitly off